### PR TITLE
fix: address post-review non-blocking observations for #33

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@ The action collects rich PR context (diff, files, linked issues, version hints, 
 - **`scripts/default_system_prompt.txt`** - Bundled system prompt used when no override is provided
 - **`scripts/run_evidence_providers.py`** - Runs user-defined evidence provider commands from a JSON config, parses severity/findings output
 - **`scripts/run_tool_harness.py`** - Tool harness in `plan_execute_once` mode: model plans read-only tool requests (gh_api, read_file, web_fetch, git_grep), action executes them, appends results to corpus
+- **`scripts/strip_metadata_markers.py`** - Strips internal metadata markers from model output before publishing (issue #33)
 - **`scripts/image_digest_analysis.py`** - Analyzes image digests from the diff for provenance context
 - **`tests/smoke_test.sh`** - Local smoke test against a real PR with mock OpenAI server
 - **`tests/mock_openai_server.py`** - Mock API server used by the smoke test
@@ -29,6 +30,9 @@ run_review.sh                   → collects context → builds corpus → calls
   ├─ run_evidence_providers.py  → User-defined provider commands
   ├─ run_tool_harness.py        → Tool harness planning + execution
   └─ Model call with retries    → Primary model, fallback if needed
+publish_review_comment         → sanitizes markdown → builds managed comment → publishes
+  ├─ strip_metadata_markers.py  → Strips <!-- ai-pr-review-*:... --> from model output
+  └─ gh pr comment              → Edit-last or create-if-none with metadata + review body
 ```
 
 ## Review corpus sections (in order)

--- a/README.md
+++ b/README.md
@@ -319,6 +319,11 @@ If a repo wants more than policy context and needs to fully control the reviewer
 ```
 
 ## Notes
+- **Reserved comment markers**: The managed PR comment uses HTML comment markers for internal metadata. These are reserved and must not appear in model-generated review markdown:
+  - `<!-- ai-pr-review-fingerprint:<value> -->` — stable patch + config fingerprint used by the precheck to skip unchanged diffs.
+  - `<!-- ai-pr-review-sha:<sha> -->` — PR head SHA used to detect out-of-date reviews.
+  The action strips any matching markers from model output before publishing (see `scripts/strip_metadata_markers.py`). The precheck parser reads only the **first** occurrence of each marker for defense in depth.
+
 
 - `ai_api_format=openai` posts to `/chat/completions` and parses `choices[0].message.content`.
 - `ai_api_format=anthropic` posts to `/messages` and parses only `content[]` blocks where `type == "text"`.

--- a/action.yml
+++ b/action.yml
@@ -324,7 +324,7 @@ runs:
         # might have generated, preventing fake markers from interfering with precheck.
         printf '%s\n' "$REVIEW_MARKDOWN" > review-markdown.raw.md
         python3 "${{ github.action_path }}/scripts/strip_metadata_markers.py" review-markdown.raw.md
-        
+
 
         if [ -z "${PR_NUMBER:-}" ]; then
           echo "publish_review_comment=true requires a pull_request event or explicit pr_number" >&2
@@ -372,7 +372,7 @@ runs:
         # might have generated, preventing fake markers from interfering with precheck.
         printf '%s\n' "$REVIEW_MARKDOWN" > review-verdict-markdown.raw.md
         python3 "${{ github.action_path }}/scripts/strip_metadata_markers.py" review-verdict-markdown.raw.md
-        
+
 
         if [ -z "${PR_NUMBER:-}" ]; then
           echo "publish_mode=review_verdict requires a pull_request event or explicit pr_number" >&2

--- a/action.yml
+++ b/action.yml
@@ -320,6 +320,11 @@ runs:
         COMMENT_MARKER: ${{ inputs.comment_marker }}
       run: |
         set -euo pipefail
+        # Sanitize model output: strip internal metadata markers that the model
+        # might have generated, preventing fake markers from interfering with precheck.
+        printf '%s\n' "$REVIEW_MARKDOWN" > review-markdown.raw.md
+        python3 "${{ github.action_path }}/scripts/strip_metadata_markers.py" review-markdown.raw.md
+        
 
         if [ -z "${PR_NUMBER:-}" ]; then
           echo "publish_review_comment=true requires a pull_request event or explicit pr_number" >&2
@@ -344,7 +349,7 @@ runs:
           echo
           echo "_Analysis engine: ${ANALYSIS_ENGINE}_"
           echo
-          printf '%s\n' "$REVIEW_MARKDOWN"
+          cat review-markdown.raw.md
         } > review-comment.md
 
         gh pr comment "$PR_NUMBER" --repo "$REPO" --edit-last --create-if-none --body-file review-comment.md
@@ -363,6 +368,11 @@ runs:
         APPROVE_FORKS: ${{ inputs.approve_forks }}
       run: |
         set -euo pipefail
+        # Sanitize model output: strip internal metadata markers that the model
+        # might have generated, preventing fake markers from interfering with precheck.
+        printf '%s\n' "$REVIEW_MARKDOWN" > review-verdict-markdown.raw.md
+        python3 "${{ github.action_path }}/scripts/strip_metadata_markers.py" review-verdict-markdown.raw.md
+        
 
         if [ -z "${PR_NUMBER:-}" ]; then
           echo "publish_mode=review_verdict requires a pull_request event or explicit pr_number" >&2
@@ -394,7 +404,7 @@ runs:
           echo
           echo "_Analysis engine: ${ANALYSIS_ENGINE}_"
           echo
-          printf '%s\n' "$REVIEW_MARKDOWN"
+          cat review-verdict-markdown.raw.md
         } > "$BODY_FILE"
 
         if [ "$CAN_APPROVE" = true ]; then

