### PR TITLE
fix: set PYTHONPATH for linked issue context extraction

### DIFF
--- a/scripts/run_review.sh
+++ b/scripts/run_review.sh
@@ -305,7 +305,7 @@ head -c "$MAX_FILES" pr-files.json > pr-files.truncated.json
 jq -r '.body // ""' pr.json > pr-body.txt
 
 log "Gathering linked issue context..."
-REPO="$REPO" python3 - <<'PY' > linked-issues.json
+PYTHONPATH="${SCRIPT_DIR}/.." REPO="$REPO" python3 - <<'PY' > linked-issues.json
 import json
 import os
 from pathlib import Path


### PR DESCRIPTION
## Problem

The Python heredoc that extracts linked issue refs (line 308) imports from `pr_reviewer.github_context`, but was missing the `PYTHONPATH="${SCRIPT_DIR}/.."` prefix that all other Python calls in the script have. This caused a `ModuleNotFoundError: No module named 'pr_reviewer'` when running the action.

## Fix

Add `PYTHONPATH="${SCRIPT_DIR}/.."` to the linked issue context extraction Python call, matching the pattern used by all other Python invocations in `run_review.sh`.