### PR TITLE
fix: use pytest tmp_path fixture properly in test_round_trip

### DIFF
--- a/tests/test_response_parser.py
+++ b/tests/test_response_parser.py
@@ -241,10 +241,9 @@ class TestParseResponse(TestCase):
 # parse_response_file
 # ---------------------------------------------------------------------------
 
-class TestParseResponseFile(TestCase):
-    def test_round_trip(self, tmp_path=None):
+class TestParseResponseFile:
+    def test_round_trip(self, tmp_path):
         """Write a response file, then read and parse it."""
-        import tempfile
         data = {
             "choices": [{
                 "message": {"content": json.dumps({
@@ -253,17 +252,11 @@ class TestParseResponseFile(TestCase):
                 })},
             }],
         }
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".json", delete=False, dir="/tmp"
-        ) as f:
-            json.dump(data, f)
-            path = f.name
-        try:
-            result = parse_response_file(path)
-            self.assertEqual(result["verdict"], "request_changes")
-            self.assertIn("typo", result["review_markdown"])
-        finally:
-            Path(path).unlink(missing_ok=True)
+        path = tmp_path / "response.json"
+        path.write_text(json.dumps(data))
+        result = parse_response_file(str(path))
+        assert result["verdict"] == "request_changes"
+        assert "typo" in result["review_markdown"]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes part of #36

## Summary

The `tmp_path` parameter in `test_round_trip` was accepted but never used - the test manually created a tempfile in `/tmp` instead of using the pytest fixture.

## Changes

- Convert `TestParseResponseFile` from `unittest.TestCase` to plain class (pytest style)
- Remove `tmp_path=None` default parameter and manual `tempfile.NamedTemporaryFile` usage
- Use the `tmp_path` fixture directly via `tmp_path / "response.json"`
- Use `path.write_text()` instead of `json.dump()` + manual file management
- Switch from `self.assert*` to plain `assert` statements

## Testing

All 162 tests pass.