### PR TITLE
Add .gitignore with sane defaults

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,27 @@
+# Python
+__pycache__/
+*.py[cod]
+*.egg-info/
+dist/
+build/
+*.egg
+.venv/
+venv/
+
+# Node.js (if used for testing)
+node_modules/
+npm-debug.log*
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Mock server artifacts
+test_uploads/


### PR DESCRIPTION
Covers Python artifacts (`__pycache__/`, `*.pyc`), IDE files, OS junk (`.DS_Store`), and test artifacts used by the smoke test mock server.

Keeps the working tree clean after running scripts locally.