### PR TITLE
Fix: inject enforcement reasons into Final Recommendation banner

### DIFF
--- a/pr_reviewer/enforcement.py
+++ b/pr_reviewer/enforcement.py
@@ -31,14 +31,14 @@ def apply_evidence_blocker_enforcement(
         True if enforcement was applied, False otherwise.
     """
     if not Path(evidence_path).exists():
-        return False
+        return False, ""
     try:
         evidence = json.loads(Path(evidence_path).read_text(encoding="utf-8", errors="replace"))
     except (json.JSONDecodeError, OSError):
-        return False
+        return False, ""
 
     if not evidence.get("has_blocker"):
-        return False
+        return False, ""
 
     blocker_ids = [
         p["id"]
@@ -60,8 +60,13 @@ def apply_evidence_blocker_enforcement(
 
     data["verdict"] = "request_changes"
     data["review_markdown"] = markdown
+    reason = (
+        f"Evidence provider blocker detected"
+        + (f": {ids_str}" if ids_str else "")
+        + ". One or more configured evidence providers reported blocker-level findings."
+    )
     Path(output_path).write_text(json.dumps(data, ensure_ascii=False) + "\n", encoding="utf-8")
-    return True
+    return True, reason
 
 
 def _get_tool_harness_failure_reason(tool_harness_path: str = "tool-harness.json") -> str | None:
@@ -130,7 +135,7 @@ def apply_tool_harness_failure_enforcement(
     """
     reason = _get_tool_harness_failure_reason(tool_harness_path)
     if not reason:
-        return False
+        return False, ""
 
     data = json.loads(Path(output_path).read_text(encoding="utf-8", errors="replace"))
     markdown = str(data.get("review_markdown") or "")
@@ -145,8 +150,13 @@ def apply_tool_harness_failure_enforcement(
 
     data["verdict"] = "request_changes"
     data["review_markdown"] = markdown
+    reason = (
+        f"Tool harness failure detected ({reason}). "
+        + "The tool harness failed during planning or execution; "
+        + "this workflow is configured fail-closed for tool harness failures."
+    )
     Path(output_path).write_text(json.dumps(data, ensure_ascii=False) + "\n", encoding="utf-8")
-    return True
+    return True, reason
 
 
 def apply_tool_min_successful_enforcement(
@@ -171,11 +181,11 @@ def apply_tool_min_successful_enforcement(
         True if enforcement was applied, False otherwise.
     """
     if not _harness_requested_tools(tool_harness_path):
-        return False
+        return False, ""
 
     successful = _count_successful_requests(tool_harness_path)
     if successful >= min_required:
-        return False
+        return False, ""
 
     data = json.loads(Path(output_path).read_text(encoding="utf-8", errors="replace"))
     markdown = str(data.get("review_markdown") or "")
@@ -189,12 +199,18 @@ def apply_tool_min_successful_enforcement(
 
     data["verdict"] = "request_changes"
     data["review_markdown"] = markdown
+    reason = (
+        f"Tool harness gathered insufficient evidence. "
+        + f"This workflow requires at least {min_required} successful tool requests, "
+        + f"but only {successful} succeeded."
+    )
     Path(output_path).write_text(json.dumps(data, ensure_ascii=False) + "\n", encoding="utf-8")
-    return True
+    return True, reason
 
 
 def normalize_enforced_review_markdown(
     output_path: str = "ai-output.json",
+    reasons: list[str] | None = None,
 ) -> None:
     """Add 'Final Recommendation: Request changes' banner when enforcement forced request_changes.
 
@@ -202,6 +218,8 @@ def normalize_enforced_review_markdown(
     ----------
     output_path : str
         Path to ``ai-output.json``.
+    reasons : list[str] | None
+        Specific enforcement reason strings to include in the banner.
     """
     data = json.loads(Path(output_path).read_text(encoding="utf-8", errors="replace"))
     verdict = data.get("verdict")
@@ -214,12 +232,23 @@ def normalize_enforced_review_markdown(
             markdown,
         )
         if not markdown.lstrip().startswith("## Final Recommendation"):
-            markdown = (
-                "## Final Recommendation\n"
-                "Request changes. One or more configured enforcement checks require this PR "
-                "to be treated as blocking even if the model's initial review text was approving.\n\n"
-                + markdown.lstrip()
-            )
+            if reasons:
+                reasons_bullet = "\n".join(f"- {r}" for r in reasons)
+                banner = (
+                    "## Final Recommendation\n"
+                    "Request changes. The following enforcement check(s) require this PR "
+                    "to be treated as blocking even if the model's initial review text was approving:\n\n"
+                    f"{reasons_bullet}\n\n"
+                    + markdown.lstrip()
+                )
+            else:
+                banner = (
+                    "## Final Recommendation\n"
+                    "Request changes. One or more configured enforcement checks require this PR "
+                    "to be treated as blocking even if the model's initial review text was approving.\n\n"
+                    + markdown.lstrip()
+                )
+            markdown = banner
 
         data["review_markdown"] = markdown
         Path(output_path).write_text(json.dumps(data, ensure_ascii=False) + "\n", encoding="utf-8")
@@ -252,21 +281,28 @@ def apply_all_enforcement(
         Number of enforcement actions applied (0, 1, or 2).
     """
     applied = 0
+    reasons: list[str] = []
 
     if evidence_blocker_enabled:
-        if apply_evidence_blocker_enforcement(evidence_path, output_path):
+        ok, reason = apply_evidence_blocker_enforcement(evidence_path, output_path)
+        if ok:
             applied += 1
+            reasons.append(reason)
 
     if tool_failure_enabled:
-        if apply_tool_harness_failure_enforcement(tool_harness_path, output_path):
+        ok, reason = apply_tool_harness_failure_enforcement(tool_harness_path, output_path)
+        if ok:
             applied += 1
+            reasons.append(reason)
         elif tool_min_successful > 0:
-            if apply_tool_min_successful_enforcement(
+            ok, reason = apply_tool_min_successful_enforcement(
                 tool_min_successful, tool_harness_path, output_path
-            ):
+            )
+            if ok:
                 applied += 1
+                reasons.append(reason)
 
     if applied > 0:
-        normalize_enforced_review_markdown(output_path)
+        normalize_enforced_review_markdown(output_path, reasons if reasons else None)
 
     return applied

--- a/tests/test_enforcement.py
+++ b/tests/test_enforcement.py
@@ -33,7 +33,7 @@ class TestApplyEvidenceBlockerEnforcement:
         output_path.write_text(json.dumps(output))
 
         result = apply_evidence_blocker_enforcement(str(evidence_path), str(output_path))
-        assert result is False
+        assert result == (False, "")
         assert json.loads(output_path.read_text())["verdict"] == "approve"
 
     def test_enforces_request_changes_with_blocker(self, tmp_path):
@@ -51,7 +51,8 @@ class TestApplyEvidenceBlockerEnforcement:
         output_path.write_text(json.dumps(output))
 
         result = apply_evidence_blocker_enforcement(str(evidence_path), str(output_path))
-        assert result is True
+        assert result[0] is True
+        assert "secret-scanner" in result[1]
         updated = json.loads(output_path.read_text())
         assert updated["verdict"] == "request_changes"
         assert "blocker-level findings" in updated["review_markdown"]
@@ -61,7 +62,7 @@ class TestApplyEvidenceBlockerEnforcement:
         output_path = tmp_path / "ai-output.json"
         output_path.write_text(json.dumps({"verdict": "approve", "review_markdown": "ok"}))
         result = apply_evidence_blocker_enforcement(str(tmp_path / "missing.json"), str(output_path))
-        assert result is False
+        assert result == (False, "")
 
     def test_invalid_json_evidence(self, tmp_path):
         evidence_path = tmp_path / "evidence.json"
@@ -69,7 +70,7 @@ class TestApplyEvidenceBlockerEnforcement:
         evidence_path.write_text("not json")
         output_path.write_text(json.dumps({"verdict": "approve", "review_markdown": "ok"}))
         result = apply_evidence_blocker_enforcement(str(evidence_path), str(output_path))
-        assert result is False
+        assert result == (False, "")
 
 
 class TestToolHarnessFailure:
@@ -169,7 +170,8 @@ class TestApplyToolHarnessFailureEnforcement:
         output_path.write_text(json.dumps(output))
 
         result = apply_tool_harness_failure_enforcement(str(harness_path), str(output_path))
-        assert result is True
+        assert result[0] is True
+        assert "context limit exceeded" in result[1]
         updated = json.loads(output_path.read_text())
         assert updated["verdict"] == "request_changes"
         assert "context limit exceeded" in updated["review_markdown"]
@@ -184,7 +186,7 @@ class TestApplyToolHarnessFailureEnforcement:
         output_path.write_text(json.dumps(output))
 
         result = apply_tool_harness_failure_enforcement(str(harness_path), str(output_path))
-        assert result is False
+        assert result == (False, "")
 
 
 class TestApplyToolMinSuccessfulEnforcement:
@@ -202,7 +204,8 @@ class TestApplyToolMinSuccessfulEnforcement:
         output_path.write_text(json.dumps(output))
 
         result = apply_tool_min_successful_enforcement(3, str(harness_path), str(output_path))
-        assert result is True
+        assert result[0] is True
+        assert "insufficient evidence" in result[1]
         updated = json.loads(output_path.read_text())
         assert updated["verdict"] == "request_changes"
         assert "only 1 succeeded" in updated["review_markdown"]
@@ -220,7 +223,7 @@ class TestApplyToolMinSuccessfulEnforcement:
         output_path.write_text(json.dumps(output))
 
         result = apply_tool_min_successful_enforcement(2, str(harness_path), str(output_path))
-        assert result is False
+        assert result == (False, "")
 
     def test_no_op_when_no_tools_requested(self, tmp_path):
         harness = {"planned_request_count": 0, "executed_request_count": 0}
@@ -232,7 +235,7 @@ class TestApplyToolMinSuccessfulEnforcement:
         output_path.write_text(json.dumps(output))
 
         result = apply_tool_min_successful_enforcement(2, str(harness_path), str(output_path))
-        assert result is False
+        assert result == (False, "")
 
 
 class TestNormalizeEnforcedReviewMarkdown:
@@ -263,6 +266,41 @@ class TestNormalizeEnforcedReviewMarkdown:
         normalize_enforced_review_markdown(str(path))
         assert path.read_text() == original
 
+    def test_banner_includes_specific_reasons(self, tmp_path):
+        data = {
+            "verdict": "request_changes",
+            "review_markdown": "Recommendation: Approve\n\nLGTM.",
+        }
+        path = tmp_path / "ai-output.json"
+        path.write_text(json.dumps(data))
+        reasons = [
+            "Tool harness gathered insufficient evidence. Requires 3 but only 1 succeeded.",
+            "Evidence provider blocker detected: secret-scanner.",
+        ]
+        normalize_enforced_review_markdown(str(path), reasons)
+        updated = json.loads(path.read_text())
+        assert "## Final Recommendation" in updated["review_markdown"]
+        assert "insufficient evidence" in updated["review_markdown"]
+        assert "Requires 3 but only 1 succeeded" in updated["review_markdown"]
+        assert "secret-scanner" in updated["review_markdown"]
+        assert "Model recommendation before enforcement: Approve" in updated["review_markdown"]
+
+    def test_banner_uses_generic_when_no_reasons(self, tmp_path):
+        data = {"verdict": "request_changes", "review_markdown": "Please fix this."}
+        path = tmp_path / "ai-output.json"
+        path.write_text(json.dumps(data))
+        normalize_enforced_review_markdown(str(path), [])
+        updated = json.loads(path.read_text())
+        assert "One or more configured enforcement checks" in updated["review_markdown"]
+
+    def test_banner_includes_reasons_when_list_provided(self, tmp_path):
+        data = {"verdict": "request_changes", "review_markdown": "Please fix this."}
+        path = tmp_path / "ai-output.json"
+        path.write_text(json.dumps(data))
+        normalize_enforced_review_markdown(str(path), ["specific reason here"])
+        updated = json.loads(path.read_text())
+        assert "specific reason here" in updated["review_markdown"]
+
 
 class TestApplyAllEnforcement:
     def test_evidence_blocker_applied(self, tmp_path):
@@ -284,7 +322,61 @@ class TestApplyAllEnforcement:
             output_path=str(out),
         )
         assert applied == 1
-        assert json.loads(out.read_text())["verdict"] == "request_changes"
+        updated = json.loads(out.read_text())
+        assert updated["verdict"] == "request_changes"
+        assert "evidence provider blocker" in updated["review_markdown"].lower()
+
+    def test_tool_harness_failure_includes_reason_in_banner(self, tmp_path):
+        harness = {"planning_error": "context limit exceeded"}
+        output = {"verdict": "approve", "review_markdown": "Recommendation: Approve\n\nOK"}
+
+        ep = tmp_path / "evidence-providers.json"
+        th = tmp_path / "tool-harness.json"
+        out = tmp_path / "ai-output.json"
+        th.write_text(json.dumps(harness))
+        out.write_text(json.dumps(output))
+
+        applied = apply_all_enforcement(
+            evidence_blocker_enabled=False,
+            tool_failure_enabled=True,
+            tool_min_successful=0,
+            evidence_path=str(ep),
+            tool_harness_path=str(th),
+            output_path=str(out),
+        )
+        assert applied == 1
+        updated = json.loads(out.read_text())
+        assert updated["verdict"] == "request_changes"
+        assert "context limit exceeded" in updated["review_markdown"]
+        assert "Model recommendation before enforcement: Approve" in updated["review_markdown"]
+
+    def test_tool_min_successful_includes_reason_in_banner(self, tmp_path):
+        harness = {
+            "planned_request_count": 3,
+            "executed_request_count": 3,
+            "tool_results": [{"status": "ok"}, {"status": "error"}, {"status": "error"}],
+        }
+        output = {"verdict": "approve", "review_markdown": "Recommendation: Approve\n\nOK"}
+
+        ep = tmp_path / "evidence-providers.json"
+        th = tmp_path / "tool-harness.json"
+        out = tmp_path / "ai-output.json"
+        th.write_text(json.dumps(harness))
+        out.write_text(json.dumps(output))
+
+        applied = apply_all_enforcement(
+            evidence_blocker_enabled=False,
+            tool_failure_enabled=True,
+            tool_min_successful=3,
+            evidence_path=str(ep),
+            tool_harness_path=str(th),
+            output_path=str(out),
+        )
+        assert applied == 1
+        updated = json.loads(out.read_text())
+        assert updated["verdict"] == "request_changes"
+        assert "insufficient evidence" in updated["review_markdown"].lower()
+        assert "requires at least 3" in updated["review_markdown"].lower()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

When `tool_failure_enforcement` or `evidence_blocker_enforcement` overrides the model's verdict (e.g. "Approve" → "Request Changes"), the published review text didn't explain **why**. Users saw a contradictory output:

```
⚠️ Automated recommendation: REQUEST CHANGES

Final Recommendation
Request changes. One or more configured enforcement checks require this PR to be treated as blocking even if the model's initial review text was approving.

Review Summary
Recommendation: Approve

This is a straightforward patch update...  [no mention of why it was overridden]
```

## Fix

The `Final Recommendation` banner now includes the specific enforcement reason(s) as bullet points:

```
## Final Recommendation
Request changes. The following enforcement check(s) require this PR to be treated as blocking even if the model's initial review text was approving:

- Tool harness gathered insufficient evidence. This workflow requires at least 3 successful tool requests, but only 1 succeeded.
- Evidence provider blocker detected: secret-scanner. One or more configured evidence providers reported blocker-level findings.

Model recommendation before enforcement: Approve
```

### Changes

- **`pr_reviewer/enforcement.py`**: Modified `apply_evidence_blocker_enforcement`, `apply_tool_harness_failure_enforcement`, and `apply_tool_min_successful_enforcement` to return `(bool, reason_str)` tuples. Updated `apply_all_enforcement` to collect reasons and pass them to `normalize_enforced_review_markdown`. Updated `normalize_enforced_review_markdown` to accept a `reasons` parameter and include specific reasons in the banner instead of a generic message.

- **`tests/test_enforcement.py`**: Updated all existing tests for new return types. Added 4 new tests verifying reason injection behavior.

---

Fixes #94
