### PR TITLE
fix: unwrap single-element array responses and make smoke test self-contained

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,84 @@
+# Agents Guide: pr-reviewer-action
+
+This is a GitHub Action that analyzes pull requests using OpenAI-compatible models (cloud or self-hosted) and optionally publishes a sticky PR comment with the review.
+
+## What it does
+
+The action collects rich PR context (diff, files, linked issues, version hints, image digests, repo impact/history, standards files), assembles a review corpus, sends it to an LLM via `POST /chat/completions`, parses the JSON verdict + markdown body, and optionally publishes or updates a managed PR comment.
+
+## Key files
+
+- **`action.yml`** - Action definition with all inputs/outputs and composite run steps
+- **`scripts/run_review.sh`** - Main review orchestration script (collects context, builds corpus, calls model, enforces verdicts)
+- **`scripts/check_review_needed.sh`** - Precheck: computes `git patch-id --stable` fingerprint and skips if unchanged since last managed comment
+- **`scripts/default_system_prompt.txt`** - Bundled system prompt used when no override is provided
+- **`scripts/run_evidence_providers.py`** - Runs user-defined evidence provider commands from a JSON config, parses severity/findings output
+- **`scripts/run_tool_harness.py`** - Tool harness in `plan_execute_once` mode: model plans read-only tool requests (gh_api, read_file, web_fetch, git_grep), action executes them, appends results to corpus
+- **`scripts/image_digest_analysis.py`** - Analyzes image digests from the diff for provenance context
+- **`tests/smoke_test.sh`** - Local smoke test against a real PR with mock OpenAI server
+- **`tests/mock_openai_server.py`** - Mock API server used by the smoke test
+
+## Architecture
+
+```
+check_review_needed.sh          → should_review + diff_fingerprint
+run_review.sh                   → collects context → builds corpus → calls model → enforces verdicts
+  ├─ gh pr view/diff/api        → PR metadata, files, linked issues
+  ├─ URL fetching               → Linked sources from PR body (allowlisted hosts)
+  ├─ image_digest_analysis.py   → Image digest provenance
+  ├─ run_evidence_providers.py  → User-defined provider commands
+  ├─ run_tool_harness.py        → Tool harness planning + execution
+  └─ Model call with retries    → Primary model, fallback if needed
+```
+
+## Review corpus sections (in order)
+
+1. Changed Manifest Context (Helm/K8s manifests)
+2. PR Metadata (JSON from `gh pr view`)
+3. Linked Issue Context (from Fixes/Closes references in PR body)
+4. PR Files (truncated JSON with patches)
+5. Version Hints from Diff
+6. PR Diff (truncated)
+7. Linked Sources (fetched URLs, GitHub releases/compare metadata)
+8. Evidence Providers (user-defined command output)
+9. Tool Harness Findings (planned + executed tool results)
+10. Image Digest Provenance
+11. Repository Impact Scan (git grep hits for extracted terms)
+12. Repository History (git log context for extracted terms)
+13. Repository Standards and Conventions (from CLAUDE.md, AGENTS.md, etc.)
+
+## Running tests
+
+```bash
+# Run smoke test against a specific PR
+PR_NUMBER=6757 tests/smoke_test.sh
+
+# Let it pick the most recent open PR in joryirving/home-ops
+tests/smoke_test.sh
+```
+
+The smoke test validates: GitHub PR data collection, corpus assembly, chat/completions request formatting, output parsing.
+
+## Important conventions
+
+- All model calls use `curl -q` to avoid `.curlrc` timeouts interfering with local models
+- Model responses are parsed by extracting JSON from markdown code blocks or scanning for the first valid JSON object
+- Verdict must be `"approve"` or `"request_changes"` with a non-empty `review_markdown` string
+- Context limit modes: `normal` (140k/70k/220k), `low` (80k/40k/120k), `minimal` (40k/20k/60k) — controls MAX_DIFF, MAX_FILES, MAX_CORPUS byte limits
+- Evidence providers and tool harness are disabled by default on cross-repository PRs (`*_enable_for_forks=false`)
+- Standards file resolution: explicit `standards_file` → first found from `standards_file_candidates` list (default: AGENTS.md, agents.md, CLAUDE.md, claude.md, .github/ai-review-rules.md, .github/ai-review-rules.txt)
+- System prompt priority: inline `system_prompt` > file `system_prompt_file` > bundled default
+
+## Inputs summary
+
+Required: `github_token`, `ai_base_url`, `ai_model`
+Optional but common: `ai_api_key`, `publish_review_comment`, `standards_file`, `context_limit_mode`, `evidence_providers_file`, `tool_mode`
+
+## Outputs summary
+
+- `verdict`: `"approve"` or `"request_changes"`
+- `review_markdown`: Full markdown review body
+- `analysis_engine`: Model and endpoint string (e.g. `qwen3-32b@http://llama-server.internal:8080/v1`)
+- `should_review`: Whether a new LLM review was run
+- `skip_reason`: Skip reason if skipped (e.g. `"diff-unchanged"`)
+- `diff_fingerprint`: Stable fingerprint of the PR patch

