### PR TITLE
feat: harden tool harness uncertainty controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,13 @@ The action gathers PR metadata, diff context, linked issue context from PR-closi
 | `evidence_enable_for_forks` | Allow evidence providers on cross-repository PRs | No | `false` |
 | `tool_mode` | Tool harness mode: `off` or `plan_execute_once` | No | `off` |
 | `tool_max_requests` | Maximum tool requests executed in one harness run | No | `4` |
+| `tool_planning_timeout_sec` | Timeout in seconds for tool harness planning model call | No | `30` |
+| `tool_planning_max_context_bytes` | Maximum corpus bytes passed to planning | No | `50000` |
 | `tool_max_response_bytes` | Maximum bytes captured from each tool response | No | `12000` |
+| `tool_allowed_gh_api_repos` | Comma-separated owner/repo allowlist for `gh_api` (empty = current repo only) | No | `""` |
+| `tool_request_timeout_sec` | Timeout in seconds for each tool execution request | No | `20` |
+| `tool_failure_enforcement` | Force `request_changes` when tool harness planning fails | No | `false` |
+| `tool_min_successful_requests` | Minimum successful tool requests required when `tool_failure_enforcement=true` | No | `0` |
 | `tool_enable_for_forks` | Allow tool harness on cross-repository PRs | No | `false` |
 | `skip_if_diff_unchanged` | Skip the LLM review when the current PR patch matches the last managed review fingerprint | No | `true` |
 | `comment_marker` | HTML marker for the managed PR comment | No | `<!-- ai-pr-reviewer -->` |
@@ -191,7 +197,13 @@ Provider commands can print plain text, or JSON with fields such as `severity` a
     ai_model: qwen3-32b
     tool_mode: plan_execute_once
     tool_max_requests: "4"
+    tool_planning_timeout_sec: "30"
+    tool_planning_max_context_bytes: "50000"
     tool_max_response_bytes: "12000"
