### PR TITLE
feat: add configurable model request timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,11 @@ The action gathers PR metadata, diff context, linked issue context from PR-closi
 | `tool_failure_enforcement` | Force `request_changes` when tool harness planning fails | No | `false` |
 | `tool_min_successful_requests` | Minimum successful tool requests required when `tool_failure_enforcement=true` | No | `0` |
 | `tool_enable_for_forks` | Allow tool harness on cross-repository PRs | No | `false` |
+| `ai_request_timeout_sec` | Timeout in seconds for the primary model API request (`curl --max-time`) | No | `300` |
+| `ai_connect_timeout_sec` | Timeout in seconds for the primary model API connection (`curl --connect-timeout`) | No | `30` |
+| `ai_fallback_request_timeout_sec` | Timeout in seconds for the fallback model API request (`curl --max-time`). Defaults to `ai_request_timeout_sec` when blank. | No | `""` |
+| `ai_fallback_connect_timeout_sec` | Timeout in seconds for the fallback model API connection (`curl --connect-timeout`). Defaults to `ai_connect_timeout_sec` when blank. | No | `""` |
+
 | `skip_if_diff_unchanged` | Skip the LLM review when the current PR patch matches the last managed review fingerprint | No | `true` |
 | `comment_marker` | HTML marker for the managed PR comment | No | `<!-- ai-pr-reviewer -->` |
 
@@ -255,6 +260,87 @@ merge policy.
 
 This configuration allows the AI to submit native approvals when its verdict is `approve`.
 Fork PRs are still blocked from approval unless `approve_forks` is also set to `"true"`.
+
+### Permissions per publish mode
+
+Each publish mode requires different GitHub token permissions:
+
+| Mode | Required permissions |
+|------|---------------------|
+| `comment` | `contents: read` (for repo metadata) |
+| `review_comment` | `contents: read`, `pull-requests: write` |
+| `review_verdict` | `contents: read`, `pull-requests: write` |
+
+The following copy-paste workflow example shows the full configuration for `publish_mode=review_verdict`:
+
+```yaml
+name: AI PR Review
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  review:
+    if: ${{ !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - uses: misospace/pr-reviewer-action@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          ai_base_url: https://api.openai.com/v1
+          ai_model: gpt-4.1
+          ai_api_key: ${{ secrets.OPENAI_API_KEY }}
+          publish_mode: review_verdict
+          allow_approve: "false"
+```
+
+### Why approvals may fail even with `pull-requests: write`
+
+Having the `pull-requests: write` permission in your workflow is necessary but not sufficient for native PR reviews to succeed. GitHub also enforces a repository or organization-level setting called **Allow GitHub Actions to create and approve pull requests**. If this setting is disabled, the `GITHUB_TOKEN` cannot submit native review verdicts (approve or request_changes), even when the workflow declares `pull-requests: write`.
+
+When this setting is not enabled, the action will fail with an error message from the GitHub API such as:
+
+```
+REST API v3 does not have a permission preview for pull_requests.
+You must use the Permissions API to manage permissions.
+```
+
+Or more commonly:
+
+```
+Resource not accessible by integration
+```
+
+To enable this setting:
+
+1. Go to **Settings** → **Actions** → **General** in your repository or organization.
+2. Under **Workflow permissions**, select **Allow GitHub Actions to create and approve pull requests**.
+3. Save the change.
+
+If you cannot enable this setting at the organization level, you can enable it per-repository through the same settings page.
+
+When native review publishing fails, the action logs a clear error message:
+
+```
+Native review publishing failed: unable to submit review verdict via GitHub API.
+Check that your workflow has pull-requests: write permission and that
+"Allow GitHub Actions to create and approve pull requests" is enabled in Settings → Actions → General.
+Consider using publish_mode=comment as a fallback.
+```
+
+This message appears in the workflow run logs and helps users diagnose the issue without needing to inspect the GitHub API response directly.
+
+### Non-blocking review comments
 
 ### Non-blocking review comments
 

--- a/action.yml
+++ b/action.yml
@@ -181,6 +181,22 @@ inputs:
     description: If true, allow the tool harness to run on cross-repository pull requests
     required: false
     default: "false"