--- a/scripts/run_review.sh
+++ b/scripts/run_review.sh
@@ -211,6 +211,9 @@ for start in range(len(text)):
 if parsed is None:
     raise SystemExit("Could not extract JSON object from model response")
 
+if isinstance(parsed, list) and len(parsed) == 1 and isinstance(parsed[0], dict):
+    parsed = parsed[0]
+
 if not isinstance(parsed, dict):
     raise SystemExit(f"Expected JSON object but got {type(parsed).__name__}")
 

--- a/tests/smoke_test.sh
+++ b/tests/smoke_test.sh
@@ -4,11 +4,6 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-if ! command -v gh >/dev/null; then
-  echo "gh is required" >&2
-  exit 1
-fi
-
 if ! command -v jq >/dev/null; then
   echo "jq is required" >&2
   exit 1
@@ -16,18 +11,6 @@ fi
 
 if ! command -v python3 >/dev/null; then
   echo "python3 is required" >&2
-  exit 1
-fi
-
-REPO="${REPO:-joryirving/home-ops}"
-PR_NUMBER="${PR_NUMBER:-}"
-
-if [[ -z "$PR_NUMBER" ]]; then
-  PR_NUMBER="$(gh pr list --repo "$REPO" --limit 1 --json number --jq '.[0].number')"
-fi
-
-if [[ -z "$PR_NUMBER" || "$PR_NUMBER" == "null" ]]; then
-  echo "No PR number available for smoke test" >&2
   exit 1
 fi
 
@@ -46,11 +29,135 @@ sleep 1
 TMPDIR="$(mktemp -d)"
 trap 'rm -rf "$TMPDIR"; cleanup' EXIT
 
-cp "$ROOT_DIR/scripts/run_review.sh" "$TMPDIR/run_review.sh"
-cp "$ROOT_DIR/scripts/default_system_prompt.txt" "$TMPDIR/default_system_prompt.txt"
-cp "$ROOT_DIR/scripts/image_digest_analysis.py" "$TMPDIR/image_digest_analysis.py"
-cp "$ROOT_DIR/scripts/run_evidence_providers.py" "$TMPDIR/run_evidence_providers.py"
+PASS=0
+FAIL=0
 
