### PR TITLE
Narrow tool_allowed_gh_api_repos to explicit repo in self-review workflow

### DIFF
--- a/.github/workflows/ai-pr-review.yaml
+++ b/.github/workflows/ai-pr-review.yaml
@@ -55,7 +55,7 @@ jobs:
           tool_planning_max_context_bytes: '15000'
           tool_planning_max_tokens: '300'
           tool_max_response_bytes: '12000'
-          tool_allowed_gh_api_repos: '*'
+          tool_allowed_gh_api_repos: misospace/pr-reviewer-action
           tool_request_timeout_sec: '15'
           tool_failure_enforcement: 'true'
           tool_min_successful_requests: '1'


### PR DESCRIPTION
Fixes #79

Narrow `tool_allowed_gh_api_repos` from `'*'` to `misospace/pr-reviewer-action` explicitly, preventing the `gh_api` tool from accessing arbitrary GitHub API endpoints via wildcard.