+    tool_allowed_gh_api_repos: "siderolabs/kubelet,siderolabs/talos"
+    tool_request_timeout_sec: "20"
+    tool_failure_enforcement: "true"
+    tool_min_successful_requests: "1"
 ```
 
 In `plan_execute_once` mode, the model first plans up to `tool_max_requests` read-only evidence calls, then the action executes those calls and appends the results to the final review corpus. Supported tools are:
@@ -263,6 +275,10 @@ If a repo wants more than policy context and needs to fully control the reviewer
 - Tool harness output is appended to the review corpus under `Tool Harness Findings`.
 - Tool harness planning treats corpus content as untrusted data and uses strict tool/path/host allowlists with output redaction.
 - Evidence providers and tool harness are both disabled by default on cross-repository PRs (`*_enable_for_forks=false`).
+- `gh_api` defaults to current-repo scope only. Use `tool_allowed_gh_api_repos` to allow specific upstream repos.
+- For local models, reduce `tool_planning_max_context_bytes` and `tool_planning_timeout_sec` to avoid long planning calls.
+- Set `tool_failure_enforcement=true` to fail closed when tool harness planning fails or when every tool request fails.
+- Use `tool_min_successful_requests` (for example `1`) to enforce a minimum successful tool-evidence threshold.
 
 ## Validation
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,11 +15,14 @@ This action reviews pull requests with an LLM and optional auxiliary tooling. Th
 - Tool harness treats corpus text as untrusted and does not follow corpus instructions
 - Tool harness uses a strict read-only allowlist (`gh_api`, `read_file`, `web_fetch`, `git_grep`)
 - `gh_api` is constrained to a same-repo path prefix and endpoint allowlist
+- `gh_api` can optionally include specific upstream repos via explicit allowlist (`tool_allowed_gh_api_repos`)
 - `read_file` is constrained to workspace-relative paths and blocks sensitive path patterns
 - `web_fetch` is constrained to `allowed_source_hosts`
 - Tool outputs are size-limited and pass through basic secret redaction before corpus inclusion
 - Tool and evidence-provider enrichment are skipped on cross-repository PRs by default (`tool_enable_for_forks=false`, `evidence_enable_for_forks=false`)
 - Evidence provider blocker findings can be deterministically enforced (`evidence_blocker_enforcement=true`)
+- Tool harness failures can be made fail-closed with `tool_failure_enforcement=true` (planning failure or all tool requests failing)
+- Tool harness can require minimum evidence breadth via `tool_min_successful_requests`
 
 ## Operational Guidance
 

--- a/action.yml
+++ b/action.yml
@@ -99,10 +99,34 @@ inputs:
     description: Maximum number of tool requests the harness executes when tool_mode is enabled
     required: false
     default: "4"
+  tool_planning_timeout_sec:
+    description: Timeout in seconds for the model planning call used by tool harness
+    required: false
+    default: "30"
+  tool_planning_max_context_bytes:
+    description: Maximum corpus bytes passed to the planning model
+    required: false
+    default: "50000"
   tool_max_response_bytes:
     description: Maximum bytes captured from each tool execution result
     required: false
     default: "12000"
+  tool_allowed_gh_api_repos:
+    description: Comma-separated owner/repo list allowed for gh_api tool requests (empty means current repo only)
+    required: false
+    default: ""
+  tool_request_timeout_sec:
+    description: Timeout in seconds for each tool request execution
+    required: false
+    default: "20"
+  tool_failure_enforcement:
+    description: If true, force request_changes when tool harness planning fails
+    required: false
+    default: "false"
+  tool_min_successful_requests:
+    description: Minimum number of successful tool requests required when tool failure enforcement is enabled
+    required: false
+    default: "0"
   tool_enable_for_forks:
     description: If true, allow the tool harness to run on cross-repository pull requests
     required: false
@@ -189,7 +213,13 @@ runs:
         EVIDENCE_ENABLE_FOR_FORKS: ${{ inputs.evidence_enable_for_forks }}
         TOOL_MODE: ${{ inputs.tool_mode }}
         TOOL_MAX_REQUESTS: ${{ inputs.tool_max_requests }}
+        TOOL_PLANNING_TIMEOUT_SEC: ${{ inputs.tool_planning_timeout_sec }}
+        TOOL_PLANNING_MAX_CONTEXT_BYTES: ${{ inputs.tool_planning_max_context_bytes }}
         TOOL_MAX_RESPONSE_BYTES: ${{ inputs.tool_max_response_bytes }}
+        TOOL_ALLOWED_GH_API_REPOS: ${{ inputs.tool_allowed_gh_api_repos }}
+        TOOL_REQUEST_TIMEOUT_SEC: ${{ inputs.tool_request_timeout_sec }}
+        TOOL_FAILURE_ENFORCEMENT: ${{ inputs.tool_failure_enforcement }}
+        TOOL_MIN_SUCCESSFUL_REQUESTS: ${{ inputs.tool_min_successful_requests }}
         TOOL_ENABLE_FOR_FORKS: ${{ inputs.tool_enable_for_forks }}
       run: bash "${{ github.action_path }}/scripts/run_review.sh"
 

--- a/scripts/run_review.sh
+++ b/scripts/run_review.sh
@@ -9,6 +9,16 @@ error() {
   log "ERROR: $1" >&2
 }
 
+sedi() {
+  local expr="$1"
+  local target="$2"
+  if sed --version >/dev/null 2>&1; then
+    sed -i "$expr" "$target"
+  else
+    sed -i '' "$expr" "$target"
+  fi
+}
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO="${REPO:-${GITHUB_REPOSITORY:-}}"
 PR_NUMBER="${PR_NUMBER:-}"
@@ -35,7 +45,12 @@ EVIDENCE_ENABLE_FOR_FORKS="${EVIDENCE_ENABLE_FOR_FORKS:-false}"
 TOOL_MODE="${TOOL_MODE:-off}"
 TOOL_MAX_REQUESTS="${TOOL_MAX_REQUESTS:-4}"
 TOOL_MAX_RESPONSE_BYTES="${TOOL_MAX_RESPONSE_BYTES:-12000}"
-TOOL_PLANNING_MAX_CONTEXT_BYTES="${TOOL_PLANNING_MAX_CONTEXT_BYTES:-90000}"
+TOOL_PLANNING_TIMEOUT_SEC="${TOOL_PLANNING_TIMEOUT_SEC:-30}"
+TOOL_PLANNING_MAX_CONTEXT_BYTES="${TOOL_PLANNING_MAX_CONTEXT_BYTES:-50000}"
+TOOL_REQUEST_TIMEOUT_SEC="${TOOL_REQUEST_TIMEOUT_SEC:-20}"
+TOOL_ALLOWED_GH_API_REPOS="${TOOL_ALLOWED_GH_API_REPOS:-}"
+TOOL_FAILURE_ENFORCEMENT="${TOOL_FAILURE_ENFORCEMENT:-false}"
+TOOL_MIN_SUCCESSFUL_REQUESTS="${TOOL_MIN_SUCCESSFUL_REQUESTS:-0}"
 TOOL_ENABLE_FOR_FORKS="${TOOL_ENABLE_FOR_FORKS:-false}"
 OUTPUT_FILE="${GITHUB_OUTPUT:-/dev/null}"
 
@@ -115,6 +130,11 @@ case "$(printf '%s' "$TOOL_MODE" | tr '[:upper:]' '[:lower:]')" in
     TOOL_MODE="off"
     ;;
 esac
+
+if [[ ! "$TOOL_MIN_SUCCESSFUL_REQUESTS" =~ ^[0-9]+$ ]]; then
+  error "Invalid TOOL_MIN_SUCCESSFUL_REQUESTS '$TOOL_MIN_SUCCESSFUL_REQUESTS'; defaulting to 0"
+  TOOL_MIN_SUCCESSFUL_REQUESTS=0
+fi
 
 curl_model() {
   local base_url="$1"
@@ -256,8 +276,8 @@ grep -E '^[+-].*(image:|tag:|version:|chart:|appVersion:|digest:)' pr.diff.trunc
 head -n 180 version-hints.txt > version-hints.truncated.txt || true
 
 grep -Eo 'ghcr\.io/[^/]+/[^:"@ ]+' version-hints.txt | sort -u > ghcr-images.txt || true
-sed -i 's#ghcr\.io/##' ghcr-images.txt
-sed -i 's#:.*##' ghcr-images.txt
+sedi 's#ghcr\.io/##' ghcr-images.txt
+sedi 's#:.*##' ghcr-images.txt
 sort -u ghcr-images.txt -o ghcr-images.txt
 
 log "Gathering changed manifest context..."
@@ -755,6 +775,58 @@ if [[ "$(printf '%s' "$EVIDENCE_BLOCKER_ENFORCEMENT" | tr '[:upper:]' '[:lower:]
   ' ai-output.json > ai-output.enforced.json
   mv ai-output.enforced.json ai-output.json
   log "Enforced request_changes due to blocker evidence provider findings"
+fi
+
+if [[ "$(printf '%s' "$TOOL_MODE" | tr '[:upper:]' '[:lower:]')" == "plan_execute_once" ]] && \
+  [[ "$(printf '%s' "$TOOL_FAILURE_ENFORCEMENT" | tr '[:upper:]' '[:lower:]')" == "true" ]]; then
+  TOOL_FAILURE_REASON="$(jq -r '
+    if .planning_error? != null then
+      .planning_error
+    elif .error? != null then
+      .error
+    elif ((.executed_request_count // 0) > 0) and ((([.tool_results[]?.result.status == "ok"] | any) | not)) then
+      "all tool requests failed"
+    else
+      ""
+    end
+  ' tool-harness.json 2>/dev/null || true)"
+
+  if [[ -n "$TOOL_FAILURE_REASON" ]]; then
+    jq --arg reason "$TOOL_FAILURE_REASON" '
+    .verdict = "request_changes"
+    | .review_markdown = (
+      (.review_markdown // "")
+      + "\n\n## Tool Harness Failure\n"
+      + "The tool harness failed during planning or execution ("
+      + $reason
+      + "). This workflow is configured fail-closed for tool harness failures; rerun after reducing tool planning context or fixing connectivity."
+    )
+  ' ai-output.json > ai-output.enforced.json
+    mv ai-output.enforced.json ai-output.json
+    log "Enforced request_changes due to tool harness failure"
+  elif [[ "$TOOL_MIN_SUCCESSFUL_REQUESTS" -gt 0 ]]; then
+    SUCCESSFUL_TOOL_REQUESTS="$(jq -r '[.tool_results[]?.result.status == "ok"] | map(select(. == true)) | length' tool-harness.json 2>/dev/null || echo 0)"
+    if [[ ! "$SUCCESSFUL_TOOL_REQUESTS" =~ ^[0-9]+$ ]]; then
+      SUCCESSFUL_TOOL_REQUESTS=0
+    fi
+
+    if [[ "$SUCCESSFUL_TOOL_REQUESTS" -lt "$TOOL_MIN_SUCCESSFUL_REQUESTS" ]]; then
+      jq --arg min "$TOOL_MIN_SUCCESSFUL_REQUESTS" --arg got "$SUCCESSFUL_TOOL_REQUESTS" '
+        .verdict = "request_changes"
+        | .review_markdown = (
+          (.review_markdown // "")
+          + "\n\n## Tool Harness Insufficient Evidence\n"
+          + "This workflow requires at least "
+          + $min
+          + " successful tool requests, but only "
+          + $got
+          + " succeeded. Rerun after adjusting tool planning settings."
+        )
+      ' ai-output.json > ai-output.enforced.json
+      mv ai-output.enforced.json ai-output.json
+      log "Enforced request_changes due to insufficient successful tool requests"
+    fi
+  fi
 fi
 
 echo "analysis_engine=$ANALYSIS_ENGINE" >> "$OUTPUT_FILE"

--- a/scripts/run_tool_harness.py
+++ b/scripts/run_tool_harness.py
@@ -22,6 +22,19 @@ GH_DENY_SUBSTRINGS = (
 )
 
 
+def normalize_repo_name(value):
+    text = (value or "").strip().strip("/")
+    parts = [item for item in text.split("/") if item]
+    if len(parts) != 2:
+        return ""
+    owner, repo = parts
+    if not re.match(r"^[A-Za-z0-9_.-]+$", owner):
+        return ""
+    if not re.match(r"^[A-Za-z0-9_.-]+$", repo):
+        return ""
+    return f"{owner}/{repo}"
+
+
 def env_int(name, default_value, min_value):
     raw = os.getenv(name, str(default_value)).strip()
     try:
@@ -107,7 +120,9 @@ def safe_run(args, timeout_sec):
         }
 
 
-def run_chat_completion(base_url, model, api_key, system_prompt, user_prompt):
+def run_chat_completion(
+    base_url, model, api_key, system_prompt, user_prompt, timeout_sec
+):
     payload = {
         "model": model,
         "messages": [
@@ -123,14 +138,14 @@ def run_chat_completion(base_url, model, api_key, system_prompt, user_prompt):
     if api_key:
         request.add_header("Authorization", f"Bearer {api_key}")
 
-    with urllib.request.urlopen(request, timeout=45) as response:
+    with urllib.request.urlopen(request, timeout=timeout_sec) as response:
         response_body = response.read().decode("utf-8", errors="replace")
     parsed = json.loads(response_body)
     return parsed.get("choices", [{}])[0].get("message", {}).get("content", "")
 
 
-def run_gh_api(path, max_bytes, repo, timeout_sec):
-    path_value = str(path or "").strip()
+def run_gh_api(path, max_bytes, allowed_repos, timeout_sec):
+    path_value = str(path or "").strip().lstrip("/")
     if not path_value:
         return {"status": "error", "error": "Missing path"}
     if "\n" in path_value or "\r" in path_value or " " in path_value:
@@ -138,18 +153,32 @@ def run_gh_api(path, max_bytes, repo, timeout_sec):
     if not GH_SAFE_PATH_RE.match(path_value):
         return {"status": "error", "error": "Path contains unsafe characters"}
 
-    expected_prefix = f"repos/{repo}/"
+    parts = path_value.split("/")
+    if len(parts) < 4 or parts[0] != "repos":
+        return {"status": "error", "error": "Path must match repos/{owner}/{repo}/..."}
+
+    target_repo = normalize_repo_name(f"{parts[1]}/{parts[2]}")
+    if not target_repo:
+        return {"status": "error", "error": "Invalid owner/repo in path"}
+
+    if target_repo not in allowed_repos:
+        return {
+            "status": "error",
+            "error": f"Repository not allowlisted for gh_api: {target_repo}",
+        }
+
+    expected_prefix = f"repos/{target_repo}/"
     if not path_value.startswith(expected_prefix):
         return {"status": "error", "error": f"Path must start with {expected_prefix}"}
 
     if not (
-        path_value.startswith(f"repos/{repo}/pulls/")
-        or path_value.startswith(f"repos/{repo}/issues/")
-        or path_value.startswith(f"repos/{repo}/contents/")
-        or path_value.startswith(f"repos/{repo}/compare/")
-        or path_value.startswith(f"repos/{repo}/commits")
-        or path_value.startswith(f"repos/{repo}/releases")
-        or path_value.startswith(f"repos/{repo}/tags")
+        path_value.startswith(f"repos/{target_repo}/pulls/")
+        or path_value.startswith(f"repos/{target_repo}/issues/")
+        or path_value.startswith(f"repos/{target_repo}/contents/")
+        or path_value.startswith(f"repos/{target_repo}/compare/")
+        or path_value.startswith(f"repos/{target_repo}/commits")
+        or path_value.startswith(f"repos/{target_repo}/releases")
+        or path_value.startswith(f"repos/{target_repo}/tags")
     ):
         return {"status": "error", "error": "Path not in gh_api allowlist"}
 
@@ -275,7 +304,14 @@ def run_git_grep(pattern, max_bytes, timeout_sec):
     }
 
 
-def execute_request(item, max_bytes, repo, workspace_root, allowlist, timeout_sec):
+def execute_request(
+    item,
+    max_bytes,
+    allowed_gh_api_repos,
+    workspace_root,
+    allowlist,
+    timeout_sec,
+):
     if not isinstance(item, dict):
         return {"status": "error", "error": "Request must be an object"}
 
@@ -284,7 +320,9 @@ def execute_request(item, max_bytes, repo, workspace_root, allowlist, timeout_se
         return {"status": "error", "error": "Missing tool"}
 
     if tool == "gh_api":
-        return run_gh_api(item.get("path"), max_bytes, repo, timeout_sec)
+        return run_gh_api(
+            item.get("path"), max_bytes, allowed_gh_api_repos, timeout_sec
+        )
     if tool == "read_file":
         return run_read_file(item.get("path"), max_bytes, workspace_root)
     if tool == "web_fetch":
@@ -343,13 +381,24 @@ def main():
     api_key = os.getenv("AI_API_KEY", "").strip()
     max_requests = env_int("TOOL_MAX_REQUESTS", 4, 1)
     max_bytes = env_int("TOOL_MAX_RESPONSE_BYTES", 12000, 1000)
-    max_context = env_int("TOOL_PLANNING_MAX_CONTEXT_BYTES", 90000, 5000)
+    max_context = env_int("TOOL_PLANNING_MAX_CONTEXT_BYTES", 50000, 5000)
+    planning_timeout_sec = env_int("TOOL_PLANNING_TIMEOUT_SEC", 45, 1)
     request_timeout_sec = env_int("TOOL_REQUEST_TIMEOUT_SEC", 20, 1)
     allowlist = [
         normalize_host(item)
         for item in os.getenv("ALLOWED_SOURCE_HOSTS", "").split(",")
         if normalize_host(item)
     ]
+
+    allowed_gh_api_repos = set()
+    current_repo = normalize_repo_name(repo)
+    if current_repo:
+        allowed_gh_api_repos.add(current_repo)
+    for item in os.getenv("TOOL_ALLOWED_GH_API_REPOS", "").split(","):
+        normalized = normalize_repo_name(item)
+        if normalized:
+            allowed_gh_api_repos.add(normalized)
+
     workspace_root = Path.cwd().resolve()
 
     summary = {
@@ -379,12 +428,14 @@ def main():
         "Return STRICT JSON only with one top-level key requests (array). "
         "Each request must include tool and the minimal required fields. "
         "Allowed tools: gh_api(path), read_file(path), web_fetch(url), git_grep(pattern). "
+        "For gh_api, path must be like repos/owner/repo/... and repository must be allowlisted. "
         "Never request secrets, credentials, keys, or environment files. "
         "Use at most the requested number of requests and prefer high-value evidence gaps."
     )
     planning_user = (
         f"Repository: {repo}\n"
         f"Max requests: {max_requests}\n"
+        f"Allowed repos for gh_api: {', '.join(sorted(allowed_gh_api_repos)) if allowed_gh_api_repos else '(none)'}\n"
         f"Allowed hosts for web_fetch: {', '.join(allowlist) if allowlist else '(none)'}\n"
         f"Corpus truncated for planning: {corpus_truncated}\n\n"
         "Analyze this PR corpus and request extra evidence only if needed:\n\n"
@@ -395,7 +446,12 @@ def main():
     planning_response = ""
     try:
         planning_response = run_chat_completion(
-            base_url, model, api_key, planning_system, planning_user
+            base_url,
+            model,
+            api_key,
+            planning_system,
+            planning_user,
+            planning_timeout_sec,
         )
     except Exception as exc:  # noqa: BLE001
         planning_error = str(exc)
@@ -427,7 +483,7 @@ def main():
         result = execute_request(
             request_obj,
             max_bytes,
-            repo,
+            allowed_gh_api_repos,
             workspace_root,
             allowlist,
             request_timeout_sec,


### PR DESCRIPTION
## Summary
- add configurable planning and execution controls for tool harness (`tool_planning_timeout_sec`, `tool_planning_max_context_bytes`, `tool_request_timeout_sec`)
- add upstream `gh_api` repo allowlisting with `tool_allowed_gh_api_repos` so the harness can safely query dependency upstreams
- add fail-closed uncertainty controls: `tool_failure_enforcement` and `tool_min_successful_requests`
- make macOS local smoke execution reliable by switching `sed -i` usage to a portable helper in `run_review.sh`
- update README and SECURITY docs for the new controls and guidance

## Why
The previous harness either timed out or got blocked from upstream evidence, which left the model approving PRs under uncertainty. These changes make the harness more configurable and allow deterministic fail-closed behavior when evidence gathering fails.

## Validation
- `bash -n scripts/check_review_needed.sh && bash -n scripts/run_review.sh && bash -n tests/smoke_test.sh`
- `python3 -m py_compile scripts/image_digest_analysis.py scripts/run_evidence_providers.py scripts/run_tool_harness.py tests/mock_openai_server.py`
- `ruby -e 'require "yaml"; YAML.load_file("action.yml"); YAML.load_file("examples/workflow-self-hosted.yml"); YAML.load_file("examples/workflow-cloud.yml")'`
- `tests/smoke_test.sh`
- local end-to-end smoke against `llama-vision` with fail-closed settings confirmed `request_changes` when tool planning timed out