### PR TITLE
docs: add clear error messages when native review publishing fails

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -475,7 +475,13 @@ runs:
 
         if [ "$CAN_APPROVE" = true ]; then
           echo "Submitting native approval for #$PR_NUMBER"
-          gh pr review "$PR_NUMBER" --repo "$REPO" --approve --body-file "$BODY_FILE"
+          if ! gh pr review "$PR_NUMBER" --repo "$REPO" --approve --body-file "$BODY_FILE" 2>&1; then
+            echo "ERROR: Native approval failed for #$PR_NUMBER." >&2
+            echo "This may be caused by the 'Allow GitHub Actions to create and approve pull requests' setting being disabled." >&2
+            echo "Enable this setting at: Repository Settings → Actions → General → Allow GitHub Actions to create and approve pull requests" >&2
+            echo "Or at the organization level: Organization Settings → Actions → Organization permissions → Allow GitHub Actions to create and approve pull requests" >&2
+            exit 1
+          fi
         else
           # Block approval: submit request_changes with explanation
           echo "Blocking native approval for #$PR_NUMBER (allow_approve=${ALLOW_APPROVE_BOOL}, approve_forks=${APPROVE_FORKS_BOOL}, is_fork=${IS_FORK_PR})"
@@ -486,7 +492,7 @@ runs:
             # Model approved but guardrails blocked it
             {
               echo ""
-              echo "> **Approval blocked by policy**: This workflow requires `allow_approve: true` to submit native approvals. Set that input to enable automatic approval."
+              echo "> **Approval blocked by policy**: This workflow requires \`allow_approve: true\` to submit native approvals. Set that input to enable automatic approval."
             } >> "$BODY_FILE"
 
             gh pr review "$PR_NUMBER" --repo "$REPO" --request-changes --body-file "$BODY_FILE"


### PR DESCRIPTION
## Summary

Adds clear, actionable error messages when native PR review publishing fails. When `gh pr review --approve` exits non-zero, the action now:

1. Reports that native approval failed
2. Explains the likely cause: **"Allow GitHub Actions to create and approve pull requests"** setting is disabled
3. Provides direct links to both repository and organization settings paths

This directly addresses the issue's acceptance criterion: **"Failure messages are clear when native review publishing fails."**

## Changes

- `action.yml`: Wrap `gh pr review --approve` in an error handler that outputs the actionable message

## Testing

- Verified the error message correctly references the GitHub Actions setting paths

Fixes #42