### PR TITLE
fix: harden enforced review output

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The action gathers PR metadata, diff context, linked issue context from PR-closi
 | `tool_planning_max_context_bytes` | Maximum corpus bytes passed to planning | No | `50000` |
 | `tool_planning_max_tokens` | Maximum completion tokens for tool harness planning call | No | `400` |
 | `tool_max_response_bytes` | Maximum bytes captured from each tool response | No | `12000` |
-| `tool_allowed_gh_api_repos` | Comma-separated owner/repo allowlist for `gh_api` (empty = current repo only) | No | `""` |
+| `tool_allowed_gh_api_repos` | Comma-separated owner/repo allowlist for `gh_api`; use `*` to allow any repo endpoint still permitted by the tool path allowlist (empty = current repo only) | No | `""` |
 | `tool_request_timeout_sec` | Timeout in seconds for each tool execution request | No | `20` |
 | `tool_failure_enforcement` | Force `request_changes` when tool harness planning fails | No | `false` |
 | `tool_min_successful_requests` | Minimum successful tool requests required when `tool_failure_enforcement=true` | No | `0` |
@@ -277,7 +277,7 @@ If a repo wants more than policy context and needs to fully control the reviewer
 - Tool harness output is appended to the review corpus under `Tool Harness Findings`.
 - Tool harness planning treats corpus content as untrusted data and uses strict tool/path/host allowlists with output redaction.
 - Evidence providers and tool harness are both disabled by default on cross-repository PRs (`*_enable_for_forks=false`).
-- `gh_api` defaults to current-repo scope only. Use `tool_allowed_gh_api_repos` to allow specific upstream repos.
+- `gh_api` defaults to current-repo scope only. Use `tool_allowed_gh_api_repos` to allow specific upstream repos, or `*` to allow any repository while keeping the path denylist and endpoint allowlist active.
 - For local models, reduce `tool_planning_max_context_bytes` and `tool_planning_max_tokens`, and increase `tool_planning_timeout_sec` as needed.
 - Set `tool_failure_enforcement=true` to fail closed when tool harness planning fails or when every tool request fails.
 - Use `tool_min_successful_requests` (for example `1`) to enforce a minimum successful tool-evidence threshold when the planner attempted tool requests.

--- a/action.yml
+++ b/action.yml
@@ -116,7 +116,7 @@ inputs:
     required: false
     default: "12000"
   tool_allowed_gh_api_repos:
-    description: Comma-separated owner/repo list allowed for gh_api tool requests (empty means current repo only)
+    description: Comma-separated owner/repo list allowed for gh_api tool requests; use * to allow any repo still permitted by the path allowlist (empty means current repo only)
     required: false
     default: ""
   tool_request_timeout_sec:

--- a/scripts/run_review.sh
+++ b/scripts/run_review.sh
@@ -224,6 +224,36 @@ PY
   jq -e '.review_markdown and (.review_markdown | length > 0)' ai-output.json > /dev/null
 }
 
+normalize_enforced_review_markdown() {
+  python3 - <<'PY'
+import json
+import re
+from pathlib import Path
+
+path = Path("ai-output.json")
+data = json.loads(path.read_text(encoding="utf-8", errors="replace"))
+verdict = data.get("verdict")
+markdown = str(data.get("review_markdown") or "")
+
+if verdict == "request_changes":
+    markdown = re.sub(
+        r"(?im)^(#{1,6}\s*)?Recommendation:\s*Approve\s*$",
+        r"\1Model recommendation before enforcement: Approve",
+        markdown,
+    )
+    if not markdown.lstrip().startswith("## Final Recommendation"):
+        markdown = (
+            "## Final Recommendation\n"
+            "Request changes. One or more configured enforcement checks require this PR "
+            "to be treated as blocking even if the model's initial review text was approving.\n\n"
+            + markdown.lstrip()
+        )
+
+data["review_markdown"] = markdown
+path.write_text(json.dumps(data, ensure_ascii=False) + "\n", encoding="utf-8")
+PY
+}
+
 log "Collecting PR context for #$PR_NUMBER in $REPO..."
 
 gh pr view "$PR_NUMBER" --repo "$REPO" \
@@ -296,8 +326,8 @@ fi
 cat pr-body.txt pr.diff.truncated \
   | grep -Eo 'https?://[^ )]+' \
   | sed 's/[",.;]$//' \
-  | sort -u \
-  | head -n 25 > urls.txt || true
+  | sort -u > urls.all.txt || true
+head -n 25 urls.all.txt > urls.txt || true
 
 grep -E '^[+-].*(image:|tag:|version:|chart:|appVersion:|digest:)' pr.diff.truncated > version-hints.txt || true
 head -n 180 version-hints.txt > version-hints.truncated.txt || true
@@ -574,8 +604,8 @@ log "Gathering repository impact and history..."
   | tr '[:upper:]' '[:lower:]' \
   | grep -Eo '[a-z0-9][a-z0-9._/-]{2,}' \
   | grep -Ev '^(https?|from|into|that|this|with|without|renovate|pull|request|release|notes|digest|sha|main|chart|image|version|github|com|www|docker|ghcr|io)$' \
-  | sort -u \
-  | head -n 14 > terms.txt || true
+  | sort -u > terms.all.txt || true
+head -n 14 terms.all.txt > terms.txt || true
 
 : > repo-impact.md
 : > repo-history.md
@@ -787,6 +817,8 @@ else
   fi
 fi
 
