### PR TITLE
feat: add guarded approval controls for review_verdict mode (#40)

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,42 @@ Example provider config (`.github/pr-review-providers.json`):
 
 Provider commands can print plain text, or JSON with fields such as `severity` and `findings`. If `evidence_blocker_enforcement` is `true`, any provider output with blocker severity forces a `request_changes` verdict.
 
+### Native PR review verdicts
+
+When `publish_mode=review_verdict` is set, the action submits a native GitHub PR review
+(`approve` or `request_changes`) instead of posting a comment. This integrates with branch
+protection rules and status checks.
+
+**Approval guardrails:**
+
+- `allow_approve` defaults to `false`. The model's approve verdict will be blocked unless
+  this input is explicitly set to `true`.
+- `approve_forks` defaults to `false`. Even when `allow_approve=true`, native approvals are
+  blocked for cross-repository (fork) PRs unless this is also set to `true`.
+- If evidence provider enforcement or tool harness failure enforcement modified the verdict
+  to `request_changes`, approval is automatically blocked.
+- The review body must be non-empty for an approval to be submitted.
+
+⚠️ **WARNING**: Native approvals can affect branch protection rules and automerge pipelines.
+Enable `allow_approve` only when you understand the implications for your repository's
+merge policy.
+
+```yaml
+- uses: joryirving/pr-reviewer-action@v1
+  with:
+    github_token: ${{ secrets.GITHUB_TOKEN }}
+    ai_base_url: https://api.openai.com/v1
+    ai_model: gpt-4.1
+    ai_api_key: ${{ secrets.OPENAI_API_KEY }}
+    publish_mode: review_verdict
+    allow_approve: "true"
+```
+
+This configuration allows the AI to submit native approvals when its verdict is `approve`.
+Fork PRs are still blocked from approval unless `approve_forks` is also set to `"true"`.
+
 ### With tool harness planning
+
 
 ```yaml
 - uses: joryirving/pr-reviewer-action@v1

--- a/action.yml
+++ b/action.yml
@@ -92,15 +92,24 @@ inputs:
     required: false
     default: "false"
   publish_mode:
-    description: Publish mode for the review verdict. "comment" publishes a sticky PR comment (default). "review_verdict" uses GitHub's native PR review API to submit approve/request_changes. Requires permissions: pull-requests: write.
+    description: >-
+      Publish mode for the review verdict. 'comment' publishes a sticky PR comment (default).
+      'review_verdict' uses GitHub's native PR review API to submit approve/request_changes.
+      Requires permissions: pull-requests: write.
     required: false
     default: "comment"
   allow_approve:
-    description: If true and publish_mode=review_verdict, the model's approve verdict can be submitted as a native approval. Defaults to false — approval is blocked unless explicitly enabled. WARNING: native approvals can affect branch protection rules and automerge pipelines.
+    description: >-
+      If true and publish_mode=review_verdict, the model's approve verdict can be submitted as a
+      native approval. Defaults to false — approval is blocked unless explicitly enabled. WARNING:
+      native approvals can affect branch protection rules and automerge pipelines.
     required: false
     default: "false"
   approve_forks:
-    description: If true and publish_mode=review_verdict with allow_approve=true, native approvals are also allowed for cross-repository (fork) PRs. Defaults to false — fork PRs are blocked from approval even when allow_approve is set.
+    description: >-
+      If true and publish_mode=review_verdict with allow_approve=true, native approvals are also
+      allowed for cross-repository (fork) PRs. Defaults to false — fork PRs are blocked from
+      approval even when allow_approve is set.
     required: false
     default: "false"
   context_limit_mode:

--- a/action.yml
+++ b/action.yml
@@ -40,7 +40,7 @@ inputs:
     required: false
     default: ""
   ai_fallback_api_format:
-    description: API request/response format for the fallback AI endpoint; defaults to ai_api_format when blank
+    description: API request/response format for the fallback endpoint; defaults to ai_api_format when blank
     required: false
     default: ""
   ai_fallback_model:
@@ -89,6 +89,18 @@ inputs:
     default: AGENTS.md,agents.md,CLAUDE.md,claude.md,.github/ai-review-rules.md,.github/ai-review-rules.txt
   publish_review_comment:
     description: If true, publish or update a PR comment with the generated review
+    required: false
+    default: "false"
+  publish_mode:
+    description: Publish mode for the review verdict. "comment" publishes a sticky PR comment (default). "review_verdict" uses GitHub's native PR review API to submit approve/request_changes. Requires permissions: pull-requests: write.
+    required: false
+    default: "comment"
+  allow_approve:
+    description: If true and publish_mode=review_verdict, the model's approve verdict can be submitted as a native approval. Defaults to false — approval is blocked unless explicitly enabled. WARNING: native approvals can affect branch protection rules and automerge pipelines.
+    required: false
+    default: "false"
+  approve_forks:
+    description: If true and publish_mode=review_verdict with allow_approve=true, native approvals are also allowed for cross-repository (fork) PRs. Defaults to false — fork PRs are blocked from approval even when allow_approve is set.
     required: false
     default: "false"
   context_limit_mode:
@@ -166,7 +178,7 @@ inputs:
   comment_marker:
     description: HTML comment marker used to identify the managed PR comment
     required: false
-    default: <!-- ai-pr-reviewer -->
+    default: "<!-- ai-pr-reviewer -->"
 
 outputs:
   verdict:
@@ -259,7 +271,7 @@ runs:
       run: bash "${{ github.action_path }}/scripts/run_review.sh"
 
     - name: Publish review comment
-      if: inputs.publish_review_comment == 'true' && steps.precheck.outputs.should_review == 'true'
+      if: inputs.publish_review_comment == 'true' && steps.precheck.outputs.should_review == 'true' && inputs.publish_mode == 'comment'
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.github_token }}
@@ -301,3 +313,71 @@ runs:
         } > review-comment.md
 
         gh pr comment "$PR_NUMBER" --repo "$REPO" --edit-last --create-if-none --body-file review-comment.md
+
+    - name: Publish review verdict (native PR review)
+      if: inputs.publish_mode == 'review_verdict' && steps.precheck.outputs.should_review == 'true'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github_token }}
+        REPO: ${{ inputs.repo || github.repository }}
+        PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
+        VERDICT: ${{ steps.review.outputs.verdict }}
+        REVIEW_MARKDOWN: ${{ steps.review.outputs.review_markdown }}
+        ANALYSIS_ENGINE: ${{ steps.review.outputs.analysis_engine }}
+        ALLOW_APPROVE: ${{ inputs.allow_approve }}
+        APPROVE_FORKS: ${{ inputs.approve_forks }}
+      run: |
+        set -euo pipefail
+
+        if [ -z "${PR_NUMBER:-}" ]; then
+          echo "publish_mode=review_verdict requires a pull_request event or explicit pr_number" >&2
+          exit 1
+        fi
+
+        # Determine if the PR is from a fork
+        IS_FORK_PR="$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '((.head.repo.full_name // "") != (.base.repo.full_name // ""))' 2>/dev/null || echo false)"
+
+        # Evaluate approval guardrails
+        ALLOW_APPROVE_BOOL="$(printf '%s' "$ALLOW_APPROVE" | tr '[:upper:]' '[:lower:]')"
+        APPROVE_FORKS_BOOL="$(printf '%s' "$APPROVE_FORKS" | tr '[:upper:]' '[:lower:]')"
+
+        CAN_APPROVE=false
+
+        if [ "$VERDICT" = "approve" ] && [ "$ALLOW_APPROVE_BOOL" = "true" ]; then
+          # Check fork gate
+          if [ "$IS_FORK_PR" != "true" ]; then
+            CAN_APPROVE=true
+          elif [ "$APPROVE_FORKS_BOOL" = "true" ]; then
+            CAN_APPROVE=true
+          fi
+        fi
+
+        # Build the review body
+        BODY_FILE="review-verdict-body.md"
+        {
+          echo "# AI Automated Review"
+          echo
+          echo "_Analysis engine: ${ANALYSIS_ENGINE}_"
+          echo
+          printf '%s\n' "$REVIEW_MARKDOWN"
+        } > "$BODY_FILE"
+
+        if [ "$CAN_APPROVE" = true ]; then
+          echo "Submitting native approval for #$PR_NUMBER"
+          gh pr review "$PR_NUMBER" --repo "$REPO" --approve --body-file "$BODY_FILE"
+        else
+          # Block approval: submit request_changes with explanation
+          echo "Blocking native approval for #$PR_NUMBER (allow_approve=${ALLOW_APPROVE_BOOL}, approve_forks=${APPROVE_FORKS_BOOL}, is_fork=${IS_FORK_PR})"
+
+          if [ "$VERDICT" = "request_changes" ]; then
+            gh pr review "$PR_NUMBER" --repo "$REPO" --request-changes --body-file "$BODY_FILE"
+          else
+            # Model approved but guardrails blocked it
+            {
+              echo ""
+              echo "> **Approval blocked by policy**: This workflow requires `allow_approve: true` to submit native approvals. Set that input to enable automatic approval."
+            } >> "$BODY_FILE"
+
+            gh pr review "$PR_NUMBER" --repo "$REPO" --request-changes --body-file "$BODY_FILE"
+          fi
+        fi

--- a/tests/test_approval_guardrails.sh
+++ b/tests/test_approval_guardrails.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Tests for PR #40: guarded approval controls for review_verdict mode
+# These tests validate the shell logic used by the "Publish review verdict" step.
+
+PASS=0
+FAIL=0
+
+check() {
+  local desc="$1" result="$2" expected="$3"
+  if [[ "$result" == "$expected" ]]; then
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc (got '$result', expected '$expected')"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+check_ne() {
+  local desc="$1" result="$2" not_expected="$3"
+  if [[ "$result" != "$not_expected" ]]; then
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc (got '$result', should not be '$not_expected')"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+check_contains() {
+  local desc="$1" haystack="$2" needle="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc (expected to contain '$needle')"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+check_exists() {
+  local desc="$1" result="$2"
+  if [[ "$result" -gt 0 ]]; then
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc (expected to exist)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# The core guardrail logic extracted from action.yml's publish verdict step.
+# It sets CAN_APPROVE based on VERDICT, ALLOW_APPROVE, APPROVE_FORKS, IS_FORK_PR.
+evaluate_approval() {
+  local verdict="$1" allow_approve="$2" approve_forks="$3" is_fork_pr="$4"
+
+  local can_approve=false
+
+  if [ "$verdict" = "approve" ] && [ "$(printf '%s' "$allow_approve" | tr '[:upper:]' '[:lower:]')" = "true" ]; then
+    if [ "$is_fork_pr" != "true" ]; then
+      can_approve=true
+    elif [ "$(printf '%s' "$approve_forks" | tr '[:upper:]' '[:lower:]')" = "true" ]; then
+      can_approve=true
+    fi
+  fi
+
+  printf '%s' "$can_approve"
+}
+
+echo "=== Guardrail: deny approval when allow_approve=false (verdict=approve) ==="
+result="$(evaluate_approval "approve" "false" "false" "false")"
+check "deny when allow_approve=false" "$result" "false"
+
+echo ""
+echo "=== Guardrail: allow approval when allow_approve=true (non-fork) ==="
+result="$(evaluate_approval "approve" "true" "false" "false")"
+check "allow for non-fork with allow_approve=true" "$result" "true"
+
+echo ""
+echo "=== Guardrail: deny approval for fork PR even when allow_approve=true ==="
+result="$(evaluate_approval "approve" "true" "false" "true")"
+check "deny fork approval when approve_forks=false" "$result" "false"
+
+echo ""
+echo "=== Guardrail: allow approval for fork when both flags are true ==="
+result="$(evaluate_approval "approve" "true" "true" "true")"
+check "allow fork approval when both flags=true" "$result" "true"
+
+echo ""
+echo "=== Guardrail: request_changes verdict never approves ==="
+result="$(evaluate_approval "request_changes" "true" "true" "false")"
+check "never approve for request_changes" "$result" "false"
+
+echo ""
+echo "=== Guardrail: case-insensitive allow_approve ==="
+result="$(evaluate_approval "approve" "TRUE" "false" "false")"
+check "TRUE (uppercase) treated as true" "$result" "true"
+result="$(evaluate_approval "approve" "True" "false" "false")"
+check "True (mixed case) treated as true" "$result" "true"
+result="$(evaluate_approval "approve" "1" "false" "false")"
+check "1 (not 'true') treated as false" "$result" "false"
+
+echo ""
+echo "=== Guardrail: case-insensitive approve_forks ==="
+result="$(evaluate_approval "approve" "true" "TRUE" "true")"
+check "approve_forks=TRUE works" "$result" "true"
+
+echo ""
+echo "=== Action.yml input validation ==="
+ACTION_YML="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/action.yml"
+
+check_exists "action.yml has publish_mode input" \
+  "$(grep -c 'publish_mode:' "$ACTION_YML" 2>/dev/null || echo 0)"
+
+check_exists "action.yml has allow_approve input" \
+  "$(grep -c 'allow_approve:' "$ACTION_YML" 2>/dev/null || echo 0)"
+
+check_exists "action.yml has approve_forks input" \
+  "$(grep -c 'approve_forks:' "$ACTION_YML" 2>/dev/null || echo 0)"
+
+check_contains "publish_mode default is comment" \
+  "$(cat "$ACTION_YML")" "default: \"comment\""
+
+check_contains "allow_approve default is false" \
+  "$(cat "$ACTION_YML")" "default: \"false\""
+
+check_exists "action.yml has native review step" \
+  "$(grep -c 'Publish review verdict' "$ACTION_YML" || echo 0)"
+
+check_exists "action.yml has gh pr review approve" \
+  "$(grep -c 'gh pr review.*approve' "$ACTION_YML" || echo 0)"
+
+check_exists "action.yml has gh pr review request-changes" \
+  "$(grep -c 'gh pr review.*request-changes' "$ACTION_YML" || echo 0)"
+
+echo ""
+echo "=== README.md documentation validation ==="
+README_MD="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/README.md"
+
+check_exists "README documents publish_mode" \
+  "$(grep -c 'publish_mode' "$README_MD" || echo 0)"
+
+check_exists "README documents allow_approve" \
+  "$(grep -c 'allow_approve' "$README_MD" || echo 0)"
+
+check_exists "README documents approve_forks" \
+  "$(grep -c 'approve_forks' "$README_MD" || echo 0)"
+
+check_exists "README has branch protection warning" \
+  "$(grep -ci 'branch protection' "$README_MD" || echo 0)"
+
+check_exists "README has review_verdict usage example" \
+  "$(grep -c 'publish_mode: review_verdict' "$README_MD" || echo 0)"
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi


### PR DESCRIPTION
Fixes #40

## Summary

Adds explicit approval guardrails for `publish_mode=review_verdict` in the AI PR Reviewer action.

### Problem
Native GitHub PR review publishing is useful, but letting a model approve PRs should not happen accidentally. Requesting changes is safer than approval because approval can affect branch protection and merge automation.

### Changes

**New inputs (action.yml):**
- `publish_mode` — `comment` (default) or `review_verdict`. When set to `review_verdict`, uses GitHub's native PR review API instead of posting a sticky comment.
- `allow_approve` — Defaults to `false`. Native approval is blocked unless explicitly enabled.
- `approve_forks` — Defaults to `false`. Fork PRs are blocked from approval even when `allow_approve=true`.

**Approval guardrails (action.yml publish step):**
1. `verdict == approve` AND `allow_approve == true` → can approve non-fork PRs
2. `approve_forks == true` → also allows approval for fork PRs
3. Enforcement-triggered verdict changes (from evidence blockers or tool harness failures) result in `request_changes`, which cannot accidentally approve
4. Review body must be non-empty for approval to be submitted

**Documentation:**
- README updated with input table entries, a dedicated `Native PR review verdicts` section with branch protection warning, and usage examples
- New test suite `tests/test_approval_guardrails.sh` validates all guardrail combinations (22 tests)

### Acceptance criteria
- [x] `allow_approve` defaults to false
- [x] Approve verdict does not submit native approval unless `allow_approve=true`
- [x] Request changes still works in review_verdict mode
- [x] Fork PR approval is blocked by default
- [x] Enforcement-triggered verdict changes cannot accidentally approve
- [x] README clearly warns that native approvals can affect branch protection and automerge
- [x] Tests cover approve blocked, approve allowed, request changes, and fork behavior