### PR TITLE
docs: reference PR #47 as fix for issue #33

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ The action collects rich PR context (diff, files, linked issues, version hints, 
 - **`scripts/default_system_prompt.txt`** - Bundled system prompt used when no override is provided
 - **`scripts/run_evidence_providers.py`** - Runs user-defined evidence provider commands from a JSON config, parses severity/findings output
 - **`scripts/run_tool_harness.py`** - Tool harness in `plan_execute_once` mode: model plans read-only tool requests (gh_api, read_file, web_fetch, git_grep), action executes them, appends results to corpus
-- **`scripts/strip_metadata_markers.py`** - Strips internal metadata markers from model output before publishing (issue #33)
+- **`scripts/strip_metadata_markers.py`** - Strips internal metadata markers from model output before publishing (fixed in PR #47 / issue #33)
 - **`scripts/image_digest_analysis.py`** - Analyzes image digests from the diff for provenance context
 - **`tests/smoke_test.sh`** - Local smoke test against a real PR with mock OpenAI server
 - **`tests/mock_openai_server.py`** - Mock API server used by the smoke test


### PR DESCRIPTION
## Summary

Issue #33's acceptance criteria were all satisfied by the fix merged in PR #47:
- `scripts/strip_metadata_markers.py` strips fake markers from model output
- `scripts/check_review_needed.sh` hardened to read only trusted metadata block
- `tests/test_strip_metadata_markers.py` covers injection scenarios
- README.md and AGENTS.md document reserved marker behavior

This PR adds a cross-reference in AGENTS.md to explicitly link the fix (PR #47) 
to issue #33, closing it cleanly.

## Changes

- Updated `AGENTS.md` to reference PR #47 as the fix for issue #33

Refs #33
Fixes #33