+ENFORCED_REQUEST_CHANGES=0
+
 if [[ "$(printf '%s' "$EVIDENCE_BLOCKER_ENFORCEMENT" | tr '[:upper:]' '[:lower:]')" == "true" ]] && \
   jq -e '.has_blocker == true' evidence-providers.json >/dev/null 2>&1; then
   BLOCKER_PROVIDER_IDS="$(jq -r '.providers[]? | select((.provider_severity // "") == "blocker") | .id' evidence-providers.json | paste -sd ', ' -)"
@@ -801,6 +833,7 @@ if [[ "$(printf '%s' "$EVIDENCE_BLOCKER_ENFORCEMENT" | tr '[:upper:]' '[:lower:]
     )
   ' ai-output.json > ai-output.enforced.json
   mv ai-output.enforced.json ai-output.json
+  ENFORCED_REQUEST_CHANGES=1
   log "Enforced request_changes due to blocker evidence provider findings"
 fi
 
@@ -830,6 +863,7 @@ if [[ "$(printf '%s' "$TOOL_MODE" | tr '[:upper:]' '[:lower:]')" == "plan_execut
     )
   ' ai-output.json > ai-output.enforced.json
     mv ai-output.enforced.json ai-output.json
+    ENFORCED_REQUEST_CHANGES=1
     log "Enforced request_changes due to tool harness failure"
   elif [[ "$TOOL_MIN_SUCCESSFUL_REQUESTS" -gt 0 ]]; then
     TOOL_REQUESTS_ATTEMPTED="$(jq -r 'if ((.planned_request_count // 0) > 0) or ((.executed_request_count // 0) > 0) then "true" else "false" end' tool-harness.json 2>/dev/null || echo false)"
@@ -852,11 +886,16 @@ if [[ "$(printf '%s' "$TOOL_MODE" | tr '[:upper:]' '[:lower:]')" == "plan_execut
         )
       ' ai-output.json > ai-output.enforced.json
       mv ai-output.enforced.json ai-output.json
+      ENFORCED_REQUEST_CHANGES=1
       log "Enforced request_changes due to insufficient successful tool requests"
     elif [[ "$TOOL_REQUESTS_ATTEMPTED" != "true" ]]; then
       log "Skipping minimum successful tool request enforcement because planner requested no tools"
     fi
   fi
+fi
+
+if [[ "$ENFORCED_REQUEST_CHANGES" -eq 1 ]]; then
+  normalize_enforced_review_markdown
 fi
 
 echo "analysis_engine=$ANALYSIS_ENGINE" >> "$OUTPUT_FILE"

--- a/scripts/run_tool_harness.py
+++ b/scripts/run_tool_harness.py
@@ -3,6 +3,7 @@ import json
 import os
 import re
 import subprocess
+import tempfile
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -144,14 +145,43 @@ def run_chat_completion(
         "max_tokens": max_tokens,
     }
     endpoint = base_url.rstrip("/") + "/chat/completions"
-    body = json.dumps(payload).encode("utf-8")
-    request = urllib.request.Request(endpoint, data=body, method="POST")
-    request.add_header("Content-Type", "application/json")
+    args = [
+        "curl",
+        "-q",
+        "-fsSL",
+        "--max-time",
+        str(timeout_sec),
+        endpoint,
+        "-H",
+        "Content-Type: application/json",
+    ]
     if api_key:
-        request.add_header("Authorization", f"Bearer {api_key}")
+        args.extend(["-H", f"Authorization: Bearer {api_key}"])
 
-    with urllib.request.urlopen(request, timeout=timeout_sec) as response:
-        response_body = response.read().decode("utf-8", errors="replace")
+    with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as payload_file:
+        json.dump(payload, payload_file)
+        payload_path = payload_file.name
+
+    try:
+        completed = safe_run(args + ["--data", f"@{payload_path}"], timeout_sec + 5)
+    finally:
+        try:
+            os.unlink(payload_path)
+        except OSError:
+            pass
+
+    if isinstance(completed, dict) and completed.get("timeout"):
+        raise RuntimeError("planner model request timed out")
+    if completed.returncode != 0:
+        stderr = mask_secrets((completed.stderr or "").strip())
+        if len(stderr) > 500:
+            stderr = stderr[:500] + "...[truncated]"
+        raise RuntimeError(
+            f"planner model request failed with exit code {completed.returncode}"
+            + (f": {stderr}" if stderr else "")
+        )
+
+    response_body = completed.stdout
     parsed = json.loads(response_body)
     return parsed.get("choices", [{}])[0].get("message", {}).get("content", "")
 
@@ -173,7 +203,7 @@ def run_gh_api(path, max_bytes, allowed_repos, timeout_sec):
     if not target_repo:
         return {"status": "error", "error": "Invalid owner/repo in path"}
 
-    if target_repo not in allowed_repos:
+    if "*" not in allowed_repos and target_repo not in allowed_repos:
         return {
             "status": "error",
             "error": f"Repository not allowlisted for gh_api: {target_repo}",
@@ -408,6 +438,9 @@ def main():
     if current_repo:
         allowed_gh_api_repos.add(current_repo)
     for item in os.getenv("TOOL_ALLOWED_GH_API_REPOS", "").split(","):
+        if item.strip() == "*":
+            allowed_gh_api_repos.add("*")
+            continue
         normalized = normalize_repo_name(item)
         if normalized:
             allowed_gh_api_repos.add(normalized)


### PR DESCRIPTION
## Summary
- Prevent enforced request-changes verdicts from displaying contradictory approve recommendations.
- Make tool harness planner requests use curl like the main model call and support wildcard gh_api repo allowlists.
- Avoid harmless broken-pipe noise in context gathering pipelines.

## Validation
- tests/smoke_test.sh
- python3 -m py_compile scripts/run_tool_harness.py
- bash -n scripts/run_review.sh