### PR TITLE
refactor: complete extraction of core logic from run_review.sh

### DIFF
--- a/pr_reviewer/enforcement.py
+++ b/pr_reviewer/enforcement.py
@@ -1,0 +1,272 @@
+"""Enforcement logic for review verdicts.
+
+Applies evidence blocker and tool harness enforcement rules, overriding
+the model's verdict to ``request_changes`` when configured conditions are met.
+Ported from the enforcement section in ``scripts/run_review.sh``.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+
+def apply_evidence_blocker_enforcement(
+    evidence_path: str = "evidence-providers.json",
+    output_path: str = "ai-output.json",
+) -> bool:
+    """Override verdict to request_changes if any evidence provider reported a blocker.
+
+    Parameters
+    ----------
+    evidence_path : str
+        Path to ``evidence-providers.json``.
+    output_path : str
+        Path to ``ai-output.json`` (modified in place).
+
+    Returns
+    -------
+    bool
+        True if enforcement was applied, False otherwise.
+    """
+    if not Path(evidence_path).exists():
+        return False
+    try:
+        evidence = json.loads(Path(evidence_path).read_text(encoding="utf-8", errors="replace"))
+    except (json.JSONDecodeError, OSError):
+        return False
+
+    if not evidence.get("has_blocker"):
+        return False
+
+    blocker_ids = [
+        p["id"]
+        for p in evidence.get("providers", [])
+        if p.get("provider_severity") == "blocker"
+    ]
+    ids_str = ", ".join(blocker_ids)
+
+    data = json.loads(Path(output_path).read_text(encoding="utf-8", errors="replace"))
+    verdict = data.get("verdict")
+    markdown = str(data.get("review_markdown") or "")
+
+    markdown = (
+        (markdown + "\n\n## Evidence Provider Blockers\n"
+         + "One or more configured evidence providers reported blocker-level findings"
+         + (f" ({ids_str})" if ids_str else "")
+         + ". Resolve blocker findings before approval.")
+    )
+
+    data["verdict"] = "request_changes"
+    data["review_markdown"] = markdown
+    Path(output_path).write_text(json.dumps(data, ensure_ascii=False) + "\n", encoding="utf-8")
+    return True
+
+
+def _get_tool_harness_failure_reason(tool_harness_path: str = "tool-harness.json") -> str | None:
+    if not Path(tool_harness_path).exists():
+        return None
+    try:
+        harness = json.loads(Path(tool_harness_path).read_text(encoding="utf-8", errors="replace"))
+    except (json.JSONDecodeError, OSError):
+        return None
+
+    if harness.get("planning_error") is not None:
+        return str(harness["planning_error"])
+    if harness.get("error") is not None:
+        return str(harness["error"])
+    executed = harness.get("executed_request_count", 0)
+    if executed > 0:
+        statuses = harness.get("tool_results", [])
+        if not any(t.get("status") == "ok" for t in statuses if isinstance(t, dict)):
+            return "all tool requests failed"
+    return None
+
+
+def _count_successful_requests(tool_harness_path: str = "tool-harness.json") -> int:
+    if not Path(tool_harness_path).exists():
+        return 0
+    try:
+        harness = json.loads(Path(tool_harness_path).read_text(encoding="utf-8", errors="replace"))
+    except (json.JSONDecodeError, OSError):
+        return 0
+    return sum(
+        1
+        for t in harness.get("tool_results", [])
+        if isinstance(t, dict) and t.get("status") == "ok"
+    )
+
+
+def _harness_requested_tools(tool_harness_path: str = "tool-harness.json") -> bool:
+    if not Path(tool_harness_path).exists():
+        return False
+    try:
+        harness = json.loads(Path(tool_harness_path).read_text(encoding="utf-8", errors="replace"))
+    except (json.JSONDecodeError, OSError):
+        return False
+    planned = harness.get("planned_request_count", 0)
+    executed = harness.get("executed_request_count", 0)
+    return planned > 0 or executed > 0
+
+
+def apply_tool_harness_failure_enforcement(
+    tool_harness_path: str = "tool-harness.json",
+    output_path: str = "ai-output.json",
+) -> bool:
+    """Override verdict to request_changes if tool harness planning or execution failed.
+
+    Parameters
+    ----------
+    tool_harness_path : str
+        Path to ``tool-harness.json``.
+    output_path : str
+        Path to ``ai-output.json`` (modified in place).
+
+    Returns
+    -------
+    bool
+        True if enforcement was applied, False otherwise.
+    """
+    reason = _get_tool_harness_failure_reason(tool_harness_path)
+    if not reason:
+        return False
+
+    data = json.loads(Path(output_path).read_text(encoding="utf-8", errors="replace"))
+    markdown = str(data.get("review_markdown") or "")
+
+    markdown = (
+        markdown
+        + "\n\n## Tool Harness Failure\n"
+        + f"The tool harness failed during planning or execution ({reason}). "
+        + "This workflow is configured fail-closed for tool harness failures; "
+        + "rerun after reducing tool planning context or fixing connectivity."
+    )
+
+    data["verdict"] = "request_changes"
+    data["review_markdown"] = markdown
+    Path(output_path).write_text(json.dumps(data, ensure_ascii=False) + "\n", encoding="utf-8")
+    return True
+
+
+def apply_tool_min_successful_enforcement(
+    min_required: int,
+    tool_harness_path: str = "tool-harness.json",
+    output_path: str = "ai-output.json",
+) -> bool:
+    """Override verdict to request_changes if fewer than ``min_required`` tool requests succeeded.
+
+    Parameters
+    ----------
+    min_required : int
+        Minimum number of successful tool requests required.
+    tool_harness_path : str
+        Path to ``tool-harness.json``.
+    output_path : str
+        Path to ``ai-output.json`` (modified in place).
+
+    Returns
+    -------
+    bool
+        True if enforcement was applied, False otherwise.
+    """
+    if not _harness_requested_tools(tool_harness_path):
+        return False
+
+    successful = _count_successful_requests(tool_harness_path)
+    if successful >= min_required:
+        return False
+
+    data = json.loads(Path(output_path).read_text(encoding="utf-8", errors="replace"))
+    markdown = str(data.get("review_markdown") or "")
+
+    markdown = (
+        markdown
+        + "\n\n## Tool Harness Insufficient Evidence\n"
+        + f"This workflow requires at least {min_required} successful tool requests, "
+        + f"but only {successful} succeeded. Rerun after adjusting tool planning settings."
+    )
+
+    data["verdict"] = "request_changes"
+    data["review_markdown"] = markdown
+    Path(output_path).write_text(json.dumps(data, ensure_ascii=False) + "\n", encoding="utf-8")
+    return True
+
+
+def normalize_enforced_review_markdown(
+    output_path: str = "ai-output.json",
+) -> None:
+    """Add 'Final Recommendation: Request changes' banner when enforcement forced request_changes.
+
+    Parameters
+    ----------
+    output_path : str
+        Path to ``ai-output.json``.
+    """
+    data = json.loads(Path(output_path).read_text(encoding="utf-8", errors="replace"))
+    verdict = data.get("verdict")
+    markdown = str(data.get("review_markdown") or "")
+
+    if verdict == "request_changes":
+        markdown = re.sub(
+            r"(?im)^(#{1,6}\s*)?Recommendation:\s*Approve\s*$",
+            r"\1Model recommendation before enforcement: Approve",
+            markdown,
+        )
+        if not markdown.lstrip().startswith("## Final Recommendation"):
+            markdown = (
+                "## Final Recommendation\n"
+                "Request changes. One or more configured enforcement checks require this PR "
+                "to be treated as blocking even if the model's initial review text was approving.\n\n"
+                + markdown.lstrip()
+            )
+
+        data["review_markdown"] = markdown
+        Path(output_path).write_text(json.dumps(data, ensure_ascii=False) + "\n", encoding="utf-8")
+
+
+def apply_all_enforcement(
+    evidence_blocker_enabled: bool = False,
+    tool_failure_enabled: bool = False,
+    tool_min_successful: int = 0,
+    evidence_path: str = "evidence-providers.json",
+    tool_harness_path: str = "tool-harness.json",
+    output_path: str = "ai-output.json",
+) -> int:
+    """Apply all configured enforcement rules in sequence.
+
+    Parameters
+    ----------
+    evidence_blocker_enabled : bool
+        Whether evidence blocker enforcement is enabled.
+    tool_failure_enabled : bool
+        Whether tool harness failure enforcement is enabled.
+    tool_min_successful : int
+        Minimum successful tool requests (0 = disabled).
+    evidence_path, tool_harness_path, output_path : str
+        File paths as documented above.
+
+    Returns
+    -------
+    int
+        Number of enforcement actions applied (0, 1, or 2).
+    """
+    applied = 0
+
+    if evidence_blocker_enabled:
+        if apply_evidence_blocker_enforcement(evidence_path, output_path):
+            applied += 1
+
+    if tool_failure_enabled:
+        if apply_tool_harness_failure_enforcement(tool_harness_path, output_path):
+            applied += 1
+        elif tool_min_successful > 0:
+            if apply_tool_min_successful_enforcement(
+                tool_min_successful, tool_harness_path, output_path
+            ):
+                applied += 1
+
+    if applied > 0:
+        normalize_enforced_review_markdown(output_path)
+
+    return applied

--- a/pr_reviewer/github_context.py
+++ b/pr_reviewer/github_context.py
@@ -1,0 +1,80 @@
+"""GitHub context collection helpers.
+
+Extracts linked issue references from a PR body, normalises them to
+owner/repo#number form, and provides PR metadata structures.
+Ported from inline Python in ``scripts/run_review.sh``.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass
+
+
+GITHUB_ISSUE_REF_PATTERN = re.compile(
+    r"(?i)\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s*:?[ \t]+"
+    r"((?:[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)?#\d+)"
+)
+
+MAX_LINKED_ISSUES = 8
+
+
+@dataclass
+class LinkedIssueRef:
+    ref: str
+    repo: str
+    number: int
+
+
+def extract_linked_issue_refs(
+    body: str,
+    default_repo: str | None = None,
+) -> list[LinkedIssueRef]:
+    """Extract ``Closes/Fixes/Resolves #N`` style references from a PR body.
+
+    Parameters
+    ----------
+    body : str
+        Raw PR body text.
+    default_repo : str, optional
+        Repository to use when the reference is just ``#N`` (e.g. ``"owner/repo"``).
+
+    Returns
+    -------
+    list[LinkedIssueRef]
+        Deduplicated list of issue references (max 8), in order of appearance.
+    """
+    if default_repo is None:
+        default_repo = os.environ.get("REPO", "")
+
+    seen: set[str] = set()
+    items: list[LinkedIssueRef] = []
+
+    for match in GITHUB_ISSUE_REF_PATTERN.finditer(body):
+        ref = match.group(1)
+        if ref in seen:
+            continue
+        seen.add(ref)
+
+        if "/" in ref:
+            repo_name, issue_number = ref.split("#", 1)
+        else:
+            repo_name, issue_number = default_repo, ref[1:]
+
+        try:
+            number = int(issue_number)
+        except ValueError:
+            continue
+
+        items.append(LinkedIssueRef(ref=ref, repo=repo_name, number=number))
+
+        if len(items) >= MAX_LINKED_ISSUES:
+            break
+
+    return items
+
+
+def linked_issues_to_json(items: list[LinkedIssueRef]) -> list[dict]:
+    """Serialize a list of LinkedIssueRef to the JSON format used in run_review.sh."""
+    return [{"ref": item.ref, "repo": item.repo, "number": item.number} for item in items]

