### PR TITLE
refactor: use pytest assert idioms in test_model_parsing.py

### DIFF
--- a/tests/test_model_parsing.py
+++ b/tests/test_model_parsing.py
@@ -17,6 +17,8 @@ Tests are self-contained (no external services) and run via:
 import json
 import sys
 
+import pytest
+
 
 def parse_and_validate(response_dict):
     """Parse model response dict and return the extracted review dict."""
@@ -200,41 +202,6 @@ def reassemble_openai_sse(sse_text):
     }
 
 
-class Result:
-    """Track pass/fail counts."""
-    def __init__(self):
-        self.passed = 0
-        self.failed = 0
-        self.failures = []
-
-    def ok(self, desc, got, expected):
-        if got == expected:
-            self.passed += 1
-            print(f"  PASS: {desc}")
-        else:
-            self.failed += 1
-            msg = f"  FAIL: {desc} (got {got!r}, expected {expected!r})"
-            self.failures.append(msg)
-            print(msg)
-
-    def ok_raises(self, desc, fn, expected_msg_sub=None):
-        try:
-            fn()
-            self.failed += 1
-            msg = f"  FAIL: {desc} (expected SystemExit, got success)"
-            self.failures.append(msg)
-            print(msg)
-        except SystemExit as e:
-            if expected_msg_sub and expected_msg_sub not in str(e):
-                self.failed += 1
-                msg = f"  FAIL: {desc} (expected '{expected_msg_sub}' in error, got '{e}')"
-                self.failures.append(msg)
-                print(msg)
-            else:
-                self.passed += 1
-                print(f"  PASS: {desc}")
-
-
 def _sse_line(obj):
     """Build a single SSE data line from a Python dict."""
     return "data: " + json.dumps(obj)
@@ -250,7 +217,6 @@ def _sse_block(lines):
 # ---------------------------------------------------------------------------
 
 def test_openai_nonstream_standard():
-    r = Result()
     resp = {
         "id": "chatcmpl-test",
         "choices": [{
@@ -261,13 +227,11 @@ def test_openai_nonstream_standard():
         }]
     }
     parsed = parse_and_validate(resp)
-    r.ok("verdict=approve", parsed["verdict"], "approve")
-    r.ok("review_markdown present", len(parsed.get("review_markdown", "")), 11)
-    return r
+    assert parsed["verdict"] == "approve"
+    assert len(parsed.get("review_markdown", "")) == 11
 
 
 def test_openai_nonstream_array_wrapped():
-    r = Result()
     resp = {
         "id": "chatcmpl-test",
         "choices": [{
@@ -278,20 +242,17 @@ def test_openai_nonstream_array_wrapped():
         }]
     }
     parsed = parse_and_validate(resp)
-    r.ok("verdict=request_changes", parsed["verdict"], "request_changes")
-    r.ok("review_markdown present", len(parsed.get("review_markdown", "")), 11)
-    return r
+    assert parsed["verdict"] == "request_changes"
+    assert len(parsed.get("review_markdown", "")) == 11
 
 
 def test_openai_nonstream_string_content():
-    r = Result()
     resp = {
         "id": "msg-test",
         "content": json.dumps({"verdict":"approve","review_markdown":"Direct string."})
     }
     parsed = parse_and_validate(resp)
-    r.ok("verdict=approve from string content", parsed["verdict"], "approve")
-    return r
+    assert parsed["verdict"] == "approve"
 
 
 # ---------------------------------------------------------------------------
@@ -299,7 +260,6 @@ def test_openai_nonstream_string_content():
 # ---------------------------------------------------------------------------
 
 def test_anthropic_nonstream_text_blocks():
-    r = Result()
     resp = {
         "id": "msg-test",
         "type": "message",
@@ -311,25 +271,22 @@ def test_anthropic_nonstream_text_blocks():
         ]
     }
     parsed = parse_and_validate(resp)
-    r.ok("verdict=approve", parsed["verdict"], "approve")
-    r.ok("review_markdown correct", parsed.get("review_markdown"), "Anthropic clean.")
-    return r
+    assert parsed["verdict"] == "approve"
+    assert parsed.get("review_markdown") == "Anthropic clean."
 
 
 def test_anthropic_nonstream_only_thinking():
-    r = Result()
     resp = {
         "id": "msg-test",
         "type": "message",
         "role": "assistant",
         "content": [{"type": "thinking", "thinking": "just thinking"}]
     }
