### PR TITLE
feat: support Anthropic API format

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,3 +34,6 @@ jobs:
 
       - name: Verify smoke test helper is executable
         run: test -x tests/smoke_test.sh
+
+      - name: Run smoke test
+        run: tests/smoke_test.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,10 @@
 # Agents Guide: pr-reviewer-action
 
-This is a GitHub Action that analyzes pull requests using OpenAI-compatible models (cloud or self-hosted) and optionally publishes a sticky PR comment with the review.
+This is a GitHub Action that analyzes pull requests using OpenAI-compatible or Anthropic-compatible models (cloud or self-hosted) and optionally publishes a sticky PR comment with the review.
 
 ## What it does
 
-The action collects rich PR context (diff, files, linked issues, version hints, image digests, repo impact/history, standards files), assembles a review corpus, sends it to an LLM via `POST /chat/completions`, parses the JSON verdict + markdown body, and optionally publishes or updates a managed PR comment.
+The action collects rich PR context (diff, files, linked issues, version hints, image digests, repo impact/history, standards files), assembles a review corpus, sends it to an LLM via OpenAI `POST /chat/completions` or Anthropic `POST /messages`, parses the JSON verdict + markdown body, and optionally publishes or updates a managed PR comment.
 
 ## Key files
 
@@ -57,7 +57,7 @@ PR_NUMBER=6757 tests/smoke_test.sh
 tests/smoke_test.sh
 ```
 
-The smoke test validates: GitHub PR data collection, corpus assembly, chat/completions request formatting, output parsing.
+The smoke test validates: GitHub PR data collection, corpus assembly, OpenAI/Anthropic response parsing, and tool harness request formatting.
 
 ## Important conventions
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pr-reviewer-action
 
-Analyze pull requests with a self-hosted or cloud OpenAI-compatible model.
+Analyze pull requests with a self-hosted or cloud OpenAI-compatible or Anthropic-compatible model.
 
 [![CI](https://github.com/joryirving/pr-reviewer-action/actions/workflows/ci.yaml/badge.svg)](https://github.com/joryirving/pr-reviewer-action/actions/workflows/ci.yaml)
 
@@ -9,7 +9,8 @@ The action gathers PR metadata, diff context, linked issue context from PR-closi
 ## What it supports
 
 - self-hosted OpenAI-compatible endpoints
-- cloud OpenAI-compatible subscriptions with bearer auth
+- native Anthropic-compatible `/messages` endpoints
+- cloud OpenAI-compatible or Anthropic-compatible subscriptions
 - optional fallback model/endpoint
 - optional evidence providers for repo-specific checks
 - optional read-only tool harness for one planning round
@@ -32,12 +33,16 @@ The action gathers PR metadata, diff context, linked issue context from PR-closi
 | `github_token` | GitHub token for PR and API access | Yes | - |
 | `repo` | Repository in `owner/name` format | No | current repository |
 | `pr_number` | Pull request number | No | current `pull_request` number |
-| `ai_base_url` | Base URL of the primary OpenAI-compatible API | Yes | - |
+| `ai_base_url` | Base URL of the primary AI API | Yes | - |
+| `ai_api_format` | Primary API request/response format: `openai` or `anthropic` | No | `openai` |
 | `ai_model` | Model name for the primary analysis pass | Yes | - |
-| `ai_api_key` | Optional bearer token for the primary AI endpoint | No | `""` |
-| `ai_fallback_base_url` | Optional fallback OpenAI-compatible API base URL | No | `""` |
+| `ai_api_key` | Optional API key for the primary AI endpoint. OpenAI format sends `Authorization: Bearer`; Anthropic format sends `x-api-key` | No | `""` |
+| `ai_max_tokens` | Maximum completion tokens for primary and fallback final review calls. Required by Anthropic-compatible APIs | No | `4096` |
+| `anthropic_version` | `anthropic-version` header used for Anthropic-compatible requests | No | `2023-06-01` |
+| `ai_fallback_base_url` | Optional fallback AI API base URL | No | `""` |
+| `ai_fallback_api_format` | Fallback API request/response format; defaults to `ai_api_format` when blank | No | `""` |
 | `ai_fallback_model` | Optional fallback model name | No | `""` |
-| `ai_fallback_api_key` | Optional bearer token for the fallback AI endpoint | No | `""` |
+| `ai_fallback_api_key` | Optional API key for the fallback AI endpoint | No | `""` |
 | `ai_primary_retries` | Number of retries for the primary model | No | `8` |
 | `ai_primary_retry_delay_sec` | Delay between retries in seconds | No | `15` |
 | `allowed_source_hosts` | Comma-separated allowlist for linked URL fetching | No | `github.com,api.github.com,gitlab.com,registry.terraform.io,artifacthub.io` |
@@ -143,6 +148,22 @@ jobs:
           publish_review_comment: "true"
 ```
 
