### PR TITLE
chore: switch to native_review mode (self)

### DIFF
--- a/.github/workflows/ai-pr-review.yaml
+++ b/.github/workflows/ai-pr-review.yaml
@@ -60,4 +60,4 @@ jobs:
           tool_failure_enforcement: 'true'
           tool_min_successful_requests: '1'
           tool_enable_for_forks: 'false'
-          review_mode: native_review
+          publish_mode: native_review

--- a/.github/workflows/ai-pr-review.yaml
+++ b/.github/workflows/ai-pr-review.yaml
@@ -60,4 +60,4 @@ jobs:
           tool_failure_enforcement: 'true'
           tool_min_successful_requests: '1'
           tool_enable_for_forks: 'false'
-          publish_review_comment: 'true'
+          review_mode: native_review

--- a/.github/workflows/ai-pr-review.yaml
+++ b/.github/workflows/ai-pr-review.yaml
@@ -60,4 +60,5 @@ jobs:
           tool_failure_enforcement: 'true'
           tool_min_successful_requests: '1'
           tool_enable_for_forks: 'false'
-          publish_mode: native_review
+          publish_mode: review_verdict
+          allow_approve: 'true'


### PR DESCRIPTION
## Changes

- Switch from deprecated `publish_review_comment: 'true'` to `publish_mode: review_verdict`
- Add `allow_approve: 'true'`
- Native review mode publishes reviews as proper GitHub PR review comments with inline suggestions instead of a single summary comment
- pr-reviewer-action already at v1.0.18 (no version bump needed)
- create-github-app-token action already at v3.2.0 (no change needed)