--- a/scripts/check_review_needed.sh
+++ b/scripts/check_review_needed.sh
@@ -160,9 +160,11 @@ last_comment_body="$({
     '
 } || true)"
 
-# Extract the broad fingerprint (the full pipe-delimited value)
+# Extract the PR head SHA and broad fingerprint from the last published comment.
+# ai-pr-review-sha: stored for future out-of-date detection (not yet used in skip logic).
+# ai-pr-review-fingerprint: stable patch+config fingerprint used for skip-on-unchanged-diff.
+last_pr_sha="$(printf '%s\n' "$last_comment_body" | sed -n 's/^<!-- ai-pr-review-sha:\([^>]*\) -->$/\1/p' | head -n 1)"
 last_broad_fingerprint="$(printf '%s\n' "$last_comment_body" | sed -n 's/^<!-- ai-pr-review-fingerprint:\([^>]*\) -->$/\1/p' | head -n 1)"
-
 should_review=true
 skip_reason=""
 
@@ -174,3 +176,4 @@ fi
 echo "diff_fingerprint=$broad_fingerprint" >> "$OUTPUT_FILE"
 echo "should_review=$should_review" >> "$OUTPUT_FILE"
 echo "skip_reason=$skip_reason" >> "$OUTPUT_FILE"
+

--- a/scripts/check_review_needed.sh
+++ b/scripts/check_review_needed.sh
@@ -161,7 +161,7 @@ last_comment_body="$({
 } || true)"
 
 # Extract the broad fingerprint (the full pipe-delimited value)
-last_broad_fingerprint="$(printf '%s\n' "$last_comment_body" | sed -n 's/^<!-- ai-pr-review-fingerprint:\([^>]*\) -->$/\1/p' | tail -n 1)"
+last_broad_fingerprint="$(printf '%s\n' "$last_comment_body" | sed -n 's/^<!-- ai-pr-review-fingerprint:\([^>]*\) -->$/\1/p' | head -n 1)"
 
 should_review=true
 skip_reason=""