+### Native Anthropic-compatible endpoint
+
+```yaml
+- uses: joryirving/pr-reviewer-action@v1
+  with:
+    github_token: ${{ secrets.GITHUB_TOKEN }}
+    ai_base_url: https://api.anthropic.com/v1
+    ai_api_format: anthropic
+    ai_model: claude-sonnet-4-5
+    ai_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+    ai_max_tokens: "4096"
+    publish_review_comment: "true"
+```
+
+When `ai_api_format: anthropic` is set, the action posts to `/messages`, sends the `x-api-key` and `anthropic-version` headers, and parses only Anthropic `text` content blocks. Non-text blocks such as `thinking` are ignored so private reasoning is not copied into PR comments.
+
 ### With a fallback model
 
 ```yaml
@@ -153,6 +174,7 @@ jobs:
     ai_base_url: http://llama-server.internal:8080/v1
     ai_model: qwen3-32b
     ai_fallback_base_url: https://api.openai.com/v1
+    ai_fallback_api_format: openai
     ai_fallback_model: gpt-4.1-mini
     ai_fallback_api_key: ${{ secrets.OPENAI_API_KEY }}
 ```
@@ -263,7 +285,9 @@ If a repo wants more than policy context and needs to fully control the reviewer
 
 ## Notes
 
-- The action expects an OpenAI-compatible `POST /chat/completions` API.
+- `ai_api_format=openai` posts to `/chat/completions` and parses `choices[0].message.content`.
+- `ai_api_format=anthropic` posts to `/messages` and parses only `content[]` blocks where `type == "text"`.
+- The tool harness planner uses the primary `ai_api_format`; fallback settings apply only to the final review call.
 - `system_prompt` takes precedence over `system_prompt_file`.
 - `system_prompt_file` takes precedence over the bundled generic prompt.
 - `standards_file` is optional; if blank, the action checks `standards_file_candidates` in order and uses the first file found. `AGENTS.md` is checked first by default, then `CLAUDE.md`, making the action compatible with both Claude Code and non-Claude Code setups.
@@ -285,7 +309,7 @@ If a repo wants more than policy context and needs to fully control the reviewer
 
 ## Validation
 
-This repo includes a local smoke test that exercises the action logic against a real GitHub pull request while using a mock OpenAI-compatible API server.
+This repo includes a local smoke test that exercises the action logic against a real GitHub pull request while using a mock OpenAI/Anthropic-compatible API server.
 
 Run it with a specific PR:
 
@@ -303,7 +327,7 @@ The smoke test validates:
 
 - GitHub PR data collection through `gh`
 - review corpus assembly
-- OpenAI-compatible `chat/completions` request formatting
+- OpenAI-compatible `chat/completions` and Anthropic-compatible `messages` response parsing
 - output parsing and action output generation
 
 ## Examples

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,7 +15,8 @@ This action reviews pull requests with an LLM and optional auxiliary tooling. Th
 - Tool harness treats corpus text as untrusted and does not follow corpus instructions
 - Tool harness uses a strict read-only allowlist (`gh_api`, `read_file`, `web_fetch`, `git_grep`)
 - `gh_api` is constrained to a same-repo path prefix and endpoint allowlist