+  ai_request_timeout_sec:
+    description: Timeout in seconds for the primary model API request (curl --max-time)
+    required: false
+    default: "300"
+  ai_connect_timeout_sec:
+    description: Timeout in seconds for the primary model API connection (curl --connect-timeout)
+    required: false
+    default: "30"
+  ai_fallback_request_timeout_sec:
+    description: Timeout in seconds for the fallback model API request (curl --max-time). Defaults to ai_request_timeout_sec when blank.
+    required: false
+    default: ""
+  ai_fallback_connect_timeout_sec:
+    description: Timeout in seconds for the fallback model API connection (curl --connect-timeout). Defaults to ai_connect_timeout_sec when blank.
+    required: false
+    default: ""
   skip_if_diff_unchanged:
     description: If true, skip the LLM review when the effective PR diff matches the last managed review comment fingerprint
     required: false
@@ -258,6 +274,10 @@ runs:
         TOOL_FAILURE_ENFORCEMENT: ${{ inputs.tool_failure_enforcement }}
         TOOL_MIN_SUCCESSFUL_REQUESTS: ${{ inputs.tool_min_successful_requests }}
         TOOL_ENABLE_FOR_FORKS: ${{ inputs.tool_enable_for_forks }}
+        AI_REQUEST_TIMEOUT_SEC: ${{ inputs.ai_request_timeout_sec }}
+        AI_CONNECT_TIMEOUT_SEC: ${{ inputs.ai_connect_timeout_sec }}
+        AI_FALLBACK_REQUEST_TIMEOUT_SEC: ${{ inputs.ai_fallback_request_timeout_sec }}
+        AI_FALLBACK_CONNECT_TIMEOUT_SEC: ${{ inputs.ai_fallback_connect_timeout_sec }}
       run: bash "${{ github.action_path }}/scripts/check_review_needed.sh"
 
     - name: Run AI review
@@ -304,6 +324,10 @@ runs:
         TOOL_FAILURE_ENFORCEMENT: ${{ inputs.tool_failure_enforcement }}
         TOOL_MIN_SUCCESSFUL_REQUESTS: ${{ inputs.tool_min_successful_requests }}
         TOOL_ENABLE_FOR_FORKS: ${{ inputs.tool_enable_for_forks }}
+        AI_REQUEST_TIMEOUT_SEC: ${{ inputs.ai_request_timeout_sec }}
+        AI_CONNECT_TIMEOUT_SEC: ${{ inputs.ai_connect_timeout_sec }}
+        AI_FALLBACK_REQUEST_TIMEOUT_SEC: ${{ inputs.ai_fallback_request_timeout_sec }}
+        AI_FALLBACK_CONNECT_TIMEOUT_SEC: ${{ inputs.ai_fallback_connect_timeout_sec }}
       run: bash "${{ github.action_path }}/scripts/run_review.sh"
 
     - name: Publish review comment

--- a/scripts/run_review.sh
+++ b/scripts/run_review.sh
@@ -59,6 +59,10 @@ TOOL_ALLOWED_GH_API_REPOS="${TOOL_ALLOWED_GH_API_REPOS:-}"
 TOOL_FAILURE_ENFORCEMENT="${TOOL_FAILURE_ENFORCEMENT:-false}"
 TOOL_MIN_SUCCESSFUL_REQUESTS="${TOOL_MIN_SUCCESSFUL_REQUESTS:-0}"
 TOOL_ENABLE_FOR_FORKS="${TOOL_ENABLE_FOR_FORKS:-false}"