--- a/pr_reviewer/sse_reassembler.py
+++ b/pr_reviewer/sse_reassembler.py
@@ -1,0 +1,180 @@
+"""Reassemble Server-Sent Events (SSE) streaming responses into consolidated JSON.
+
+Ported from the ``reassemble_sse_response`` function in ``scripts/run_review.sh``.
+Handles OpenAI chat completions streaming and Anthropic messages streaming formats,
+normalising both to a unified OpenAI-style response structure.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def reassemble_sse(response_text: str, api_format: str) -> dict:
+    """Reassemble SSE lines from a streaming response into a structured dict.
+
+    Parameters
+    ----------
+    response_text : str
+        Raw response text containing SSE data lines (one ``data: ...`` per line).
+    api_format : str
+        Either ``"openai"`` or ``"anthropic"``.
+
+    Returns
+    -------
+    dict
+        A normalised OpenAI-style response dict with an ``id``, ``model``,
+        ``choices``, and ``usage`` field.
+    """
+    lines = response_text.splitlines()
+    content_parts: list[str] = []
+
+    if api_format == "anthropic":
+        return _reassemble_anthropic(lines, content_parts)
+    return _reassemble_openai(lines, content_parts)
+
+
+def _reassemble_anthropic(lines: list[str], content_parts: list[str]) -> dict:
+    stop_reason: str | None = None
+    stop_sequence: str | None = None
+    message_id: str | None = None
+    model: str | None = None
+    input_tokens = 0
+    output_tokens = 0
+
+    for line in lines:
+        line = line.strip()
+        if not line.startswith("data:"):
+            continue
+        data = line[5:].strip()
+        if not data or data == "[DONE]":
+            continue
+        try:
+            event = json.loads(data)
+        except json.JSONDecodeError:
+            continue
+
+        etype = event.get("type", "")
+        if etype == "message_start":
+            message_id = event.get("message", {}).get("id")
+            model = event.get("message", {}).get("model")
+            input_tokens = event.get("message", {}).get("usage", {}).get("input_tokens", 0)
+            output_tokens = event.get("message", {}).get("usage", {}).get("output_tokens", 0)
+        elif etype == "content_block_delta":
+            delta = event.get("delta", {})
+            if delta.get("type") in ("text_delta", "text"):
+                text_chunk = delta.get("text", "")
+                if isinstance(text_chunk, str):
+                    content_parts.append(text_chunk)
+        elif etype == "message_delta":
+            delta = event.get("delta", {})
+            stop_reason = delta.get("stop_reason")
+            stop_sequence = delta.get("stop_sequence")
+            usage = delta.get("usage", {})
+            if usage:
+                output_tokens += usage.get("output_tokens", 0)
+
+    content_text = "".join(content_parts)
+    return {
+        "id": message_id or "",
+        "object": "chat.completion",
+        "model": model or "",
+        "choices": [{
+            "index": 0,
+            "message": {"role": "assistant", "content": content_text},
+            "finish_reason": stop_reason or "stop",
+        }],
+        "usage": {
+            "prompt_tokens": input_tokens,
+            "completion_tokens": output_tokens,
+            "total_tokens": input_tokens + output_tokens,
+        },
+    }
+
+
+def _reassemble_openai(lines: list[str], content_parts: list[str]) -> dict:
+    finish_reason: str | None = None
+    model: str | None = None
+    usage_prompt_tokens = 0
+    usage_completion_tokens = 0
+    id_val = ""
+
+    for line in lines:
+        line = line.strip()
+        if not line.startswith("data:"):
+            continue
+        data = line[5:].strip()
+        if not data or data == "[DONE]":
+            continue
+        try:
+            chunk = json.loads(data)
+        except json.JSONDecodeError:
+            continue
+
+        id_val = chunk.get("id", id_val)
+        model = chunk.get("model", model)
+        choices = chunk.get("choices", [])
+        for choice in choices:
+            delta = choice.get("delta", {})
+            if isinstance(delta, dict):
+                c = delta.get("content")
+                if isinstance(c, str):
+                    content_parts.append(c)
+            fr = choice.get("finish_reason")
+            if fr is not None:
+                finish_reason = fr
+        usage = chunk.get("usage")
+        if isinstance(usage, dict):
+            usage_prompt_tokens += usage.get("prompt_tokens", 0)
+            usage_completion_tokens += usage.get("completion_tokens", 0)
+
+    content_text = "".join(content_parts)
+    return {
+        "id": id_val,
+        "object": "chat.completion",
+        "model": model or "",
+        "choices": [{
+            "index": 0,
+            "message": {"role": "assistant", "content": content_text},
+            "finish_reason": finish_reason or "stop",
+        }],
+        "usage": {
+            "prompt_tokens": usage_prompt_tokens,
+            "completion_tokens": usage_completion_tokens,
+            "total_tokens": usage_prompt_tokens + usage_completion_tokens,
+        },
+    }
+
+
+def reassemble_sse_file(response_path: str, api_format: str) -> dict:
+    """Convenience wrapper that reads a response file and reassembles SSE.
+
+    Parameters
+    ----------
+    response_path : str
+        Path to the SSE response file.
+    api_format : str
+        Either ``"openai"`` or ``"anthropic"``.
+
+    Returns
+    -------
+    dict
+        The normalised response dict.
+    """
+    text = Path(response_path).read_text(encoding="utf-8", errors="replace")
+    return reassemble_sse(text, api_format)
+
+
+def reassemble_sse_to_file(response_path: str, api_format: str) -> None:
+    """Read a SSE response file, reassemble it, and overwrite ``response_path``.
+
+    Parameters
+    ----------
+    response_path : str
+        Path to the SSE response file (will be overwritten with normalised JSON).
+    api_format : str
+        Either ``"openai"`` or ``"anthropic"``.
+    """
+    result = reassemble_sse_file(response_path, api_format)
+    Path(response_path).write_text(json.dumps(result, ensure_ascii=False) + "\n", encoding="utf-8")

--- a/scripts/run_review.sh
+++ b/scripts/run_review.sh
@@ -245,142 +245,10 @@ build_model_request() {
 reassemble_sse_response() {
   local response_file="$1"
   local api_format="$2"
-
-  if [[ "$api_format" == "anthropic" ]]; then
-    python3 - "$response_file" <<'PY'
-import sys
-from pathlib import Path
-
-response_file = sys.argv[1]
-lines = Path(response_file).read_text(encoding="utf-8", errors="replace").splitlines()
-
-content_parts = []
-stop_reason = None
-stop_sequence = None
-model = None
-message_id = None
-input_tokens = 0
-output_tokens = 0
-
-for line in lines:
-    line = line.strip()
-    if not line.startswith("data:"):
-        continue
-    data = line[5:].strip()
-    if not data or data == "[DONE]":
-        continue
-    try:
-        import json
-        event = json.loads(data)
-    except json.JSONDecodeError:
-        continue
-
-    etype = event.get("type", "")
-    if etype == "message_start":
-        message_id = event.get("message", {}).get("id")
-        model = event.get("message", {}).get("model")
-        input_tokens = event.get("message", {}).get("usage", {}).get("input_tokens", 0)
-        output_tokens = event.get("message", {}).get("usage", {}).get("output_tokens", 0)
-    elif etype == "content_block_delta":
-        delta = event.get("delta", {})
-        # Anthropic streaming spec uses delta.type == "text_delta"; accept "text" as well for
-        # non-conforming proxies. Thinking/tool_use deltas are intentionally ignored.
-        if delta.get("type") in ("text_delta", "text"):
-            text_chunk = delta.get("text", "")
-            if isinstance(text_chunk, str):
-                content_parts.append(text_chunk)
-    elif etype == "message_delta":
-        delta = event.get("delta", {})
-        stop_reason = delta.get("stop_reason")
-        stop_sequence = delta.get("stop_sequence")
-        usage = delta.get("usage", {})
-        if usage:
-            output_tokens += usage.get("output_tokens", 0)
-
-content_text = "".join(content_parts)
-result = {
-    "id": message_id or "",
-    "object": "chat.completion",
-    "model": model or "",
-    "choices": [{
-        "index": 0,
-        "message": {"role": "assistant", "content": content_text},
-        "finish_reason": stop_reason or "stop"
-    }],
-    "usage": {
-        "prompt_tokens": input_tokens,
-        "completion_tokens": output_tokens,
-        "total_tokens": input_tokens + output_tokens
-    }
-}
-
-Path(response_file).write_text(json.dumps(result, ensure_ascii=False) + "\n", encoding="utf-8")
-PY
-  else
-    python3 - "$response_file" <<'PY'
-import sys
-from pathlib import Path
-
-response_file = sys.argv[1]
-lines = Path(response_file).read_text(encoding="utf-8", errors="replace").splitlines()
-
-content_parts = []
-finish_reason = None
-model = None
-usage_prompt_tokens = 0
-usage_completion_tokens = 0
-id_val = ""
-
-for line in lines:
-    line = line.strip()
-    if not line.startswith("data:"):
-        continue
-    data = line[5:].strip()
-    if not data or data == "[DONE]":
-        continue
-    try:
-        import json
-        chunk = json.loads(data)
-    except json.JSONDecodeError:
-        continue
-
-    id_val = chunk.get("id", id_val)
-    model = chunk.get("model", model)
-    choices = chunk.get("choices", [])
-    for choice in choices:
-        delta = choice.get("delta", {})
-        if isinstance(delta, dict):
-            c = delta.get("content")
-            if isinstance(c, str):
-                content_parts.append(c)
-        fr = choice.get("finish_reason")
-        if fr is not None:
-            finish_reason = fr
-    usage = chunk.get("usage")
-    if isinstance(usage, dict):
-        usage_prompt_tokens += usage.get("prompt_tokens", 0)
-        usage_completion_tokens += usage.get("completion_tokens", 0)
-
-content_text = "".join(content_parts)
-result = {
-    "id": id_val,
-    "object": "chat.completion",
-    "model": model or "",
-    "choices": [{
-        "index": 0,
-        "message": {"role": "assistant", "content": content_text},
-        "finish_reason": finish_reason or "stop"
-    }],
-    "usage": {
-        "prompt_tokens": usage_prompt_tokens,
-        "completion_tokens": usage_completion_tokens,
-        "total_tokens": usage_prompt_tokens + usage_completion_tokens
-    }
-}
-
-Path(response_file).write_text(json.dumps(result, ensure_ascii=False) + "\n", encoding="utf-8")
-PY
-  fi
+  PYTHONPATH="${SCRIPT_DIR}/.." python3 -c "
+from pr_reviewer.sse_reassembler import reassemble_sse_to_file
+reassemble_sse_to_file('$response_file', '$api_format')
+"
 }
 
 parse_and_validate() {
@@ -396,33 +264,10 @@ Path('ai-output.json').write_text(json.dumps(result, ensure_ascii=False) + '\n',
 }
 
 normalize_enforced_review_markdown() {
-  python3 - <<'PY'
-import json
-import re
-from pathlib import Path
-
-path = Path("ai-output.json")
-data = json.loads(path.read_text(encoding="utf-8", errors="replace"))
-verdict = data.get("verdict")
-markdown = str(data.get("review_markdown") or "")
-
-if verdict == "request_changes":
-    markdown = re.sub(
-        r"(?im)^(#{1,6}\s*)?Recommendation:\s*Approve\s*$",
-        r"\1Model recommendation before enforcement: Approve",
-        markdown,
-    )
-    if not markdown.lstrip().startswith("## Final Recommendation"):
-        markdown = (
-            "## Final Recommendation\n"
-            "Request changes. One or more configured enforcement checks require this PR "
-            "to be treated as blocking even if the model's initial review text was approving.\n\n"
-            + markdown.lstrip()
-        )
-
-data["review_markdown"] = markdown
-path.write_text(json.dumps(data, ensure_ascii=False) + "\n", encoding="utf-8")
-PY
+  PYTHONPATH="${SCRIPT_DIR}/.." python3 -c "
+from pr_reviewer.enforcement import normalize_enforced_review_markdown
+normalize_enforced_review_markdown()
+"
 }
 
 log "Collecting PR context for #$PR_NUMBER in $REPO..."
@@ -445,28 +290,16 @@ head -c "$MAX_FILES" pr-files.json > pr-files.truncated.json
 jq -r '.body // ""' pr.json > pr-body.txt
 
 log "Gathering linked issue context..."
-python3 - <<'PY' > linked-issues.json
+REPO="$REPO" python3 - <<'PY' > linked-issues.json
 import json
 import os
-import re
 from pathlib import Path
+from pr_reviewer.github_context import extract_linked_issue_refs, linked_issues_to_json
 
 repo = os.environ["REPO"]
 body = Path("pr-body.txt").read_text(encoding="utf-8", errors="replace")
-pattern = re.compile(r'(?i)\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s*:?[ \t]+((?:[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)?#\d+)')
-seen = set()
-items = []
-for match in pattern.finditer(body):
-    ref = match.group(1)
-    if ref in seen:
-        continue
-    seen.add(ref)
-    if "/" in ref:
-        repo_name, issue_number = ref.split("#", 1)
-    else:
-        repo_name, issue_number = repo, ref[1:]
-    items.append({"ref": ref, "repo": repo_name, "number": int(issue_number)})
-print(json.dumps(items[:8]))
+items = extract_linked_issue_refs(body, default_repo=repo)
+print(json.dumps(linked_issues_to_json(items)))
 PY
 
 : > linked-issues.md

--- a/tests/test_enforcement.py
+++ b/tests/test_enforcement.py
@@ -1,0 +1,291 @@
+"""Tests for pr_reviewer.enforcement."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest import main as unittest_main
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from pr_reviewer.enforcement import (
+    apply_evidence_blocker_enforcement,
+    apply_tool_harness_failure_enforcement,
+    apply_tool_min_successful_enforcement,
+    normalize_enforced_review_markdown,
+    apply_all_enforcement,
+    _get_tool_harness_failure_reason,
+    _count_successful_requests,
+    _harness_requested_tools,
+)
+
+
+class TestApplyEvidenceBlockerEnforcement:
+    def test_no_op_when_no_blocker(self, tmp_path):
+        evidence = {"has_blocker": False, "providers": []}
+        output = {"verdict": "approve", "review_markdown": "LGTM"}
+
+        evidence_path = tmp_path / "evidence-providers.json"
+        output_path = tmp_path / "ai-output.json"
+        evidence_path.write_text(json.dumps(evidence))
+        output_path.write_text(json.dumps(output))
+
+        result = apply_evidence_blocker_enforcement(str(evidence_path), str(output_path))
+        assert result is False
+        assert json.loads(output_path.read_text())["verdict"] == "approve"
+
+    def test_enforces_request_changes_with_blocker(self, tmp_path):
+        evidence = {
+            "has_blocker": True,
+            "providers": [
+                {"id": "secret-scanner", "provider_severity": "blocker"},
+            ],
+        }
+        output = {"verdict": "approve", "review_markdown": "LGTM"}
+
+        evidence_path = tmp_path / "evidence-providers.json"
+        output_path = tmp_path / "ai-output.json"
+        evidence_path.write_text(json.dumps(evidence))
+        output_path.write_text(json.dumps(output))
+
+        result = apply_evidence_blocker_enforcement(str(evidence_path), str(output_path))
+        assert result is True
+        updated = json.loads(output_path.read_text())
+        assert updated["verdict"] == "request_changes"
+        assert "blocker-level findings" in updated["review_markdown"]
+        assert "secret-scanner" in updated["review_markdown"]
+
+    def test_missing_evidence_file(self, tmp_path):
+        output_path = tmp_path / "ai-output.json"
+        output_path.write_text(json.dumps({"verdict": "approve", "review_markdown": "ok"}))
+        result = apply_evidence_blocker_enforcement(str(tmp_path / "missing.json"), str(output_path))
+        assert result is False
+
+    def test_invalid_json_evidence(self, tmp_path):
+        evidence_path = tmp_path / "evidence.json"
+        output_path = tmp_path / "ai-output.json"
+        evidence_path.write_text("not json")
+        output_path.write_text(json.dumps({"verdict": "approve", "review_markdown": "ok"}))
+        result = apply_evidence_blocker_enforcement(str(evidence_path), str(output_path))
+        assert result is False
+
+
+class TestToolHarnessFailure:
+    def test_planning_error_detected(self, tmp_path):
+        harness = {"planning_error": "timeout after 30s"}
+        path = tmp_path / "tool-harness.json"
+        path.write_text(json.dumps(harness))
+        assert _get_tool_harness_failure_reason(str(path)) == "timeout after 30s"
+
+    def test_error_field_detected(self, tmp_path):
+        harness = {"error": "connection refused"}
+        path = tmp_path / "tool-harness.json"
+        path.write_text(json.dumps(harness))
+        assert _get_tool_harness_failure_reason(str(path)) == "connection refused"
+
+    def test_all_requests_failed_detected(self, tmp_path):
+        harness = {
+            "executed_request_count": 2,
+            "tool_results": [
+                {"status": "error"},
+                {"status": "error"},
+            ],
+        }
+        path = tmp_path / "tool-harness.json"
+        path.write_text(json.dumps(harness))
+        assert _get_tool_harness_failure_reason(str(path)) == "all tool requests failed"
+
+    def test_partial_failure_not_flagged(self, tmp_path):
+        harness = {
+            "executed_request_count": 2,
+            "tool_results": [
+                {"status": "ok"},
+                {"status": "error"},
+            ],
+        }
+        path = tmp_path / "tool-harness.json"
+        path.write_text(json.dumps(harness))
+        assert _get_tool_harness_failure_reason(str(path)) is None
+
+    def test_missing_file(self, tmp_path):
+        assert _get_tool_harness_failure_reason(str(tmp_path / "missing.json")) is None
+
+    def test_invalid_json(self, tmp_path):
+        path = tmp_path / "bad.json"
+        path.write_text("not json")
+        assert _get_tool_harness_failure_reason(str(path)) is None
+
+
+class TestCountSuccessfulRequests:
+    def test_counts_ok_status(self, tmp_path):
+        harness = {
+            "tool_results": [
+                {"status": "ok"},
+                {"status": "ok"},
+                {"status": "error"},
+            ],
+        }
+        path = tmp_path / "tool-harness.json"
+        path.write_text(json.dumps(harness))
+        assert _count_successful_requests(str(path)) == 2
+
+    def test_empty_results(self, tmp_path):
+        harness = {"tool_results": []}
+        path = tmp_path / "tool-harness.json"
+        path.write_text(json.dumps(harness))
+        assert _count_successful_requests(str(path)) == 0
+
+
+class TestHarnessRequestedTools:
+    def test_true_when_planned(self, tmp_path):
+        harness = {"planned_request_count": 2, "executed_request_count": 0}
+        path = tmp_path / "tool-harness.json"
+        path.write_text(json.dumps(harness))
+        assert _harness_requested_tools(str(path)) is True
+
+    def test_true_when_executed(self, tmp_path):
+        harness = {"planned_request_count": 0, "executed_request_count": 3}
+        path = tmp_path / "tool-harness.json"
+        path.write_text(json.dumps(harness))
+        assert _harness_requested_tools(str(path)) is True
+
+    def test_false_when_none(self, tmp_path):
+        harness = {"planned_request_count": 0, "executed_request_count": 0}
+        path = tmp_path / "tool-harness.json"
+        path.write_text(json.dumps(harness))
+        assert _harness_requested_tools(str(path)) is False
+
+
+class TestApplyToolHarnessFailureEnforcement:
+    def test_enforces_on_planning_error(self, tmp_path):
+        harness = {"planning_error": "context limit exceeded"}
+        output = {"verdict": "approve", "review_markdown": "Looks good"}
+
+        harness_path = tmp_path / "tool-harness.json"
+        output_path = tmp_path / "ai-output.json"
+        harness_path.write_text(json.dumps(harness))
+        output_path.write_text(json.dumps(output))
+
+        result = apply_tool_harness_failure_enforcement(str(harness_path), str(output_path))
+        assert result is True
+        updated = json.loads(output_path.read_text())
+        assert updated["verdict"] == "request_changes"
+        assert "context limit exceeded" in updated["review_markdown"]
+
+    def test_no_op_when_no_failure(self, tmp_path):
+        harness = {"planned_request_count": 1, "tool_results": [{"status": "ok"}]}
+        output = {"verdict": "approve", "review_markdown": "OK"}
+
+        harness_path = tmp_path / "tool-harness.json"
+        output_path = tmp_path / "ai-output.json"
+        harness_path.write_text(json.dumps(harness))
+        output_path.write_text(json.dumps(output))
+
+        result = apply_tool_harness_failure_enforcement(str(harness_path), str(output_path))
+        assert result is False
+
+
+class TestApplyToolMinSuccessfulEnforcement:
+    def test_enforces_when_under_minimum(self, tmp_path):
+        harness = {
+            "planned_request_count": 3,
+            "executed_request_count": 3,
+            "tool_results": [{"status": "ok"}, {"status": "error"}, {"status": "error"}],
+        }
+        output = {"verdict": "approve", "review_markdown": "OK"}
+
+        harness_path = tmp_path / "tool-harness.json"
+        output_path = tmp_path / "ai-output.json"
+        harness_path.write_text(json.dumps(harness))
+        output_path.write_text(json.dumps(output))
+
+        result = apply_tool_min_successful_enforcement(3, str(harness_path), str(output_path))
+        assert result is True
+        updated = json.loads(output_path.read_text())
+        assert updated["verdict"] == "request_changes"
+        assert "only 1 succeeded" in updated["review_markdown"]
+
+    def test_no_op_when_at_minimum(self, tmp_path):
+        harness = {
+            "planned_request_count": 2,
+            "tool_results": [{"status": "ok"}, {"status": "ok"}],
+        }
+        output = {"verdict": "approve", "review_markdown": "OK"}
+
+        harness_path = tmp_path / "tool-harness.json"
+        output_path = tmp_path / "ai-output.json"
+        harness_path.write_text(json.dumps(harness))
+        output_path.write_text(json.dumps(output))
+
+        result = apply_tool_min_successful_enforcement(2, str(harness_path), str(output_path))
+        assert result is False
+
+    def test_no_op_when_no_tools_requested(self, tmp_path):
+        harness = {"planned_request_count": 0, "executed_request_count": 0}
+        output = {"verdict": "approve", "review_markdown": "OK"}
+
+        harness_path = tmp_path / "tool-harness.json"
+        output_path = tmp_path / "ai-output.json"
+        harness_path.write_text(json.dumps(harness))
+        output_path.write_text(json.dumps(output))
+
+        result = apply_tool_min_successful_enforcement(2, str(harness_path), str(output_path))
+        assert result is False
+
+
+class TestNormalizeEnforcedReviewMarkdown:
+    def test_approve_banner_rewritten(self, tmp_path):
+        data = {
+            "verdict": "request_changes",
+            "review_markdown": "Recommendation: Approve\n\nSome text",
+        }
+        path = tmp_path / "ai-output.json"
+        path.write_text(json.dumps(data))
+        normalize_enforced_review_markdown(str(path))
+        updated = json.loads(path.read_text())
+        assert "Model recommendation before enforcement: Approve" in updated["review_markdown"]
+
+    def test_final_recommendation_prepended(self, tmp_path):
+        data = {"verdict": "request_changes", "review_markdown": "Please fix this."}
+        path = tmp_path / "ai-output.json"
+        path.write_text(json.dumps(data))
+        normalize_enforced_review_markdown(str(path))
+        updated = json.loads(path.read_text())
+        assert updated["review_markdown"].startswith("## Final Recommendation")
+
+    def test_no_op_for_approve(self, tmp_path):
+        data = {"verdict": "approve", "review_markdown": "LGTM"}
+        path = tmp_path / "ai-output.json"
+        path.write_text(json.dumps(data))
+        original = path.read_text()
+        normalize_enforced_review_markdown(str(path))
+        assert path.read_text() == original
+
+
+class TestApplyAllEnforcement:
+    def test_evidence_blocker_applied(self, tmp_path):
+        evidence = {"has_blocker": True, "providers": [{"id": "x", "provider_severity": "blocker"}]}
+        output = {"verdict": "approve", "review_markdown": "OK"}
+
+        ep = tmp_path / "evidence-providers.json"
+        th = tmp_path / "tool-harness.json"
+        out = tmp_path / "ai-output.json"
+        ep.write_text(json.dumps(evidence))
+        out.write_text(json.dumps(output))
+
+        applied = apply_all_enforcement(
+            evidence_blocker_enabled=True,
+            tool_failure_enabled=False,
+            tool_min_successful=0,
+            evidence_path=str(ep),
+            tool_harness_path=str(th),
+            output_path=str(out),
+        )
+        assert applied == 1
+        assert json.loads(out.read_text())["verdict"] == "request_changes"
+
+
+if __name__ == "__main__":
+    unittest_main()