-    r.ok_raises("rejects only-thinking response", lambda: parse_and_validate(resp))
-    return r
+    with pytest.raises(SystemExit, match="Could not extract JSON"):
+        parse_and_validate(resp)
 
 
 def test_anthropic_nonstream_mixed_text_list():
-    r = Result()
     resp = {
         "id": "msg-test",
         "type": "message",
@@ -341,8 +298,7 @@ def test_anthropic_nonstream_mixed_text_list():
         ]
     }
     parsed = parse_and_validate(resp)
-    r.ok("verdict=approve from mixed list", parsed["verdict"], "approve")
-    return r
+    assert parsed["verdict"] == "approve"
 
 
 # ---------------------------------------------------------------------------
@@ -350,7 +306,6 @@ def test_anthropic_nonstream_mixed_text_list():
 # ---------------------------------------------------------------------------
 
 def test_openai_sse_single_delta():
-    r = Result()
     review_json = json.dumps({"verdict":"approve","review_markdown":"Single delta."})
     sse = _sse_block([
         _sse_line({"id":"chatcmpl-1","object":"chat.completion.chunk","model":"gpt-4","choices":[{"index":0,"delta":{"role":"assistant"}}]}),
@@ -360,15 +315,13 @@ def test_openai_sse_single_delta():
     ])
     assembled = reassemble_openai_sse(sse)
     parsed = parse_and_validate(assembled)
-    r.ok("verdict=approve", parsed["verdict"], "approve")
-    r.ok("review_markdown correct", parsed.get("review_markdown"), "Single delta.")
-    r.ok("model propagated", assembled["model"], "gpt-4")
-    r.ok("id propagated", assembled["id"], "chatcmpl-1")
-    return r
+    assert parsed["verdict"] == "approve"
+    assert parsed.get("review_markdown") == "Single delta."
+    assert assembled["model"] == "gpt-4"
+    assert assembled["id"] == "chatcmpl-1"
 
 
 def test_openai_sse_multiple_deltas():
-    r = Result()
     review = json.dumps({"verdict":"request_changes","review_markdown":"Multi chunk."})
     mid_point = len(review) // 2
     part1 = review[:mid_point]
@@ -383,13 +336,11 @@ def test_openai_sse_multiple_deltas():
     ])
     assembled = reassemble_openai_sse(sse)
     parsed = parse_and_validate(assembled)
-    r.ok("verdict=request_changes", parsed["verdict"], "request_changes")
-    r.ok("review_markdown correct", parsed.get("review_markdown"), "Multi chunk.")
-    return r
+    assert parsed["verdict"] == "request_changes"
+    assert parsed.get("review_markdown") == "Multi chunk."
 
 
 def test_openai_sse_with_usage():
-    r = Result()
     review_json = json.dumps({"verdict":"approve","review_markdown":"With usage."})
     sse = _sse_block([
         _sse_line({"id":"chatcmpl-3","object":"chat.completion.chunk","model":"gpt-4","choices":[{"index":0,"delta":{"content":review_json}}]}),
@@ -397,16 +348,14 @@ def test_openai_sse_with_usage():
         "data: [DONE]",
     ])
     assembled = reassemble_openai_sse(sse)
-    r.ok("prompt_tokens tracked", assembled["usage"]["prompt_tokens"], 100)
-    r.ok("completion_tokens tracked", assembled["usage"]["completion_tokens"], 50)
-    r.ok("total_tokens correct", assembled["usage"]["total_tokens"], 150)
+    assert assembled["usage"]["prompt_tokens"] == 100
+    assert assembled["usage"]["completion_tokens"] == 50
+    assert assembled["usage"]["total_tokens"] == 150
     parsed = parse_and_validate(assembled)
-    r.ok("parsed verdict after reassembly", parsed["verdict"], "approve")
-    return r
+    assert parsed["verdict"] == "approve"
 
 
 def test_openai_sse_with_blank_lines():
-    r = Result()
     review_json = json.dumps({"verdict":"approve","review_markdown":"Blank lines."})
     sse = _sse_block([
         _sse_line({"id":"chatcmpl-4","choices":[{"delta":{"content":review_json}}]}),
@@ -414,8 +363,7 @@ def test_openai_sse_with_blank_lines():
     ])
     assembled = reassemble_openai_sse(sse)
     parsed = parse_and_validate(assembled)
-    r.ok("handles blank lines", parsed["verdict"], "approve")
-    return r
+    assert parsed["verdict"] == "approve"
 
 
 # ---------------------------------------------------------------------------
