### PR TITLE
chore: add ci and license

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Python
-        uses: actions/setup-python@42375524ee3024772badf8e19a689d0d7dd3f14a # v5.6.1
+        uses: actions/setup-python@v5
         with:
           python-version: '3.x'
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: ["main"]
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Python
+        uses: actions/setup-python@42375524ee3024772badf8e19a689d0d7dd3f14a # v5.6.1
+        with:
+          python-version: '3.x'
+
+      - name: Validate action metadata YAML
+        run: ruby -e 'require "yaml"; YAML.load_file("action.yml")'
+
+      - name: Validate example workflow YAML
+        run: ruby -e 'require "yaml"; YAML.load_file("examples/workflow-self-hosted.yml"); YAML.load_file("examples/workflow-cloud.yml")'
+
+      - name: Check shell scripts
+        run: bash -n scripts/check_review_needed.sh && bash -n scripts/run_review.sh && bash -n tests/smoke_test.sh
+
+      - name: Check Python scripts
+        run: python3 -m py_compile scripts/image_digest_analysis.py tests/mock_openai_server.py
+
+      - name: Verify smoke test helper is executable
+        run: test -x tests/smoke_test.sh

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Jory Irving
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Analyze pull requests with a self-hosted or cloud OpenAI-compatible model.
 
+[![CI](https://github.com/joryirving/pr-reviewer-action/actions/workflows/ci.yaml/badge.svg)](https://github.com/joryirving/pr-reviewer-action/actions/workflows/ci.yaml)
+
 The action gathers PR metadata, diff context, linked sources, image digest provenance, basic repository impact/history, and an optional standards file such as `CLAUDE.md`. It returns a structured verdict and markdown review body, and it can also publish or update a sticky PR comment.
 
 ## What it supports
@@ -213,3 +215,7 @@ Copyable workflows are included here:
 
 - `examples/workflow-self-hosted.yml`
 - `examples/workflow-cloud.yml`
+
+## License
+
+MIT


### PR DESCRIPTION
## Summary
- add a minimal CI workflow to validate action metadata and helper scripts
- add an MIT license
- add a CI badge to the README

## Why
This makes the action repo enforceable with required status checks and gives it the expected baseline project metadata.