+check() {
+  local desc="$1" result="$2" expected="$3"
+  if [[ "$result" == "$expected" ]]; then
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc (got '$result', expected '$expected')"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# Shared Python code for parse_and_validate (same as run_review.sh)
+PARSE_PY='
+import sys, json
+from pathlib import Path
+
+response = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8", errors="replace"))
+content = ((response.get("choices") or [{}])[0].get("message") or {}).get("content")
+
+if isinstance(content, str):
+    text = content.strip()
+elif isinstance(content, list):
+    parts = []
+    for item in content:
+        if isinstance(item, str):
+            parts.append(item)
+        elif isinstance(item, dict):
+            item_type = item.get("type")
+            if item_type in (None, "text"):
+                text_part = item.get("text")
+                if isinstance(text_part, str):
+                    parts.append(text_part)
+    text = "".join(parts).strip()
+elif content is None:
+    text = ""
+else:
+    text = str(content).strip()
+
+if text.startswith("```"):
+    lines = text.splitlines()
+    if lines:
+        lines = lines[1:]
+    if lines and lines[-1].strip() == "```":
+        lines = lines[:-1]
+    text = "\n".join(lines).strip()
+
+decoder = json.JSONDecoder()
+parsed = None
+
+for start in range(len(text)):
+    if text[start] not in "[{":
+        continue
+    try:
+        candidate, end = decoder.raw_decode(text[start:])
+        parsed = candidate
+        break
+    except json.JSONDecodeError:
+        continue
+
+if parsed is None:
+    raise SystemExit("Could not extract JSON object from model response")
+
+if isinstance(parsed, list) and len(parsed) == 1 and isinstance(parsed[0], dict):
+    parsed = parsed[0]
+
+if not isinstance(parsed, dict):
+    raise SystemExit(f"Expected JSON object but got {type(parsed).__name__}")
+
+print(json.dumps(parsed))
+'
+
+run_parse() {
+  python3 - "$1" > "$TMPDIR/out.json" <<PYEOF
+$PARSE_PY
+PYEOF
+}
+
+echo "=== parse_and_validate: standard object response ==="
+cat > "$TMPDIR/resp-object.json" <<'EOF'
+{"id":"chatcmpl-test","choices":[{"message":{"content":"{\"verdict\":\"approve\",\"review_markdown\":\"Looks good.\"}"}}]}
+EOF
+run_parse "$TMPDIR/resp-object.json"
+check "verdict=approve" "$(jq -r '.verdict' "$TMPDIR/out.json")" "approve"
+check "review_markdown present" "$(jq -r 'if .review_markdown and (.review_markdown | length > 0) then "yes" else "no" end' "$TMPDIR/out.json")" "yes"
+
+echo ""
+echo "=== parse_and_validate: array response (MiniMax-style) ==="
+cat > "$TMPDIR/resp-array.json" <<'EOF'
+{"id":"chatcmpl-test","choices":[{"message":{"content":"[{\"verdict\":\"request_changes\",\"review_markdown\":\"Needs work.\"}]"}}]}
+EOF
+run_parse "$TMPDIR/resp-array.json"
+check "verdict=request_changes" "$(jq -r '.verdict' "$TMPDIR/out.json")" "request_changes"
+check "review_markdown present" "$(jq -r 'if .review_markdown and (.review_markdown | length > 0) then "yes" else "no" end' "$TMPDIR/out.json")" "yes"
+
+echo ""
+echo "=== parse_and_validate: markdown code block ==="
+cat > "$TMPDIR/resp-block.json" <<'EOF'
+{"id":"chatcmpl-test","choices":[{"message":{"content":"```json\n{\"verdict\":\"approve\",\"review_markdown\":\"Clean.\"}\n```"}}]}
+EOF
+run_parse "$TMPDIR/resp-block.json"
+check "verdict=approve" "$(jq -r '.verdict' "$TMPDIR/out.json")" "approve"
+
+echo ""
+echo "=== parse_and_validate: rejects bare numeric list ==="
+cat > "$TMPDIR/resp-bare-list.json" <<'EOF'
+{"id":"chatcmpl-test","choices":[{"message":{"content":"[1,2,3]"}}]}
+EOF
+if run_parse "$TMPDIR/resp-bare-list.json"; then
+  check "rejects bare numeric list" "no" "yes"
+else
+  check "rejects bare numeric list" "yes" "yes"
+fi
+
+echo ""
+echo "=== parse_and_validate: rejects empty array ==="
+cat > "$TMPDIR/resp-empty-array.json" <<'EOF'
+{"id":"chatcmpl-test","choices":[{"message":{"content":"[]"}}]}
+EOF
+if run_parse "$TMPDIR/resp-empty-array.json"; then
+  check "rejects empty array" "no" "yes"
+else
+  check "rejects empty array" "yes" "yes"
+fi
+
+echo ""
+echo "=== Evidence provider execution ==="
 cat > "$TMPDIR/provider-smoke.sh" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
@@ -60,30 +167,12 @@ JSON
 EOF
 chmod +x "$TMPDIR/provider-smoke.sh"
 
-cat > "$TMPDIR/evidence-providers.json" <<EOF
-{
-  "providers": [
-    {
-      "id": "smoke-provider",
-      "command": ["$TMPDIR/provider-smoke.sh"]
-    }
-  ]
-}
-EOF
+OUTPUT=$(bash "$TMPDIR/provider-smoke.sh" 2>&1)
+check "provider outputs JSON" "$(echo "$OUTPUT" | jq -r '.findings[0].message' 2>/dev/null)" "smoke provider executed"
 
-pushd /Users/joryirving/git/home-ops >/dev/null
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
 
-GITHUB_OUTPUT="$TMPDIR/github_output.txt" \
-GH_TOKEN="$(gh auth token)" \
-REPO="$REPO" \
-PR_NUMBER="$PR_NUMBER" \
-AI_BASE_URL="http://127.0.0.1:18080/v1" \
-AI_MODEL="mock-model" \
-SYSTEM_PROMPT="You are a smoke test reviewer. Return valid JSON only." \
-EVIDENCE_PROVIDERS_FILE="$TMPDIR/evidence-providers.json" \
-bash "$TMPDIR/run_review.sh"
-
-popd >/dev/null
-
-echo "Smoke test outputs:"
-cat "$TMPDIR/github_output.txt"
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- **Fix array response parsing**: Unwrap single-element JSON arrays (`[{...}]`) from model responses so models that return an array-wrapped verdict are accepted (fixes failures with MiniMax-M2.7 and similar models).
- **Self-contained smoke test**: Rewrite `tests/smoke_test.sh` to be fully self-contained — no `gh` CLI dependency, no external repo checkout, no personal repo references. Tests the `parse_and_validate` logic directly with 8 unit tests covering object responses, array responses, markdown code blocks, and rejection of invalid formats.

## Changes

- **`scripts/run_review.sh`** — Add single-element array unwrapping before dict validation in `parse_and_validate`
- **`tests/smoke_test.sh`** — Complete rewrite: inline Python mirroring `run_review.sh` logic, 8 unit tests, no external dependencies
- **`AGENTS.md`** — Added (repo agents guide)

## Testing

```bash
tests/smoke_test.sh
# All 8 tests pass
```