### PR TITLE
fix: enforce tool success threshold only when attempted

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ If a repo wants more than policy context and needs to fully control the reviewer
 - `gh_api` defaults to current-repo scope only. Use `tool_allowed_gh_api_repos` to allow specific upstream repos.
 - For local models, reduce `tool_planning_max_context_bytes` and `tool_planning_max_tokens`, and increase `tool_planning_timeout_sec` as needed.
 - Set `tool_failure_enforcement=true` to fail closed when tool harness planning fails or when every tool request fails.
-- Use `tool_min_successful_requests` (for example `1`) to enforce a minimum successful tool-evidence threshold.
+- Use `tool_min_successful_requests` (for example `1`) to enforce a minimum successful tool-evidence threshold when the planner attempted tool requests.
 - Model requests use `curl -q` so user-level `.curlrc` timeouts do not unexpectedly cancel long-running local model calls.
 
 ## Validation

--- a/scripts/run_review.sh
+++ b/scripts/run_review.sh
@@ -807,12 +807,13 @@ if [[ "$(printf '%s' "$TOOL_MODE" | tr '[:upper:]' '[:lower:]')" == "plan_execut
     mv ai-output.enforced.json ai-output.json
     log "Enforced request_changes due to tool harness failure"
   elif [[ "$TOOL_MIN_SUCCESSFUL_REQUESTS" -gt 0 ]]; then
+    TOOL_REQUESTS_ATTEMPTED="$(jq -r 'if ((.planned_request_count // 0) > 0) or ((.executed_request_count // 0) > 0) then "true" else "false" end' tool-harness.json 2>/dev/null || echo false)"
     SUCCESSFUL_TOOL_REQUESTS="$(jq -r '[.tool_results[]?.result.status == "ok"] | map(select(. == true)) | length' tool-harness.json 2>/dev/null || echo 0)"
     if [[ ! "$SUCCESSFUL_TOOL_REQUESTS" =~ ^[0-9]+$ ]]; then
       SUCCESSFUL_TOOL_REQUESTS=0
     fi
 
-    if [[ "$SUCCESSFUL_TOOL_REQUESTS" -lt "$TOOL_MIN_SUCCESSFUL_REQUESTS" ]]; then
+    if [[ "$TOOL_REQUESTS_ATTEMPTED" == "true" ]] && [[ "$SUCCESSFUL_TOOL_REQUESTS" -lt "$TOOL_MIN_SUCCESSFUL_REQUESTS" ]]; then
       jq --arg min "$TOOL_MIN_SUCCESSFUL_REQUESTS" --arg got "$SUCCESSFUL_TOOL_REQUESTS" '
         .verdict = "request_changes"
         | .review_markdown = (
@@ -827,6 +828,8 @@ if [[ "$(printf '%s' "$TOOL_MODE" | tr '[:upper:]' '[:lower:]')" == "plan_execut
       ' ai-output.json > ai-output.enforced.json
       mv ai-output.enforced.json ai-output.json
       log "Enforced request_changes due to insufficient successful tool requests"
+    elif [[ "$TOOL_REQUESTS_ATTEMPTED" != "true" ]]; then
+      log "Skipping minimum successful tool request enforcement because planner requested no tools"
     fi
   fi
 fi


### PR DESCRIPTION
## Summary
- adjust `tool_min_successful_requests` enforcement so it only applies when the planner/harness actually attempted tool requests
- keep fail-closed behavior for true harness failures (`planning_error`, execution errors, all attempted requests failed)
- update README wording to match runtime behavior

## Why
A planner decision of "no tools needed" should not trigger `Tool Harness Insufficient Evidence` when the run otherwise succeeds.

## Validation
- `bash -n scripts/run_review.sh`
- `tests/smoke_test.sh`