### PR TITLE
chore: add CODEOWNERS and context limit mode

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @joryirving

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ The action gathers PR metadata, diff context, linked sources, image digest prove
 | `standards_file` | Standards or conventions file from the reviewed repo | No | `CLAUDE.md` |
 | `standards_file_candidates` | Candidate files to auto-discover when `standards_file` is missing or blank | No | `CLAUDE.md,claude.md,AGENTS.md,agents.md,.github/ai-review-rules.md,.github/ai-review-rules.txt` |
 | `publish_review_comment` | Publish or update a managed PR comment | No | `false` |
+| `context_limit_mode` | Context budget mode: `normal` (140k/70k/220k), `low` (80k/40k/120k), `minimal` (40k/20k/60k) | No | `normal` |
 | `skip_if_diff_unchanged` | Skip the LLM review when the current PR patch matches the last managed review fingerprint | No | `true` |
 | `comment_marker` | HTML marker for the managed PR comment | No | `<!-- ai-pr-reviewer -->` |
 
@@ -185,6 +186,7 @@ If a repo wants more than policy context and needs to fully control the reviewer
 - `standards_file` is optional; if it is missing, the action will try `standards_file_candidates` before continuing without repository standards context.
 - By default, the action computes a stable patch fingerprint with `git patch-id --stable` and skips the LLM call when that fingerprint matches the most recent managed review comment. This avoids token spend on rebases and other history-only changes.
 - `publish_review_comment` uses `gh pr comment --edit-last --create-if-none`, so the comment is managed by the token identity used in the workflow.
+- `context_limit_mode` reduces the amount of PR data sent to the LLM. Use `minimal` for models with very small context windows. This skips nothing but truncates more aggressively.
 
 ## Validation
 

--- a/action.yml
+++ b/action.yml
@@ -67,6 +67,10 @@ inputs:
     description: If true, publish or update a PR comment with the generated review
     required: false
     default: "false"
+  context_limit_mode:
+    description: Context budget mode - normal (140k/70k/220k), low (80k/40k/120k), minimal (40k/20k/60k)
+    required: false
+    default: normal
   skip_if_diff_unchanged:
     description: If true, skip the LLM review when the effective PR diff matches the last managed review comment fingerprint
     required: false
@@ -141,6 +145,7 @@ runs:
         SYSTEM_PROMPT_FILE: ${{ inputs.system_prompt_file }}
         STANDARDS_FILE: ${{ inputs.standards_file }}
         STANDARDS_FILE_CANDIDATES: ${{ inputs.standards_file_candidates }}
+        CONTEXT_LIMIT_MODE: ${{ inputs.context_limit_mode }}
       run: bash "${{ github.action_path }}/scripts/run_review.sh"
 
     - name: Publish review comment

--- a/scripts/run_review.sh
+++ b/scripts/run_review.sh
@@ -26,7 +26,20 @@ SYSTEM_PROMPT="${SYSTEM_PROMPT:-}"
 SYSTEM_PROMPT_FILE="${SYSTEM_PROMPT_FILE:-}"
 STANDARDS_FILE="${STANDARDS_FILE:-CLAUDE.md}"
 STANDARDS_FILE_CANDIDATES="${STANDARDS_FILE_CANDIDATES:-CLAUDE.md,claude.md,AGENTS.md,agents.md,.github/ai-review-rules.md,.github/ai-review-rules.txt}"
+CONTEXT_LIMIT_MODE="${CONTEXT_LIMIT_MODE:-normal}"
 OUTPUT_FILE="${GITHUB_OUTPUT:-/dev/null}"
+
+apply_context_limits() {
+  case "${CONTEXT_LIMIT_MODE:-normal}" in
+    minimal)
+      MAX_DIFF=40000; MAX_FILES=20000; MAX_CORPUS=60000 ;;
+    low)
+      MAX_DIFF=80000; MAX_FILES=40000; MAX_CORPUS=120000 ;;
+    normal|*)
+      MAX_DIFF=140000; MAX_FILES=70000; MAX_CORPUS=220000 ;;
+  esac
+}
+apply_context_limits
 
 if [[ -z "$REPO" || -z "$PR_NUMBER" || -z "$AI_BASE_URL" || -z "$AI_MODEL" ]]; then
   error "Missing required environment variables: REPO, PR_NUMBER, AI_BASE_URL, or AI_MODEL"
@@ -152,11 +165,11 @@ gh pr view "$PR_NUMBER" --repo "$REPO" \
   --json number,title,body,headRefOid,baseRefName,headRefName,author,changedFiles,additions,deletions,files,url > pr.json
 
 gh pr diff "$PR_NUMBER" --repo "$REPO" > pr.diff
-head -c 140000 pr.diff > pr.diff.truncated
+head -c "$MAX_DIFF" pr.diff > pr.diff.truncated
 
 gh api "repos/$REPO/pulls/$PR_NUMBER/files" --paginate > pr-files.raw.json
 jq '[.[] | {filename,status,additions,deletions,changes,previous_filename,patch}]' pr-files.raw.json > pr-files.json
-head -c 70000 pr-files.json > pr-files.truncated.json
+head -c "$MAX_FILES" pr-files.json > pr-files.truncated.json
 
 jq -r '.body // ""' pr.json > pr-body.txt
 
@@ -488,7 +501,7 @@ fi
   cat standards-context.md
 } > review-corpus.md
 
-head -c 220000 review-corpus.md > review-corpus.truncated.md
+head -c "$MAX_CORPUS" review-corpus.md > review-corpus.truncated.md
 
 log "Analyzing with $AI_MODEL..."
 


### PR DESCRIPTION
## Summary
- add CODEOWNERS with @joryirving for PR review notifications
- add context_limit_mode input with normal/low/minimal presets to reduce context sent to LLM
- update README with new input documentation

## Changes
- context_limit_mode: normal (default) — diff 140k, files 70k, corpus 220k
- context_limit_mode: low — diff 80k, files 40k, corpus 120k
- context_limit_mode: minimal — diff 40k, files 20k, corpus 60k

No behavior change when using the default normal mode.