--- a/scripts/strip_metadata_markers.py
+++ b/scripts/strip_metadata_markers.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Strip internal AI PR reviewer metadata markers from review markdown.
+
+This prevents model-generated content from containing fake metadata markers
+(<!-- ai-pr-review-fingerprint:... -->, <!-- ai-pr-review-sha:... -->) that
+could interfere with the precheck parser when scanning comment bodies.
+
+Reserved marker patterns:
+  <!-- ai-pr-review-fingerprint:<value> -->
+  <!-- ai-pr-review-sha:<sha> -->
+
+Usage:
+  cat review-body.md | python3 strip_metadata_markers.py          # stdin → stdout
+  python3 strip_metadata_markers.py review-body.md                 # file in-place
+  python3 strip_metadata_markers.py --dry-run review-body.md      # preview only
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# Reserved internal metadata patterns — must stay in sync with action.yml.
+RESERVED_PATTERNS = [
+    re.compile(r'<!--\s*ai-pr-review-fingerprint\s*:\s*[^>]*-->', re.IGNORECASE),
+    re.compile(r'<!--\s*ai-pr-review-sha\s*:\s*[^>]*-->', re.IGNORECASE),
+]
+
+
+def strip_reserved_markers(text: str) -> str:
+    """Remove all reserved metadata marker comments from *text*.
+
+    Returns a new string with matching markers replaced by an empty string.
+    """
+    for pattern in RESERVED_PATTERNS:
+        text = pattern.sub("", text)
+    return text
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Strip internal AI PR reviewer metadata markers from review markdown."
+    )
+    parser.add_argument("file", nargs="?", help="File to process (default: stdin)")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the number of replacements without modifying the file.",
+    )
+    args = parser.parse_args()
+
+    if args.file:
+        content = Path(args.file).read_text(encoding="utf-8")
+    else:
+        content = sys.stdin.read()
+
+    stripped = strip_reserved_markers(content)
+
+    # Count replacements for reporting
+    total = sum(
+        len(p.findall(content))
+        for p in RESERVED_PATTERNS
+    )
+
+    if args.dry_run:
+        print(f"{total} marker(s) stripped (dry run).")
+        print(stripped)
+        return
+
+    if args.file:
+        Path(args.file).write_text(stripped, encoding="utf-8")
+        print(f"Stripped {total} marker(s) from {args.file}.")
+    else:
+        sys.stdout.write(stripped)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_strip_metadata_markers.py
+++ b/tests/test_strip_metadata_markers.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Tests for scripts/strip_metadata_markers.py.
+
+Regression tests for issue #33: model-generated review markdown must not
+contain internal metadata markers that could interfere with the precheck parser.
+"""
+
+import sys
+from pathlib import Path
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+from strip_metadata_markers import strip_reserved_markers  # noqa: E402
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# strip_reserved_markers
+# ---------------------------------------------------------------------------
+
+
+class TestStripReservedMarkers:
+    """Verify that internal metadata markers are stripped from review markdown."""
+
+    def test_no_markers_unchanged(self):
+        """Markdown without markers passes through unchanged."""
+        text = "## Review\n\nLooks good, LGTM!"
+        assert strip_reserved_markers(text) == text
+
+    def test_strips_fingerprint_marker(self):
+        """A fake fingerprint marker in model output is removed."""
+        text = "## Review\n<!-- ai-pr-review-fingerprint:fake|cfg:abc123 -->\nLooks good."
+        result = strip_reserved_markers(text)
+        assert "ai-pr-review-fingerprint" not in result
+        assert "Looks good." in result
+
+    def test_strips_sha_marker(self):
+        """A fake sha marker in model output is removed."""
+        text = "## Review\n<!-- ai-pr-review-sha:deadbeef12345678 -->\nLooks good."
+        result = strip_reserved_markers(text)
+        assert "ai-pr-review-sha" not in result
+        assert "Looks good." in result
+
+    def test_strips_multiple_markers(self):
+        """Multiple fake markers are all removed."""
+        text = (
+            "## Review\n"
+            "<!-- ai-pr-review-fingerprint:fake|cfg:abc -->\n"
+            "Some review text.\n"
+            "<!-- ai-pr-review-sha:deadbeef12345678 -->\n"
+            "More text."
+        )
+        result = strip_reserved_markers(text)
+        assert "ai-pr-review-fingerprint" not in result
+        assert "ai-pr-review-sha" not in result
+        assert "Some review text." in result
+        assert "More text." in result
+
+    def test_preserves_normal_html_comments(self):
+        """Non-reserved HTML comments are preserved."""
+        text = "## Review\n<!-- TODO: fix this later -->\nLooks good."
+        result = strip_reserved_markers(text)
+        assert "<!-- TODO: fix this later -->" in result
+
+    def test_preserves_normal_code_fences(self):
+        """Code fences and normal markdown are preserved."""
+        text = "```python\nprint('hello')\n```\n<!-- not a reserved marker -->"
+        result = strip_reserved_markers(text)
+        assert "```python" in result
+        # The non-reserved HTML comment should stay
+        assert "<!-- not a reserved marker -->" in result
+
+    def test_case_insensitive(self):
+        """Marker matching is case-insensitive."""
+        text = "<!-- AI-PR-REVIEW-FINGERPRINT:FAKE -->\ntext"
+        result = strip_reserved_markers(text)
+        assert "AI-PR-REVIEW-FINGERPRINT" not in result
+
+    def test_with_whitespace_in_marker(self):
+        """Markers with extra whitespace inside are still stripped."""
+        text = "<!--  ai-pr-review-fingerprint : fake -->\ntext"
+        result = strip_reserved_markers(text)
+        assert "ai-pr-review-fingerprint" not in result
+
+    def test_empty_input(self):
+        assert strip_reserved_markers("") == ""
+
+    def test_none_like_input(self):
+        # The function expects str; None would raise, which is fine.
+        with pytest.raises(TypeError):
+            strip_reserved_markers(None)  # type: ignore
+
+
+class TestFakeMarkerInjection:
+    """Direct regression tests for the attack scenario described in issue #33."""
+
+    def test_model_cannot_override_fingerprint(self):
+        """Model output cannot create a fingerprint that overrides the trusted one."""
+        # Simulate what would happen if the model generated a fake marker
+        fake_marker = "<!-- ai-pr-review-fingerprint:malicious|cfg:badhash -->"
+        markdown_with_fake = f"## Review\n{fake_marker}\nApproved."
+
+        result = strip_reserved_markers(markdown_with_fake)
+        assert "ai-pr-review-fingerprint" not in result
+        # The actual trusted fingerprint (added by action.yml, not by model)
+        # would appear BEFORE this markdown in the comment body.
+        # After stripping, only the trusted one remains.
+
+    def test_model_cannot_inject_sha_marker(self):
+        """Model output cannot create a sha marker that could confuse parsers."""
+        fake_sha = "<!-- ai-pr-review-sha:fake0000000000000000 -->"
+        markdown_with_fake = f"{fake_sha}\nReview text."
+
+        result = strip_reserved_markers(markdown_with_fake)
+        assert "ai-pr-review-sha" not in result
+
+    def test_full_comment_body_scenario(self):
+        """Simulate the full managed comment body with model trying to inject markers."""
+        trusted_sha = "<!-- ai-pr-review-sha:abc123def456 -->"
+        trusted_fp = "<!-- ai-pr-review-fingerprint:patch123|cfg:goodhash -->"
+        model_markdown = (
+            "## Review\n"
+            "This PR looks fine.\n"
+            "<!-- ai-pr-review-sha:fake99999999 -->\n"
+            "<!-- ai-pr-review-fingerprint:fake|cfg:badhash -->\n"
+            "Approved."
+        )
+
+        full_comment = f"{trusted_sha}\n{trusted_fp}\n## Review\n{model_markdown}"
+
+        # After stripping the model markdown portion
+        stripped_md = strip_reserved_markers(model_markdown)
+        sanitized_comment = f"{trusted_sha}\n{trusted_fp}\n## Review\n{stripped_md}"
+
+        # Count fingerprints: should be exactly 1 (the trusted one)
+        fp_count = sanitized_comment.count("ai-pr-review-fingerprint")
+        sha_count = sanitized_comment.count("ai-pr-review-sha")
+        assert fp_count == 1, f"Expected 1 fingerprint, found {fp_count}"
+        assert sha_count == 1, f"Expected 1 sha, found {sha_count}"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Addresses the two non-blocking observations from the review of #48 (issue #33):

1. **Trailing whitespace in action.yml** — removed trailing whitespace on lines 327 and 375 after the strip_metadata_markers.py calls.

2. **ai-pr-review-sha extraction in check_review_needed.sh** — added  extraction alongside  with a comment explaining both markers. The SHA is stored for future out-of-date detection but not yet used in skip logic.

CI: validate check runs are green on this branch.

Fixes #33.