+AI_REQUEST_TIMEOUT_SEC="${AI_REQUEST_TIMEOUT_SEC:-300}"
+AI_CONNECT_TIMEOUT_SEC="${AI_CONNECT_TIMEOUT_SEC:-30}"
+AI_FALLBACK_REQUEST_TIMEOUT_SEC="${AI_FALLBACK_REQUEST_TIMEOUT_SEC:-${AI_REQUEST_TIMEOUT_SEC}}"
+AI_FALLBACK_CONNECT_TIMEOUT_SEC="${AI_FALLBACK_CONNECT_TIMEOUT_SEC:-${AI_CONNECT_TIMEOUT_SEC}}"
 OUTPUT_FILE="${GITHUB_OUTPUT:-/dev/null}"
 
 apply_context_limits() {
@@ -176,6 +180,8 @@ curl_model() {
   local payload_file="$4"
   local output_file="$5"
   local stream="${6:-false}"
+  local request_timeout_sec="${7:-300}"
+  local connect_timeout_sec="${8:-30}"
 
   local endpoint
   local auth_header=()
@@ -198,6 +204,8 @@ curl_model() {
     "$endpoint"
     -H "Content-Type: application/json"
     --data "@$payload_file"
+    --max-time "$request_timeout_sec"
+    --connect-timeout "$connect_timeout_sec"
   )
 
   args+=( "${auth_header[@]}" )
@@ -789,7 +797,7 @@ PRIMARY_OK=0
 ATTEMPT=1
 while [ "$ATTEMPT" -le "$AI_PRIMARY_RETRIES" ]; do
   echo "Primary model attempt ${ATTEMPT}/${AI_PRIMARY_RETRIES}: $AI_MODEL @ $AI_BASE_URL ($AI_API_FORMAT)"
-  if curl_model "$AI_BASE_URL" "$AI_API_KEY" "$AI_API_FORMAT" ai-request.primary.json ai-response.primary.json "$STREAM_BOOL" && \
+  if curl_model "$AI_BASE_URL" "$AI_API_KEY" "$AI_API_FORMAT" ai-request.primary.json ai-response.primary.json "$STREAM_BOOL" "$AI_REQUEST_TIMEOUT_SEC" "$AI_CONNECT_TIMEOUT_SEC" && \
     { [[ "$STREAM_BOOL" != "true" ]] || reassemble_sse_response ai-response.primary.json "$AI_API_FORMAT"; } && \
     parse_and_validate ai-response.primary.json; then
     PRIMARY_OK=1
@@ -827,7 +835,7 @@ else
     ai-request.fallback.json \
     "$FALLBACK_STREAM_BOOL"
 
-  if curl_model "$AI_FALLBACK_BASE_URL" "$AI_FALLBACK_API_KEY" "$AI_FALLBACK_API_FORMAT" ai-request.fallback.json ai-response.fallback.json "$FALLBACK_STREAM_BOOL" && \
+  if curl_model "$AI_FALLBACK_BASE_URL" "$AI_FALLBACK_API_KEY" "$AI_FALLBACK_API_FORMAT" ai-request.fallback.json ai-response.fallback.json "$FALLBACK_STREAM_BOOL" "$AI_FALLBACK_REQUEST_TIMEOUT_SEC" "$AI_FALLBACK_CONNECT_TIMEOUT_SEC" && \
     { [[ "$FALLBACK_STREAM_BOOL" != "true" ]] || reassemble_sse_response ai-response.fallback.json "$AI_FALLBACK_API_FORMAT"; } && \
     parse_and_validate ai-response.fallback.json; then
     ANALYSIS_ENGINE="$AI_FALLBACK_MODEL@$AI_FALLBACK_BASE_URL ($AI_FALLBACK_API_FORMAT)"


### PR DESCRIPTION
Fixes #37

Add four new inputs for configurable timeout behavior on primary and fallback AI model API calls:

- `ai_request_timeout_sec` — `curl --max-time` for the primary model (default: 300s)
- `ai_connect_timeout_sec` — `curl --connect-timeout` for the primary model (default: 30s)
- `ai_fallback_request_timeout_sec` — `curl --max-time` for the fallback model (defaults to `ai_request_timeout_sec` when blank)
- `ai_fallback_connect_timeout_sec` — `curl --connect-timeout` for the fallback model (defaults to `ai_connect_timeout_sec` when blank)

Changes:
- **action.yml**: 4 new inputs + env var passthrough to both workflow steps
- **scripts/run_review.sh**: `curl_model()` now accepts request/connect timeout params and passes `--max-time` / `--connect-timeout` to curl; fallback timeouts default to primary values when blank
- **README.md**: Documents all 4 new inputs in the inputs table