### PR TITLE
fix: prefer AGENTS.md over CLAUDE.md in standards file candidates

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ The action gathers PR metadata, diff context, linked issue context from PR-closi
 | `allowed_source_hosts` | Comma-separated allowlist for linked URL fetching | No | `github.com,api.github.com,gitlab.com,registry.terraform.io,artifacthub.io` |
 | `system_prompt` | Optional system prompt override | No | bundled prompt |
 | `system_prompt_file` | File in the reviewed repo to use as the full system prompt | No | `""` |
-| `standards_file` | Standards or conventions file from the reviewed repo | No | `CLAUDE.md` |
-| `standards_file_candidates` | Candidate files to auto-discover when `standards_file` is missing or blank | No | `CLAUDE.md,claude.md,AGENTS.md,agents.md,.github/ai-review-rules.md,.github/ai-review-rules.txt` |
+| `standards_file` | Explicit standards file path; takes priority over candidates | No | `""` |
+| `standards_file_candidates` | Candidate files checked in order; first found is used | No | `AGENTS.md,agents.md,CLAUDE.md,claude.md,.github/ai-review-rules.md,.github/ai-review-rules.txt` |
 | `publish_review_comment` | Publish or update a managed PR comment | No | `false` |
 | `context_limit_mode` | Context budget mode: `normal` (140k/70k/220k), `low` (80k/40k/120k), `minimal` (40k/20k/60k) | No | `normal` |
 | `skip_if_diff_unchanged` | Skip the LLM review when the current PR patch matches the last managed review fingerprint | No | `true` |
@@ -188,7 +188,7 @@ If a repo wants more than policy context and needs to fully control the reviewer
 - The action expects an OpenAI-compatible `POST /chat/completions` API.
 - `system_prompt` takes precedence over `system_prompt_file`.
 - `system_prompt_file` takes precedence over the bundled generic prompt.
-- `standards_file` is optional; if it is missing, the action will try `standards_file_candidates` before continuing without repository standards context.
+- `standards_file` is optional; if blank, the action checks `standards_file_candidates` in order and uses the first file found. `AGENTS.md` is checked first by default, then `CLAUDE.md`, making the action compatible with both Claude Code and non-Claude Code setups.
 - By default, the action computes a stable patch fingerprint with `git patch-id --stable` and skips the LLM call when that fingerprint matches the most recent managed review comment. This avoids token spend on rebases and other history-only changes.
 - `publish_review_comment` uses `gh pr comment --edit-last --create-if-none`, so the comment is managed by the token identity used in the workflow.
 - `context_limit_mode` reduces the amount of PR data sent to the LLM. Use `minimal` for models with very small context windows. This skips nothing but truncates more aggressively.

--- a/action.yml
+++ b/action.yml
@@ -58,11 +58,11 @@ inputs:
   standards_file:
     description: Repository standards file path for conventions and policy context
     required: false
-    default: CLAUDE.md
+    default: ""
   standards_file_candidates:
-    description: Comma-separated candidate files to auto-discover when standards_file is not set or missing
+    description: Candidate files to auto-discover when standards_file is not set. First found is used.
     required: false
-    default: CLAUDE.md,claude.md,AGENTS.md,agents.md,.github/ai-review-rules.md,.github/ai-review-rules.txt
+    default: AGENTS.md,agents.md,CLAUDE.md,claude.md,.github/ai-review-rules.md,.github/ai-review-rules.txt
   publish_review_comment:
     description: If true, publish or update a PR comment with the generated review
     required: false


### PR DESCRIPTION
## Summary
- Change `STANDARDS_FILE_CANDIDATES` default order to check `AGENTS.md` first, then `CLAUDE.md`
- This makes the action work out of the box for non-Claude Code setups without requiring explicit configuration
- Update README to document the priority

## Why
Claude Code users use `CLAUDE.md`. Other agents (Cursor, Copilot, etc.) conventionally use `AGENTS.md`. The action should check `AGENTS.md` first so it works for both without configuration.