-- `gh_api` can optionally include specific upstream repos via explicit allowlist (`tool_allowed_gh_api_repos`)
+- `gh_api` can optionally include specific upstream repos via explicit allowlist (`tool_allowed_gh_api_repos`) or all repos via `*` while preserving endpoint/path denylist checks
+- Anthropic responses are parsed from `text` blocks only; non-text blocks such as `thinking` are not added to review output
 - `read_file` is constrained to workspace-relative paths and blocks sensitive path patterns
 - `web_fetch` is constrained to `allowed_source_hosts`
 - Tool outputs are size-limited and pass through basic secret redaction before corpus inclusion

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: AI PR Reviewer
-description: Analyze a pull request with a self-hosted or cloud OpenAI-compatible model and optionally publish a sticky PR comment.
+description: Analyze a pull request with a self-hosted or cloud OpenAI-compatible or Anthropic-compatible model and optionally publish a sticky PR comment.
 
 inputs:
   github_token:
@@ -14,17 +14,33 @@ inputs:
     required: false
     default: ""
   ai_base_url:
-    description: Base URL of the primary OpenAI-compatible API
+    description: Base URL of the primary AI API
     required: true
+  ai_api_format:
+    description: API request/response format for the primary AI endpoint (openai or anthropic)
+    required: false
+    default: openai
   ai_model:
     description: Model name for the primary analysis pass
     required: true
   ai_api_key:
-    description: Optional bearer token for the primary AI endpoint
+    description: Optional API key for the primary AI endpoint
     required: false
     default: ""
+  ai_max_tokens:
+    description: Maximum completion tokens for the primary and fallback final review calls
+    required: false
+    default: "4096"
+  anthropic_version:
+    description: Anthropic API version header used when ai_api_format or ai_fallback_api_format is anthropic
+    required: false
+    default: "2023-06-01"
   ai_fallback_base_url:
-    description: Optional base URL of a fallback OpenAI-compatible API
+    description: Optional base URL of a fallback AI API
+    required: false
+    default: ""
+  ai_fallback_api_format:
+    description: API request/response format for the fallback AI endpoint; defaults to ai_api_format when blank
     required: false
     default: ""
   ai_fallback_model:
@@ -32,7 +48,7 @@ inputs:
     required: false
     default: ""
   ai_fallback_api_key:
-    description: Optional bearer token for the fallback AI endpoint
+    description: Optional API key for the fallback AI endpoint
     required: false
     default: ""
   ai_primary_retries:
@@ -197,9 +213,13 @@ runs:
         REPO: ${{ inputs.repo || github.repository }}
         PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
         AI_BASE_URL: ${{ inputs.ai_base_url }}
+        AI_API_FORMAT: ${{ inputs.ai_api_format }}
         AI_MODEL: ${{ inputs.ai_model }}
         AI_API_KEY: ${{ inputs.ai_api_key }}
+        AI_MAX_TOKENS: ${{ inputs.ai_max_tokens }}
+        ANTHROPIC_VERSION: ${{ inputs.anthropic_version }}
         AI_FALLBACK_BASE_URL: ${{ inputs.ai_fallback_base_url }}
+        AI_FALLBACK_API_FORMAT: ${{ inputs.ai_fallback_api_format }}
         AI_FALLBACK_MODEL: ${{ inputs.ai_fallback_model }}
         AI_FALLBACK_API_KEY: ${{ inputs.ai_fallback_api_key }}
         AI_PRIMARY_RETRIES: ${{ inputs.ai_primary_retries }}

--- a/scripts/run_review.sh
+++ b/scripts/run_review.sh
@@ -23,9 +23,13 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO="${REPO:-${GITHUB_REPOSITORY:-}}"
 PR_NUMBER="${PR_NUMBER:-}"
 AI_BASE_URL="${AI_BASE_URL:-}"