--- a/tests/test_github_context.py
+++ b/tests/test_github_context.py
@@ -1,0 +1,114 @@
+"""Tests for pr_reviewer.github_context."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest import main as unittest_main
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from pr_reviewer.github_context import (
+    extract_linked_issue_refs,
+    linked_issues_to_json,
+    MAX_LINKED_ISSUES,
+    GITHUB_ISSUE_REF_PATTERN,
+)
+
+
+class TestExtractLinkedIssueRefs:
+    def test_closes_hash(self):
+        refs = extract_linked_issue_refs("Closes #123", default_repo="owner/repo")
+        assert len(refs) == 1
+        assert refs[0].number == 123
+        assert refs[0].ref == "#123"
+        assert refs[0].repo == "owner/repo"
+
+    def test_fixes_with_repo(self):
+        refs = extract_linked_issue_refs("Fixes misospace/another-repo#456", default_repo="owner/repo")
+        assert len(refs) == 1
+        assert refs[0].number == 456
+        assert refs[0].repo == "misospace/another-repo"
+
+    def test_multiple_refs_deduplicated(self):
+        body = "Closes #1\nFixes #2\nCloses #1\nResolves #3"
+        refs = extract_linked_issue_refs(body, default_repo="owner/repo")
+        assert len(refs) == 3
+        nums = [r.number for r in refs]
+        assert nums == [1, 2, 3]
+
+    def test_resolves_keyword(self):
+        refs = extract_linked_issue_refs("RESOLVES #99", default_repo="x/y")
+        assert len(refs) == 1
+        assert refs[0].number == 99
+
+    def test_close_with_colon(self):
+        refs = extract_linked_issue_refs("Close: #42", default_repo="a/b")
+        assert len(refs) == 1
+        assert refs[0].number == 42
+
+    def test_max_8_items(self):
+        body = "\n".join(f"Closes #{i}" for i in range(1, 15))
+        refs = extract_linked_issue_refs(body, default_repo="owner/repo")
+        assert len(refs) == MAX_LINKED_ISSUES
+
+    def test_no_refs(self):
+        refs = extract_linked_issue_refs("Just some text", default_repo="owner/repo")
+        assert len(refs) == 0
+
+    def test_invalid_number_skipped(self):
+        refs = extract_linked_issue_refs("Closes #abc", default_repo="owner/repo")
+        assert len(refs) == 0
+
+    def test_uses_env_repo_for_hash_refs(self):
+        refs = extract_linked_issue_refs("Closes #42", default_repo=None)
+        assert refs[0].repo == ""
+
+    def test_case_insensitive(self):
+        refs = extract_linked_issue_refs("FIXES #1\nclose #2", default_repo="owner/repo")
+        assert len(refs) == 2
+
+    def test_whitespace_variations(self):
+        refs = extract_linked_issue_refs("Closes:  #42", default_repo="x/y")
+        assert len(refs) == 1
+        assert refs[0].number == 42
+
+
+class TestLinkedIssuesToJson:
+    def test_serialises_correctly(self):
+        from pr_reviewer.github_context import LinkedIssueRef
+        items = [
+            LinkedIssueRef(ref="#1", repo="owner/repo", number=1),
+            LinkedIssueRef(ref="other/repo#5", repo="other/repo", number=5),
+        ]
+        result = linked_issues_to_json(items)
+        assert result == [
+            {"ref": "#1", "repo": "owner/repo", "number": 1},
+            {"ref": "other/repo#5", "repo": "other/repo", "number": 5},
+        ]
+
+
+class TestPattern:
+    def test_pattern_matches_closes(self):
+        match = GITHUB_ISSUE_REF_PATTERN.search("Closes #123")
+        assert match is not None
+        assert match.group(1) == "#123"
+
+    def test_pattern_matches_fixes(self):
+        match = GITHUB_ISSUE_REF_PATTERN.search("Fixes owner/repo#456")
+        assert match is not None
+        assert match.group(1) == "owner/repo#456"
+
+    def test_pattern_case_insensitive(self):
+        match = GITHUB_ISSUE_REF_PATTERN.search("RESOLVES #99")
+        assert match is not None
+
+    def test_pattern_rejects_plain_text(self):
+        match = GITHUB_ISSUE_REF_PATTERN.search("Just some text without refs")
+        assert match is None
+
+
+if __name__ == "__main__":
+    unittest_main()

--- a/tests/test_sse_reassembler.py
+++ b/tests/test_sse_reassembler.py
@@ -1,0 +1,172 @@
+"""Tests for pr_reviewer.sse_reassembler."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest import main as unittest_main
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from pr_reviewer.sse_reassembler import (
+    reassemble_sse,
+    reassemble_sse_file,
+    reassemble_sse_to_file,
+)
+
+
+def _make_sse_line(data: dict) -> str:
+    return f"data: {json.dumps(data)}"
+
+
+class TestReassembleAnthropic:
+    def test_message_start_only(self):
+        lines = [
+            _make_sse_line({
+                "type": "message_start",
+                "message": {
+                    "id": "msg_123",
+                    "model": "claude-3-5-sonnet",
+                    "usage": {"input_tokens": 10, "output_tokens": 0},
+                },
+            }),
+        ]
+        result = reassemble_sse("\n".join(lines), "anthropic")
+        assert result["id"] == "msg_123"
+        assert result["model"] == "claude-3-5-sonnet"
+        assert result["choices"][0]["message"]["content"] == ""
+        assert result["usage"]["prompt_tokens"] == 10
+
+    def test_content_block_delta_text(self):
+        lines = [
+            _make_sse_line({"type": "message_start", "message": {"id": "msg_1", "model": "m", "usage": {"input_tokens": 1, "output_tokens": 0}}}),
+            _make_sse_line({"type": "content_block_delta", "delta": {"type": "text_delta", "text": "Hello"}}),
+            _make_sse_line({"type": "content_block_delta", "delta": {"type": "text_delta", "text": " world"}}),
+            _make_sse_line({"type": "message_delta", "delta": {"stop_reason": "end_turn", "usage": {"output_tokens": 5}}}),
+        ]
+        result = reassemble_sse("\n".join(lines), "anthropic")
+        assert result["choices"][0]["message"]["content"] == "Hello world"
+        assert result["choices"][0]["finish_reason"] == "end_turn"
+        assert result["usage"]["completion_tokens"] == 5
+
+    def test_text_delta_type_text_accepted(self):
+        lines = [
+            _make_sse_line({"type": "message_start", "message": {"id": "msg_1", "model": "m", "usage": {"input_tokens": 1, "output_tokens": 0}}}),
+            _make_sse_line({"type": "content_block_delta", "delta": {"type": "text", "text": "Hi"}}),
+            _make_sse_line({"type": "message_delta", "delta": {"stop_reason": "stop"}}),
+        ]
+        result = reassemble_sse("\n".join(lines), "anthropic")
+        assert result["choices"][0]["message"]["content"] == "Hi"
+
+    def test_thinking_delta_ignored(self):
+        lines = [
+            _make_sse_line({"type": "message_start", "message": {"id": "msg_1", "model": "m", "usage": {"input_tokens": 1, "output_tokens": 0}}}),
+            _make_sse_line({"type": "content_block_delta", "delta": {"type": "thinking_delta", "text": "..."}}),
+            _make_sse_line({"type": "content_block_delta", "delta": {"type": "text_delta", "text": "Result"}}),
+        ]
+        result = reassemble_sse("\n".join(lines), "anthropic")
+        assert result["choices"][0]["message"]["content"] == "Result"
+
+    def test_dones_ignored(self):
+        lines = [
+            _make_sse_line({"type": "message_start", "message": {"id": "msg_1", "model": "m", "usage": {"input_tokens": 1}}}),
+            "data: [DONE]",
+        ]
+        result = reassemble_sse("\n".join(lines), "anthropic")
+        assert result["choices"][0]["message"]["content"] == ""
+
+    def test_invalid_json_skipped(self):
+        lines = [
+            _make_sse_line({"type": "message_start", "message": {"id": "msg_1", "model": "m", "usage": {"input_tokens": 1}}}),
+            "data: not valid json",
+            _make_sse_line({"type": "content_block_delta", "delta": {"type": "text_delta", "text": "OK"}}),
+            _make_sse_line({"type": "message_delta", "delta": {"stop_reason": "stop"}}),
+        ]
+        result = reassemble_sse("\n".join(lines), "anthropic")
+        assert result["choices"][0]["message"]["content"] == "OK"
+
+    def test_output_tokens_accumulated_from_message_delta(self):
+        lines = [
+            _make_sse_line({"type": "message_start", "message": {"id": "m", "model": "c", "usage": {"input_tokens": 5, "output_tokens": 3}}}),
+            _make_sse_line({"type": "message_delta", "delta": {"stop_reason": "end", "usage": {"output_tokens": 7}}}),
+        ]
+        result = reassemble_sse("\n".join(lines), "anthropic")
+        assert result["usage"]["completion_tokens"] == 10
+
+
+class TestReassembleOpenAI:
+    def test_basic_completion(self):
+        lines = [
+            _make_sse_line({"id": "chat_1", "model": "gpt-4o", "choices": [{"index": 0, "delta": {"content": "Hello"}, "finish_reason": None}]}),
+            _make_sse_line({"id": "chat_1", "model": "gpt-4o", "choices": [{"index": 0, "delta": {"content": " world"}, "finish_reason": None}]}),
+            _make_sse_line({"id": "chat_1", "model": "gpt-4o", "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}], "usage": {"prompt_tokens": 5, "completion_tokens": 2}}),
+        ]
+        result = reassemble_sse("\n".join(lines), "openai")
+        assert result["id"] == "chat_1"
+        assert result["model"] == "gpt-4o"
+        assert result["choices"][0]["message"]["content"] == "Hello world"
+        assert result["choices"][0]["finish_reason"] == "stop"
+        assert result["usage"]["prompt_tokens"] == 5
+        assert result["usage"]["completion_tokens"] == 2
+
+    def test_usage_accumulates_across_chunks(self):
+        lines = [
+            _make_sse_line({"id": "c", "choices": [{"delta": {"content": "a"}}], "usage": {"prompt_tokens": 1, "completion_tokens": 1}}),
+            _make_sse_line({"id": "c", "choices": [{"delta": {"content": "b"}}], "usage": {"prompt_tokens": 0, "completion_tokens": 1}}),
+            _make_sse_line({"id": "c", "choices": [{"delta": {}, "finish_reason": "stop"}], "usage": {"prompt_tokens": 0, "completion_tokens": 1}}),
+        ]
+        result = reassemble_sse("\n".join(lines), "openai")
+        assert result["usage"]["prompt_tokens"] == 1
+        assert result["usage"]["completion_tokens"] == 3
+
+    def test_dones_ignored(self):
+        lines = [
+            _make_sse_line({"id": "c", "choices": [{"delta": {"content": "Hi"}}]}),
+            "data: [DONE]",
+        ]
+        result = reassemble_sse("\n".join(lines), "openai")
+        assert result["choices"][0]["message"]["content"] == "Hi"
+
+    def test_invalid_json_skipped(self):
+        lines = [
+            _make_sse_line({"id": "c", "choices": [{"delta": {"content": "A"}}]}),
+            "data: not json",
+            _make_sse_line({"id": "c", "choices": [{"delta": {"content": "B"}}]}),
+        ]
+        result = reassemble_sse("\n".join(lines), "openai")
+        assert result["choices"][0]["message"]["content"] == "AB"
+
+
+class TestReassembleSSEFile:
+    def test_round_trip(self, tmp_path):
+        lines = [
+            _make_sse_line({"type": "message_start", "message": {"id": "msg_99", "model": "claude-3", "usage": {"input_tokens": 7, "output_tokens": 0}}}),
+            _make_sse_line({"type": "content_block_delta", "delta": {"type": "text_delta", "text": "Done"}}),
+            _make_sse_line({"type": "message_delta", "delta": {"stop_reason": "end_turn"}, "usage": {"output_tokens": 3}}),
+        ]
+        path = tmp_path / "sse_response.txt"
+        path.write_text("\n".join(lines))
+        result = reassemble_sse_file(str(path), "anthropic")
+        assert result["id"] == "msg_99"
+        assert result["choices"][0]["message"]["content"] == "Done"
+
+
+class TestReassembleSSEToFile:
+    def test_overwrites_with_normalised_json(self, tmp_path):
+        lines = [
+            _make_sse_line({"type": "message_start", "message": {"id": "msg_1", "model": "c", "usage": {"input_tokens": 2, "output_tokens": 0}}}),
+            _make_sse_line({"type": "content_block_delta", "delta": {"type": "text_delta", "text": "Written"}}),
+            _make_sse_line({"type": "message_delta", "delta": {"stop_reason": "stop"}}),
+        ]
+        path = tmp_path / "out.txt"
+        path.write_text("\n".join(lines))
+        reassemble_sse_to_file(str(path), "anthropic")
+        result = json.loads(path.read_text())
+        assert result["id"] == "msg_1"
+        assert result["choices"][0]["message"]["content"] == "Written"
+
+
+if __name__ == "__main__":
+    unittest_main()


### PR DESCRIPTION
Fixes #36

## Summary

Completes the extraction of core logic from `run_review.sh` into testable Python modules. This is the remaining work after PR #64 which extracted `response_parser`.

## Modules Extracted

| Module | Responsibility | Lines removed from shell |
|--------|---------------|-------------------------|
| pr_reviewer/sse_reassembler.py | SSE streaming reassembly (OpenAI + Anthropic) | ~130 |
| pr_reviewer/enforcement.py | Verdict override logic, normalize_enforced_review_markdown() | ~50 |
| pr_reviewer/github_context.py | Linked issue reference extraction | ~22 |

## Changes to run_review.sh

- `reassemble_sse_response()` now delegates to `pr_reviewer.sse_reassembler.reassemble_sse_to_file`
- `normalize_enforced_review_markdown()` now delegates to `pr_reviewer.enforcement.normalize_enforced_review_markdown`
- Linked issue parsing now uses `pr_reviewer.github_context.extract_linked_issue_refs`

**run_review.sh reduced from 1103 → 936 lines (167 lines removed)**

## Acceptance Criteria

- [x] Existing behavior is preserved (all 162 unit tests pass)
- [x] Core logic is testable without GitHub Actions (SSE, enforcement, github_context modules have no bash dependencies)
- [x] Smoke test still passes (17/17)
- [x] Bash script reduced to orchestration
- [x] response_parser extraction from #64 already done
- [ ] Close #36 after merge