@@ -423,7 +371,6 @@ def test_openai_sse_with_blank_lines():
 # ---------------------------------------------------------------------------
 
 def test_anthropic_sse_text_delta():
-    r = Result()
     review_json = json.dumps({"verdict":"approve","review_markdown":"Streamed clean."})
     mid = len(review_json) // 2
     part1 = review_json[:mid]
@@ -440,15 +387,13 @@ def test_anthropic_sse_text_delta():
     ])
     assembled = reassemble_anthropic_sse(sse)
     parsed = parse_and_validate(assembled)
-    r.ok("verdict=approve", parsed["verdict"], "approve")
-    r.ok("review_markdown correct", parsed.get("review_markdown"), "Streamed clean.")
-    r.ok("model propagated", assembled["model"], "claude-3-5-sonnet")
-    r.ok("message_id propagated", assembled["id"], "msg_smoke")
-    return r
+    assert parsed["verdict"] == "approve"
+    assert parsed.get("review_markdown") == "Streamed clean."
+    assert assembled["model"] == "claude-3-5-sonnet"
+    assert assembled["id"] == "msg_smoke"
 
 
 def test_anthropic_sse_thinking_ignored():
-    r = Result()
     review_json = json.dumps({"verdict":"request_changes","review_markdown":"After thinking."})
     sse = _sse_block([
         _sse_line({"type":"message_start","message":{"id":"msg-think","model":"claude-3-5-sonnet"}}),
@@ -463,15 +408,13 @@ def test_anthropic_sse_thinking_ignored():
     ])
     assembled = reassemble_anthropic_sse(sse)
     content = assembled["choices"][0]["message"]["content"]
-    r.ok("thinking excluded from content", "private reasoning" not in content, True)
+    assert "private reasoning" not in content
     parsed = parse_and_validate(assembled)
-    r.ok("verdict=request_changes", parsed["verdict"], "request_changes")
-    r.ok("review_markdown correct", parsed.get("review_markdown"), "After thinking.")
-    return r
+    assert parsed["verdict"] == "request_changes"
+    assert parsed.get("review_markdown") == "After thinking."
 
 
 def test_anthropic_sse_tool_use_ignored():
-    r = Result()
     review_json = json.dumps({"verdict":"approve","review_markdown":"Tool blocks ignored."})
     sse = _sse_block([
         _sse_line({"type":"message_start","message":{"id":"msg-tool","model":"claude-3-5-sonnet"}}),
@@ -486,16 +429,14 @@ def test_anthropic_sse_tool_use_ignored():
     ])
     assembled = reassemble_anthropic_sse(sse)
     content = assembled["choices"][0]["message"]["content"]
-    r.ok("tool_use input_json excluded", "input_json" not in content, True)
-    r.ok("tool_use name excluded", "read_file" not in content, True)
+    assert "input_json" not in content
+    assert "read_file" not in content
     parsed = parse_and_validate(assembled)
-    r.ok("verdict=approve", parsed["verdict"], "approve")
-    r.ok("review_markdown correct", parsed.get("review_markdown"), "Tool blocks ignored.")
-    return r
+    assert parsed["verdict"] == "approve"
+    assert parsed.get("review_markdown") == "Tool blocks ignored."
 
 
 def test_anthropic_sse_empty_stream():