+AI_API_FORMAT="${AI_API_FORMAT:-openai}"
 AI_MODEL="${AI_MODEL:-}"
 AI_API_KEY="${AI_API_KEY:-}"
+AI_MAX_TOKENS="${AI_MAX_TOKENS:-4096}"
+ANTHROPIC_VERSION="${ANTHROPIC_VERSION:-2023-06-01}"
 AI_FALLBACK_BASE_URL="${AI_FALLBACK_BASE_URL:-}"
+AI_FALLBACK_API_FORMAT="${AI_FALLBACK_API_FORMAT:-}"
 AI_FALLBACK_MODEL="${AI_FALLBACK_MODEL:-}"
 AI_FALLBACK_API_KEY="${AI_FALLBACK_API_KEY:-}"
 AI_PRIMARY_RETRIES="${AI_PRIMARY_RETRIES:-8}"
@@ -75,6 +79,32 @@ fi
 if [[ -z "$GH_TOKEN" ]]; then
   error "Missing GitHub token in GH_TOKEN or GITHUB_TOKEN"
   exit 1
+fi
+
+normalize_api_format() {
+  local value="$1"
+  value="$(printf '%s' "$value" | tr '[:upper:]' '[:lower:]')"
+  case "$value" in
+    openai|anthropic) printf '%s' "$value" ;;
+    *) return 1 ;;
+  esac
+}
+
+if ! AI_API_FORMAT="$(normalize_api_format "$AI_API_FORMAT")"; then
+  error "Invalid AI_API_FORMAT '$AI_API_FORMAT'; expected openai or anthropic"
+  exit 1
+fi
+
+if [[ -z "$AI_FALLBACK_API_FORMAT" ]]; then
+  AI_FALLBACK_API_FORMAT="$AI_API_FORMAT"
+elif ! AI_FALLBACK_API_FORMAT="$(normalize_api_format "$AI_FALLBACK_API_FORMAT")"; then
+  error "Invalid AI_FALLBACK_API_FORMAT '$AI_FALLBACK_API_FORMAT'; expected openai or anthropic"
+  exit 1
+fi
+
+if [[ ! "$AI_MAX_TOKENS" =~ ^[0-9]+$ || "$AI_MAX_TOKENS" -lt 1 ]]; then
+  error "Invalid AI_MAX_TOKENS '$AI_MAX_TOKENS'; defaulting to 4096"
+  AI_MAX_TOKENS=4096
 fi
 
 if [[ -n "$AI_FALLBACK_BASE_URL" && -z "$AI_FALLBACK_MODEL" ]]; then
