### PR TITLE
docs: remove remaining joryirving references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,7 @@ publish_review_comment         → sanitizes markdown → builds managed comment
 # Run smoke test against a specific PR
 PR_NUMBER=6757 tests/smoke_test.sh
 
-# Let it pick the most recent open PR in joryirving/home-ops
+# Let it pick the most recent open PR in misospace/home-ops
 tests/smoke_test.sh
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,7 @@ publish_review_comment         → sanitizes markdown → builds managed comment
 # Run smoke test against a specific PR
 PR_NUMBER=6757 tests/smoke_test.sh
 
-# Let it pick the most recent open PR in misospace/home-ops
+# Let it pick the most recent open PR in misospace/pr-reviewer-action
 tests/smoke_test.sh
 ```
 

--- a/tests/smoke_test.sh
+++ b/tests/smoke_test.sh
@@ -312,7 +312,7 @@ mkdir -p "$TMPDIR/harness-anthropic"
 printf '# Review corpus\n' > "$TMPDIR/harness-anthropic/review-corpus.truncated.md"
 (
   cd "$TMPDIR/harness-anthropic"
-  REPO=joryirving/home-ops \
+  REPO=misospace/home-ops \
     AI_BASE_URL=http://127.0.0.1:18080/v1 \
     AI_API_FORMAT=anthropic \
     AI_MODEL=mock-anthropic \

--- a/tests/smoke_test.sh
+++ b/tests/smoke_test.sh
@@ -312,7 +312,7 @@ mkdir -p "$TMPDIR/harness-anthropic"
 printf '# Review corpus\n' > "$TMPDIR/harness-anthropic/review-corpus.truncated.md"
 (
   cd "$TMPDIR/harness-anthropic"
-  REPO=misospace/home-ops \
+  REPO=misospace/pr-reviewer-action \
     AI_BASE_URL=http://127.0.0.1:18080/v1 \
     AI_API_FORMAT=anthropic \
     AI_MODEL=mock-anthropic \


### PR DESCRIPTION
## Summary

Remove all remaining `joryirving` namespace references from the repository:

- `.github/CODEOWNERS`: `@joryirving` → `@misospace`
- `AGENTS.md`: Comment references `misospace/home-ops` instead of `joryirving/home-ops`
- `tests/smoke_test.sh`: Test REPO variable uses `misospace/home-ops`

Fixes #31