-    r = Result()
     sse = _sse_block([
         _sse_line({"type":"message_start","message":{"id":"msg-empty","model":"claude-3-5-sonnet"}}),
         _sse_line({"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"only thinking"}}),
@@ -503,13 +444,12 @@ def test_anthropic_sse_empty_stream():
         _sse_line({"type":"message_stop"}),
     ])
     assembled = reassemble_anthropic_sse(sse)
-    r.ok("empty content after reassembly", assembled["choices"][0]["message"]["content"], "")
-    r.ok_raises("empty stream rejected by parser", lambda: parse_and_validate(assembled))
-    return r
+    assert assembled["choices"][0]["message"]["content"] == ""
+    with pytest.raises(SystemExit, match="Could not extract JSON"):
+        parse_and_validate(assembled)
 
 
 def test_anthropic_sse_text_type_alias():
-    r = Result()
     review_json = json.dumps({"verdict":"approve","review_markdown":"Type alias."})
     sse = _sse_block([
         _sse_line({"type":"message_start","message":{"id":"msg-alias","model":"claude-3-5-sonnet"}}),
@@ -518,8 +458,7 @@ def test_anthropic_sse_text_type_alias():
     ])
     assembled = reassemble_anthropic_sse(sse)
     parsed = parse_and_validate(assembled)
-    r.ok("handles text type alias", parsed["verdict"], "approve")
-    return r
+    assert parsed["verdict"] == "approve"
 
 
 # ---------------------------------------------------------------------------
@@ -527,52 +466,45 @@ def test_anthropic_sse_text_type_alias():
 # ---------------------------------------------------------------------------
 
 def test_malformed_bare_numeric_list():
-    r = Result()
     resp = {"id": "chatcmpl-test", "choices": [{"message": {"content": "[1,2,3]"}}]}
-    r.ok_raises("rejects bare numeric list", lambda: parse_and_validate(resp))
-    return r
+    with pytest.raises(SystemExit):
+        parse_and_validate(resp)
 
 
 def test_malformed_empty_array():
-    r = Result()
     resp = {"id": "chatcmpl-test", "choices": [{"message": {"content": "[]"}}]}
-    r.ok_raises("rejects empty array", lambda: parse_and_validate(resp))
-    return r
+    with pytest.raises(SystemExit):
+        parse_and_validate(resp)
 
 
 def test_malformed_non_json_prose():
-    r = Result()
     resp = {"id": "chatcmpl-test", "choices": [{"message": {"content": "I can't help with that right now."}}]}
-    r.ok_raises("rejects pure prose", lambda: parse_and_validate(resp))
-    return r
+    with pytest.raises(SystemExit):
+        parse_and_validate(resp)
 
 
 def test_malformed_invalid_json():
-    r = Result()
     resp = {"id": "chatcmpl-test", "choices": [{"message": {"content": '{"verdict":"approve","review_markdown":broken}'}}]}
-    r.ok_raises("rejects broken JSON", lambda: parse_and_validate(resp))
-    return r
+    with pytest.raises(SystemExit):
+        parse_and_validate(resp)
 
 
 def test_malformed_empty_content():
-    r = Result()
     resp = {"id": "chatcmpl-test", "choices": [{"message": {"content": ""}}]}
-    r.ok_raises("rejects empty content", lambda: parse_and_validate(resp))
-    return r
+    with pytest.raises(SystemExit):
+        parse_and_validate(resp)
 
 
 def test_malformed_none_content():
-    r = Result()
     resp = {"id": "chatcmpl-test", "choices": [{"message": {"content": None}}]}
-    r.ok_raises("rejects null content", lambda: parse_and_validate(resp))
-    return r
+    with pytest.raises(SystemExit):
+        parse_and_validate(resp)
 
 
 def test_malformed_missing_choices():
-    r = Result()
     resp = {"id": "chatcmpl-test", "choices": []}
-    r.ok_raises("rejects empty choices array", lambda: parse_and_validate(resp))
-    return r
+    with pytest.raises(SystemExit):
+        parse_and_validate(resp)
 
 
 # ---------------------------------------------------------------------------
@@ -580,7 +512,6 @@ def test_malformed_missing_choices():
 # ---------------------------------------------------------------------------
 
 def test_edge_markdown_fence_variants():
-    r = Result()
     for lang in ["json", "", "JSON"]:
         fence_start = f"```{lang}" if lang else "```"
         resp = {
@@ -588,59 +519,49 @@ def test_edge_markdown_fence_variants():
             "choices": [{"message": {"content": f"{fence_start}\n{{\"verdict\":\"approve\",\"review_markdown\":\"Fence: {lang}\"}}\n```"}}]
         }
         parsed = parse_and_validate(resp)
-        r.ok(f"verdict with fence lang={lang!r}", parsed["verdict"], "approve")
-    return r
+        assert parsed["verdict"] == "approve"
 
 
 def test_edge_leading_trailing_prose():
-    r = Result()
     resp = {
         "id": "chatcmpl-test",
         "choices": [{"message": {"content": "Here is my review:\n\n{\"verdict\":\"approve\",\"review_markdown\":\"Clean PR.\"}\n\nLet me know if you need anything else."}}]
     }
     parsed = parse_and_validate(resp)
-    r.ok("verdict from prose-wrapped JSON", parsed["verdict"], "approve")
-    r.ok("review_markdown correct", parsed.get("review_markdown"), "Clean PR.")
-    return r
+    assert parsed["verdict"] == "approve"
+    assert parsed.get("review_markdown") == "Clean PR."
 
 
 def test_edge_single_item_array():
-    r = Result()
     resp = {
         "id": "chatcmpl-test",
         "choices": [{"message": {"content": "[{\"verdict\":\"request_changes\",\"review_markdown\":\"Needs fixes.\"}]"}}]
     }
     parsed = parse_and_validate(resp)
-    r.ok("unwrapped single-item array", parsed["verdict"], "request_changes")
-    r.ok("review_markdown from unwrapped", parsed.get("review_markdown"), "Needs fixes.")
-    return r
+    assert parsed["verdict"] == "request_changes"
+    assert parsed.get("review_markdown") == "Needs fixes."
 
 
 def test_edge_single_item_array_wrapped_in_fence():
-    r = Result()
     resp = {
         "id": "chatcmpl-test",
         "choices": [{"message": {"content": "```json\n[{\"verdict\":\"approve\",\"review_markdown\":\"Fenced array.\"}]\n```"}}]
     }
     parsed = parse_and_validate(resp)
-    r.ok("unwrapped fenced array", parsed["verdict"], "approve")
-    return r
+    assert parsed["verdict"] == "approve"
 
 
 def test_edge_invalid_verdict_values():
-    r = Result()
     for verdict in ["unknown", "ERROR", "", "approve_extra"]:
         resp = {
             "id": "chatcmpl-test",
             "choices": [{"message": {"content": json.dumps({"verdict": verdict, "review_markdown": "test"})}}]
         }
         parsed = parse_and_validate(resp)
-        r.ok(f"parser accepts verdict={verdict!r}", parsed.get("verdict"), verdict)
-    return r
+        assert parsed.get("verdict") == verdict
 
 
 def test_edge_sse_corrupted_chunk():
-    r = Result()
     review_json = json.dumps({"verdict":"approve","review_markdown":"Corrupted skip."})
     sse_lines = [
         _sse_line({"id":"chatcmpl-5","choices":[{"delta":{"content":review_json}}]}),
@@ -651,12 +572,10 @@ def test_edge_sse_corrupted_chunk():
     sse = "\n\n".join(sse_lines)
     assembled = reassemble_openai_sse(sse)
     parsed = parse_and_validate(assembled)
-    r.ok("handles corrupted SSE chunk", parsed["verdict"], "approve")
-    return r
+    assert parsed["verdict"] == "approve"
 
 
 def test_edge_anthropic_usage_accumulation():
-    r = Result()
     review_json = json.dumps({"verdict":"approve","review_markdown":"Usage accumulation."})
     sse = _sse_block([
         _sse_line({"type":"message_start","message":{"id":"msg-usage","model":"claude-3-5-sonnet","usage":{"input_tokens":100,"output_tokens":0}}}),
@@ -665,10 +584,9 @@ def test_edge_anthropic_usage_accumulation():
         _sse_line({"type":"message_stop"}),
     ])
     assembled = reassemble_anthropic_sse(sse)
-    r.ok("input_tokens from message_start", assembled["usage"]["prompt_tokens"], 100)
-    r.ok("output_tokens accumulated", assembled["usage"]["completion_tokens"], 50)
-    r.ok("total_tokens correct", assembled["usage"]["total_tokens"], 150)
-    return r
+    assert assembled["usage"]["prompt_tokens"] == 100
+    assert assembled["usage"]["completion_tokens"] == 50
+    assert assembled["usage"]["total_tokens"] == 150
 
 
 # ---------------------------------------------------------------------------
@@ -680,55 +598,68 @@ def main():
     print("Model Parsing & SSE Reassembly Tests")
     print("=" * 60)
 
-    all_results = []
+    test_functions = [
+        ("OpenAI Non-Stream Response Parsing", [
+            test_openai_nonstream_standard,
+            test_openai_nonstream_array_wrapped,
+            test_openai_nonstream_string_content,
+        ]),
+        ("Anthropic Non-Stream Response Parsing", [
+            test_anthropic_nonstream_text_blocks,
+            test_anthropic_nonstream_only_thinking,
+            test_anthropic_nonstream_mixed_text_list,
+        ]),
+        ("OpenAI SSE Reassembly", [
+            test_openai_sse_single_delta,
+            test_openai_sse_multiple_deltas,
+            test_openai_sse_with_usage,
+            test_openai_sse_with_blank_lines,
+        ]),
+        ("Anthropic SSE Reassembly", [
+            test_anthropic_sse_text_delta,
+            test_anthropic_sse_thinking_ignored,
+            test_anthropic_sse_tool_use_ignored,
+            test_anthropic_sse_empty_stream,
+            test_anthropic_sse_text_type_alias,
+        ]),
+        ("Invalid / Malformed Outputs", [
+            test_malformed_bare_numeric_list,
+            test_malformed_empty_array,
+            test_malformed_non_json_prose,
+            test_malformed_invalid_json,
+            test_malformed_empty_content,
+            test_malformed_none_content,
+            test_malformed_missing_choices,
+        ]),
+        ("Edge Cases & Boundary Conditions", [
+            test_edge_markdown_fence_variants,
+            test_edge_leading_trailing_prose,
+            test_edge_single_item_array,
+            test_edge_single_item_array_wrapped_in_fence,
+            test_edge_invalid_verdict_values,
+            test_edge_sse_corrupted_chunk,
+            test_edge_anthropic_usage_accumulation,
+        ]),
+    ]
 
-    print("\n--- OpenAI Non-Stream Response Parsing ---")
-    all_results.append(test_openai_nonstream_standard())
-    all_results.append(test_openai_nonstream_array_wrapped())
-    all_results.append(test_openai_nonstream_string_content())
-
-    print("\n--- Anthropic Non-Stream Response Parsing ---")
-    all_results.append(test_anthropic_nonstream_text_blocks())
-    all_results.append(test_anthropic_nonstream_only_thinking())
-    all_results.append(test_anthropic_nonstream_mixed_text_list())
-
-    print("\n--- OpenAI SSE Reassembly ---")
-    all_results.append(test_openai_sse_single_delta())
-    all_results.append(test_openai_sse_multiple_deltas())
-    all_results.append(test_openai_sse_with_usage())
-    all_results.append(test_openai_sse_with_blank_lines())
-
-    print("\n--- Anthropic SSE Reassembly ---")
-    all_results.append(test_anthropic_sse_text_delta())
-    all_results.append(test_anthropic_sse_thinking_ignored())
-    all_results.append(test_anthropic_sse_tool_use_ignored())
-    all_results.append(test_anthropic_sse_empty_stream())
-    all_results.append(test_anthropic_sse_text_type_alias())
-
-    print("\n--- Invalid / Malformed Outputs ---")
-    all_results.append(test_malformed_bare_numeric_list())
-    all_results.append(test_malformed_empty_array())
-    all_results.append(test_malformed_non_json_prose())
-    all_results.append(test_malformed_invalid_json())
-    all_results.append(test_malformed_empty_content())
-    all_results.append(test_malformed_none_content())
-    all_results.append(test_malformed_missing_choices())
-
-    print("\n--- Edge Cases & Boundary Conditions ---")
-    all_results.append(test_edge_markdown_fence_variants())
-    all_results.append(test_edge_leading_trailing_prose())
-    all_results.append(test_edge_single_item_array())
-    all_results.append(test_edge_single_item_array_wrapped_in_fence())
-    all_results.append(test_edge_invalid_verdict_values())
-    all_results.append(test_edge_sse_corrupted_chunk())
-    all_results.append(test_edge_anthropic_usage_accumulation())
-
-    total_passed = sum(r.passed for r in all_results)
-    total_failed = sum(r.failed for r in all_results)
-    total = total_passed + total_failed
+    total_passed = 0
+    total_failed = 0
     failures = []
-    for r in all_results:
-        failures.extend(r.failures)
+
+    for section_name, tests in test_functions:
+        print(f"\n--- {section_name} ---")
+        for test_fn in tests:
+            try:
+                test_fn()
+                print(f"  PASS: {test_fn.__name__}")
+                total_passed += 1
+            except Exception as e:
+                total_failed += 1
+                msg = f"  FAIL: {test_fn.__name__}: {e}"
+                failures.append(msg)
+                print(msg)
+
+    total = total_passed + total_failed
 
     if failures:
         print("\n--- Failures ---")


### PR DESCRIPTION
Replaces the custom `Result` class pattern with standard `assert` statements and `pytest.raises()` matchers, eliminating all 29 `PytestReturnNotNoneWarning` warnings emitted by pytest.

**Changes:**
- Removed `Result` class entirely
- Replaced all `r.ok()` calls with direct `assert` statements
- Replaced all `r.ok_raises()` calls with `pytest.raises(SystemExit, match=...)`
- Updated `main()` to use try/except around each test function instead of collecting `Result` objects
- Added `import pytest`

**Verification:**
```
$ python3 -m pytest tests/test_model_parsing.py --tb=short
======================== 29 passed in 0.04s ========================
```

Zero warnings, all 29 tests pass.

Fixes #78