@@ -140,22 +170,62 @@ fi
 curl_model() {
   local base_url="$1"
   local api_key="$2"
-  local payload_file="$3"
-  local output_file="$4"
+  local api_format="$3"
+  local payload_file="$4"
+  local output_file="$5"
+
+  local endpoint
+  local auth_header=()
+  if [[ "$api_format" == "anthropic" ]]; then
+    endpoint="$base_url/messages"
+    auth_header=( -H "anthropic-version: $ANTHROPIC_VERSION" )
+    if [[ -n "$api_key" ]]; then
+      auth_header+=( -H "x-api-key: $api_key" )
+    fi
+  else
+    endpoint="$base_url/chat/completions"
+    if [[ -n "$api_key" ]]; then
+      auth_header=( -H "Authorization: Bearer $api_key" )
+    fi
+  fi
 
   local args=(
     -q
     -fsSL
-    "$base_url/chat/completions"
+    "$endpoint"
     -H "Content-Type: application/json"
     --data "@$payload_file"
   )
 
-  if [[ -n "$api_key" ]]; then
-    args+=( -H "Authorization: Bearer $api_key" )
-  fi
+  args+=( "${auth_header[@]}" )
 
   curl "${args[@]}" > "$output_file"
+}
+
+build_model_request() {
+  local api_format="$1"
+  local model="$2"
+  local system="$3"
+  local user="$4"
+  local corpus_file="$5"
+  local output_file="$6"
+
+  if [[ "$api_format" == "anthropic" ]]; then
+    jq -n \
+      --arg model "$model" \
+      --arg system "$system" \
+      --arg user "$user" \
+      --argjson max_tokens "$AI_MAX_TOKENS" \
+      --rawfile corpus "$corpus_file" \
+      '{model:$model,max_tokens:$max_tokens,system:$system,messages:[{role:"user",content:($user + "\n\n" + $corpus)}],temperature:0.1}' > "$output_file"
+  else
+    jq -n \
+      --arg model "$model" \
+      --arg system "$system" \
+      --arg user "$user" \
+      --rawfile corpus "$corpus_file" \
+      '{model:$model,messages:[{role:"system",content:$system},{role:"user",content:($user + "\n\n" + $corpus)}],temperature:0.1}' > "$output_file"
+  fi
 }
 
 parse_and_validate() {
@@ -166,7 +236,19 @@ import json
 from pathlib import Path
 
 response = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8", errors="replace"))
-content = ((response.get("choices") or [{}])[0].get("message") or {}).get("content")
+
+content = None
+if isinstance(response.get("choices"), list):
+    content = ((response.get("choices") or [{}])[0].get("message") or {}).get("content")
+elif isinstance(response.get("content"), list):
+    # Anthropic message responses may include thinking/tool blocks. Only text blocks are review content.
+    parts = []
+    for item in response.get("content") or []:
+        if isinstance(item, dict) and item.get("type") == "text" and isinstance(item.get("text"), str):
+            parts.append(item["text"])
+    content = "".join(parts)
+elif isinstance(response.get("content"), str):
+    content = response.get("content")
 
 if isinstance(content, str):
     text = content.strip()
@@ -765,20 +847,21 @@ EOF
   head -c "$MAX_CORPUS" review-corpus.md > review-corpus.truncated.md
 fi
 
-log "Analyzing with $AI_MODEL..."
+log "Analyzing with $AI_MODEL using $AI_API_FORMAT API format..."
 
-jq -n \
-  --arg model "$AI_MODEL" \
-  --arg system "$SYSTEM_PROMPT" \
-  --arg user "Analyze this pull request corpus and return STRICT JSON." \
-  --rawfile corpus review-corpus.truncated.md \
-  '{model:$model,messages:[{role:"system",content:$system},{role:"user",content:($user + "\n\n" + $corpus)}],temperature:0.1}' > ai-request.primary.json
+build_model_request \
+  "$AI_API_FORMAT" \
+  "$AI_MODEL" \
+  "$SYSTEM_PROMPT" \
+  "Analyze this pull request corpus and return STRICT JSON." \
+  review-corpus.truncated.md \
+  ai-request.primary.json
 
 PRIMARY_OK=0
 ATTEMPT=1
 while [ "$ATTEMPT" -le "$AI_PRIMARY_RETRIES" ]; do
-  echo "Primary model attempt ${ATTEMPT}/${AI_PRIMARY_RETRIES}: $AI_MODEL @ $AI_BASE_URL"
-  if curl_model "$AI_BASE_URL" "$AI_API_KEY" ai-request.primary.json ai-response.primary.json && \
+  echo "Primary model attempt ${ATTEMPT}/${AI_PRIMARY_RETRIES}: $AI_MODEL @ $AI_BASE_URL ($AI_API_FORMAT)"
+  if curl_model "$AI_BASE_URL" "$AI_API_KEY" "$AI_API_FORMAT" ai-request.primary.json ai-response.primary.json && \
     parse_and_validate ai-response.primary.json; then
     PRIMARY_OK=1
     break
@@ -790,7 +873,7 @@ while [ "$ATTEMPT" -le "$AI_PRIMARY_RETRIES" ]; do
 done
 
 if [ "$PRIMARY_OK" -eq 1 ]; then
-  ANALYSIS_ENGINE="$AI_MODEL@$AI_BASE_URL"
+  ANALYSIS_ENGINE="$AI_MODEL@$AI_BASE_URL ($AI_API_FORMAT)"
   echo "Primary model succeeded"
 else
   if [[ -z "$AI_FALLBACK_BASE_URL" || -z "$AI_FALLBACK_MODEL" ]]; then
@@ -798,18 +881,19 @@ else
     exit 1
   fi
 
-  echo "Primary model unavailable after retries; trying fallback: $AI_FALLBACK_MODEL @ $AI_FALLBACK_BASE_URL" >&2
+  echo "Primary model unavailable after retries; trying fallback: $AI_FALLBACK_MODEL @ $AI_FALLBACK_BASE_URL ($AI_FALLBACK_API_FORMAT)" >&2
   head -c 120000 review-corpus.md > review-corpus.fallback.truncated.md
-  jq -n \
-    --arg model "$AI_FALLBACK_MODEL" \
-    --arg system "$SYSTEM_PROMPT" \
-    --arg user "Analyze this pull request corpus and return STRICT JSON." \
-    --rawfile corpus review-corpus.fallback.truncated.md \
-    '{model:$model,messages:[{role:"system",content:$system},{role:"user",content:($user + "\n\n" + $corpus)}],temperature:0.1}' > ai-request.fallback.json
+  build_model_request \
+    "$AI_FALLBACK_API_FORMAT" \
+    "$AI_FALLBACK_MODEL" \
+    "$SYSTEM_PROMPT" \
+    "Analyze this pull request corpus and return STRICT JSON." \
+    review-corpus.fallback.truncated.md \
+    ai-request.fallback.json
 
-  if curl_model "$AI_FALLBACK_BASE_URL" "$AI_FALLBACK_API_KEY" ai-request.fallback.json ai-response.fallback.json && \
+  if curl_model "$AI_FALLBACK_BASE_URL" "$AI_FALLBACK_API_KEY" "$AI_FALLBACK_API_FORMAT" ai-request.fallback.json ai-response.fallback.json && \
     parse_and_validate ai-response.fallback.json; then
-    ANALYSIS_ENGINE="$AI_FALLBACK_MODEL@$AI_FALLBACK_BASE_URL"
+    ANALYSIS_ENGINE="$AI_FALLBACK_MODEL@$AI_FALLBACK_BASE_URL ($AI_FALLBACK_API_FORMAT)"
     echo "Fallback model succeeded" >&2
   else
     error "Fallback model failed"

--- a/scripts/run_tool_harness.py
+++ b/scripts/run_tool_harness.py
@@ -50,6 +50,13 @@ def env_int_bounded(name, default_value, min_value, max_value):
     return min(max_value, value)
 
 
+def normalize_api_format(value):
+    candidate = (value or "openai").strip().lower()
+    if candidate in {"openai", "anthropic"}:
+        return candidate
+    return "openai"
+
+
 def normalize_host(host):
     return (host or "").strip().lower()
 
@@ -128,6 +135,7 @@ def safe_run(args, timeout_sec):
 
 def run_chat_completion(
     base_url,
+    api_format,
     model,
     api_key,
     system_prompt,
@@ -135,16 +143,27 @@ def run_chat_completion(
     timeout_sec,
     max_tokens,
 ):
-    payload = {
-        "model": model,
-        "messages": [
-            {"role": "system", "content": system_prompt},
-            {"role": "user", "content": user_prompt},
-        ],
-        "temperature": 0.0,
-        "max_tokens": max_tokens,
-    }
-    endpoint = base_url.rstrip("/") + "/chat/completions"
+    if api_format == "anthropic":
+        payload = {
+            "model": model,
+            "system": system_prompt,
+            "messages": [{"role": "user", "content": user_prompt}],
+            "temperature": 0.0,
+            "max_tokens": max_tokens,
+        }
+        endpoint = base_url.rstrip("/") + "/messages"
+    else:
+        payload = {
+            "model": model,
+            "messages": [
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": user_prompt},
+            ],
+            "temperature": 0.0,
+            "max_tokens": max_tokens,
+        }
+        endpoint = base_url.rstrip("/") + "/chat/completions"
+
     args = [
         "curl",
         "-q",
@@ -155,7 +174,11 @@ def run_chat_completion(
         "-H",
         "Content-Type: application/json",
     ]
-    if api_key:
+    if api_format == "anthropic":
+        args.extend(["-H", f"anthropic-version: {os.getenv('ANTHROPIC_VERSION', '2023-06-01')}"])
+        if api_key:
+            args.extend(["-H", f"x-api-key: {api_key}"])
+    elif api_key:
         args.extend(["-H", f"Authorization: Bearer {api_key}"])
 
     with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as payload_file:
@@ -183,6 +206,14 @@ def run_chat_completion(
 
     response_body = completed.stdout
     parsed = json.loads(response_body)
+    if api_format == "anthropic" and isinstance(parsed.get("content"), list):
+        parts = []
+        for item in parsed.get("content", []):
+            if isinstance(item, dict) and item.get("type") == "text":
+                text = item.get("text")
+                if isinstance(text, str):
+                    parts.append(text)
+        return "".join(parts)
     return parsed.get("choices", [{}])[0].get("message", {}).get("content", "")
 
 
@@ -419,6 +450,7 @@ def main():
 
     repo = os.getenv("REPO", "").strip()
     base_url = os.getenv("AI_BASE_URL", "").strip()
+    api_format = normalize_api_format(os.getenv("AI_API_FORMAT", "openai"))
     model = os.getenv("AI_MODEL", "").strip()
     api_key = os.getenv("AI_API_KEY", "").strip()
     max_requests = env_int("TOOL_MAX_REQUESTS", 4, 1)
@@ -493,6 +525,7 @@ def main():
     try:
         planning_response = run_chat_completion(
             base_url,
+            api_format,
             model,
             api_key,
             planning_system,

--- a/tests/mock_openai_server.py
+++ b/tests/mock_openai_server.py
@@ -4,7 +4,7 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 
 class Handler(BaseHTTPRequestHandler):
     def do_POST(self):
-        if self.path != "/v1/chat/completions":
+        if self.path not in {"/v1/chat/completions", "/v1/messages"}:
             self.send_response(404)
             self.end_headers()
             return
@@ -12,29 +12,42 @@ class Handler(BaseHTTPRequestHandler):
         content_length = int(self.headers.get("Content-Length", "0"))
         request_body = self.rfile.read(content_length).decode("utf-8", errors="replace")
 
-        response = {
-            "id": "chatcmpl-mock",
-            "object": "chat.completion",
-            "created": 0,
-            "model": "mock-model",
-            "choices": [
-                {
-                    "index": 0,
-                    "message": {
-                        "role": "assistant",
-                        "content": json.dumps(
-                            {
-                                "verdict": "approve",
-                                "review_markdown": "## Summary\nMock reviewer completed successfully.\n\n## Validation\n- OpenAI-compatible endpoint contract worked\n- PR corpus was assembled and analyzed\n\n## Request Snapshot\n- Request bytes: %s"
-                                % len(request_body),
-                                "packages": [],
-                            }
-                        ),
-                    },
-                    "finish_reason": "stop",
-                }
-            ],
-        }
+        review = json.dumps(
+            {
+                "verdict": "approve",
+                "review_markdown": "## Summary\nMock reviewer completed successfully.\n\n## Validation\n- AI endpoint contract worked\n- PR corpus was assembled and analyzed\n\n## Request Snapshot\n- Request bytes: %s"
+                % len(request_body),
+                "packages": [],
+            }
+        )
+
+        if self.path == "/v1/messages":
+            response = {
+                "id": "msg-mock",
+                "type": "message",
+                "role": "assistant",
+                "content": [
+                    {"type": "thinking", "thinking": "private reasoning"},
+                    {"type": "text", "text": review},
+                ],
+            }
+        else:
+            response = {
+                "id": "chatcmpl-mock",
+                "object": "chat.completion",
+                "created": 0,
+                "model": "mock-model",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": review,
+                        },
+                        "finish_reason": "stop",
+                    }
+                ],
+            }
 
         body = json.dumps(response).encode("utf-8")
         self.send_response(200)

--- a/tests/smoke_test.sh
+++ b/tests/smoke_test.sh
@@ -49,7 +49,18 @@ import sys, json
 from pathlib import Path
 
 response = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8", errors="replace"))
-content = ((response.get("choices") or [{}])[0].get("message") or {}).get("content")
+
+content = None
+if isinstance(response.get("choices"), list):
+    content = ((response.get("choices") or [{}])[0].get("message") or {}).get("content")
+elif isinstance(response.get("content"), list):
+    parts = []
+    for item in response.get("content") or []:
+        if isinstance(item, dict) and item.get("type") == "text" and isinstance(item.get("text"), str):
+            parts.append(item["text"])
+    content = "".join(parts)
+elif isinstance(response.get("content"), str):
+    content = response.get("content")
 
 if isinstance(content, str):
     text = content.strip()
@@ -155,6 +166,33 @@ if run_parse "$TMPDIR/resp-empty-array.json"; then
 else
   check "rejects empty array" "yes" "yes"
 fi
+
+echo ""
+echo "=== parse_and_validate: Anthropic text blocks ignore thinking ==="
+cat > "$TMPDIR/resp-anthropic.json" <<'EOF'
+{"id":"msg-test","type":"message","role":"assistant","content":[{"type":"thinking","thinking":"private reasoning"},{"type":"text","text":"{\"verdict\":\"approve\",\"review_markdown\":\"Anthropic clean.\"}"}]}
+EOF
+run_parse "$TMPDIR/resp-anthropic.json"
+check "anthropic verdict=approve" "$(jq -r '.verdict' "$TMPDIR/out.json")" "approve"
+check "anthropic ignores thinking" "$(jq -r '.review_markdown' "$TMPDIR/out.json")" "Anthropic clean."
+
+echo ""
+echo "=== Tool harness: Anthropic planner request ==="
+mkdir -p "$TMPDIR/harness-anthropic"
+printf '# Review corpus\n' > "$TMPDIR/harness-anthropic/review-corpus.truncated.md"
+(
+  cd "$TMPDIR/harness-anthropic"
+  REPO=joryirving/home-ops \
+    AI_BASE_URL=http://127.0.0.1:18080/v1 \
+    AI_API_FORMAT=anthropic \
+    AI_MODEL=mock-anthropic \
+    TOOL_MODE=plan_execute_once \
+    TOOL_ALLOWED_GH_API_REPOS='*' \
+    ALLOWED_SOURCE_HOSTS=github.com \
+    python3 "$ROOT_DIR/scripts/run_tool_harness.py"
+)
+check "anthropic planner completed" "$(jq -r '.mode' "$TMPDIR/harness-anthropic/tool-harness.json")" "plan_execute_once"
+check "anthropic planner ignored non-requests response" "$(jq -r '.planning_warning' "$TMPDIR/harness-anthropic/tool-harness.json")" "Planner response did not contain requests[]"
 
 echo ""
 echo "=== Evidence provider execution ==="


### PR DESCRIPTION
## Summary
- Add native `ai_api_format: anthropic` support for `/messages` endpoints.
- Parse only Anthropic text blocks so thinking/non-text blocks are not posted in PR comments.
- Add fallback API format inputs and document OpenAI/Anthropic behavior.
- Run the smoke test in CI and extend smoke coverage for Anthropic parsing/tool planner requests.

## Validation
- tests/smoke_test.sh
- bash -n scripts/check_review_needed.sh scripts/run_review.sh tests/smoke_test.sh
- python3 -m py_compile scripts/image_digest_analysis.py scripts/run_evidence_providers.py scripts/run_tool_harness.py tests/mock_openai_server.py
- ruby YAML load for action.yml, CI, and examples