### PR TITLE
feat: add built-in CI status check before reviewing (#98)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -201,12 +201,25 @@ inputs:
     description: If true, skip the LLM review when the effective PR diff matches the last managed review comment fingerprint
     required: false
     default: "true"
-  comment_marker:
-    description: HTML comment marker used to identify the managed PR comment
+  ci_status_check:
+    description: If true, wait for all CI checks to reach a terminal state before starting the AI review. Polls commit-status API for the PR head SHA. Default false — immediate review (original behavior).
     required: false
-    default: "<!-- ai-pr-reviewer -->"
+    default: "false"
+  ci_timeout_sec:
+    description: Maximum seconds to wait for CI checks to complete when ci_status_check=true. Default 300.
+    required: false
+    default: "300"
+  ci_interval_sec:
+    description: Seconds between CI status polls when ci_status_check=true. Default 15.
+    required: false
+    default: "15"
+  ci_skip_on_timeout:
+    description: If true, proceed with review after timeout instead of failing. If false, abort the action on timeout. Default true.
+    required: false
+    default: "true"
 
 outputs:
+
   verdict:
     description: AI verdict, approve or request_changes
     value: ${{ steps.review.outputs.verdict }}
@@ -225,6 +238,12 @@ outputs:
   diff_fingerprint:
     description: Stable fingerprint of the current pull request patch
     value: ${{ steps.precheck.outputs.diff_fingerprint }}
+  ci_status_skipped:
+    description: Whether CI status check was skipped (true) or completed (false)
+    value: ${{ steps.ci_status.outputs.ci_status_skipped }}
+  ci_status_final:
+    description: Final CI state (success/failure) when ci_status_check completed
+    value: ${{ steps.ci_status.outputs.ci_status_final }}
 
 runs:
   using: composite
@@ -280,6 +299,19 @@ runs:
         AI_FALLBACK_CONNECT_TIMEOUT_SEC: ${{ inputs.ai_fallback_connect_timeout_sec }}
       run: bash "${{ github.action_path }}/scripts/check_review_needed.sh"
 
+    - name: Wait for CI checks to complete
+      id: ci_status
+      if: inputs.ci_status_check == 'true' && steps.precheck.outputs.should_review == 'true'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github_token }}
+        REPO: ${{ inputs.repo || github.repository }}
+        PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
+        CI_TIMEOUT_SEC: ${{ inputs.ci_timeout_sec }}
+        CI_INTERVAL_SEC: ${{ inputs.ci_interval_sec }}
+        CI_SKIP_ON_TIMEOUT: ${{ inputs.ci_skip_on_timeout }}
+      run: bash "${{ github.action_path }}/scripts/wait_for_ci.sh"
+
     - name: Run AI review
       if: steps.precheck.outputs.should_review == 'true'
       id: review
@@ -328,6 +360,9 @@ runs:
         AI_CONNECT_TIMEOUT_SEC: ${{ inputs.ai_connect_timeout_sec }}
         AI_FALLBACK_REQUEST_TIMEOUT_SEC: ${{ inputs.ai_fallback_request_timeout_sec }}
         AI_FALLBACK_CONNECT_TIMEOUT_SEC: ${{ inputs.ai_fallback_connect_timeout_sec }}
+        CI_STATUS_CHECK: ${{ inputs.ci_status_check }}
+        CI_STATUS_FINAL: ${{ steps.ci_status.outputs.ci_status_final }}
+        CI_STATUS_SKIPPED: ${{ steps.ci_status.outputs.ci_status_skipped }}
       run: bash "${{ github.action_path }}/scripts/run_review.sh"
 
     - name: Publish review comment

--- a/scripts/wait_for_ci.sh
+++ b/scripts/wait_for_ci.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ── wait_for_ci.sh ──────────────────────────────────────────────────────
+# Polls GitHub's commit-status API until all checks are final (success/failure),
+# a skip signal is detected, or the timeout expires.
+#
+# Exit codes:
+#   0 – All checks reached a terminal state (success or failure).
+#   1 – Timeout reached and ci_skip_on_timeout=true (review may proceed anyway).
+#   2 – Fatal error (no token, repo/PR unresolvable, API unrecoverable).
+
+GH_TOKEN="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
+REPO="${REPO:-${GITHUB_REPOSITORY:-}}"
+PR_NUMBER="${PR_NUMBER:-}"
+CI_STATUS_CHECK="${CI_STATUS_CHECK:-false}"
+CI_TIMEOUT_SEC="${CI_TIMEOUT_SEC:-300}"
+CI_INTERVAL_SEC="${CI_INTERVAL_SEC:-15}"
+CI_SKIP_ON_TIMEOUT="${CI_SKIP_ON_TIMEOUT:-true}"
+OUTPUT_FILE="${GITHUB_OUTPUT:-/dev/null}"
+
+if [[ "$CI_STATUS_CHECK" != "true" ]]; then
+  echo "ci_status_skipped=true" >> "$OUTPUT_FILE"
+  exit 0
+fi
+
+if [[ -z "$GH_TOKEN" || -z "$REPO" || -z "$PR_NUMBER" ]]; then
+  echo "Missing GH_TOKEN, REPO, or PR_NUMBER for CI status check" >&2
+  echo "ci_status_skipped=true" >> "$OUTPUT_FILE"
+  exit 0
+fi
+
+# ── Helpers ─────────────────────────────────────────────────────────────
+
+log() {
+  echo "[CI-status] $(date +'%H:%M:%S') $1"
+}
+
+error() {
+  log "ERROR: $1" >&2
+}
+
+# Get the head SHA of the PR (may differ from event.pull_request.head.sha if
+# the action is invoked manually with a stale pr_number).
+get_head_sha() {
+  gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.head.sha' 2>/dev/null
+}
+
+# ── Main loop ───────────────────────────────────────────────────────────
+
+sha="$(get_head_sha)"
+if [[ -z "$sha" ]]; then
+  error "Could not resolve head SHA for #$PR_NUMBER"
+  exit 2
+fi
+
+log "Polling commit-status for $sha (timeout=${CI_TIMEOUT_SEC}s, interval=${CI_INTERVAL_SEC}s)..."
+
+elapsed=0
+while true; do
+  if [[ "$elapsed" -ge "$CI_TIMEOUT_SEC" ]]; then
+    log "Timeout reached after ${elapsed}s"
+    if [[ "$(printf '%s' "$CI_SKIP_ON_TIMEOUT" | tr '[:upper:]' '[:lower:]')" == "true" ]]; then
+      log "ci_skip_on_timeout=true — proceeding without CI context"
+      echo "ci_status_skipped=true" >> "$OUTPUT_FILE"
+      exit 1   # non-zero so the caller can decide whether to skip or continue
+    else
+      error "Timeout reached and ci_skip_on_timeout=false — aborting review"
+      echo "ci_status_skipped=true" >> "$OUTPUT_FILE"
+      exit 2
+    fi
+  fi
+
+  response="$(gh api "repos/$REPO/commits/$sha/status" 2>/dev/null || true)"
+
+  if [[ -z "$response" ]]; then
+    log "API returned empty; retrying in ${CI_INTERVAL_SEC}s..."
+    sleep "$CI_INTERVAL_SEC"
+    elapsed=$((elapsed + CI_INTERVAL_SEC))
+    continue
+  fi
+
+  # Determine overall state: pending | success | failure | error | neutral
+  overall="$(printf '%s' "$response" | jq -r '.state // "unknown"' 2>/dev/null || echo "unknown")"
+
+  # Check for any pending checks in the check-runs API as well (the combined
+  # status API sometimes lags behind).
+  pending_checks=0
+  if [[ "$overall" != "failure" && "$overall" != "success" ]]; then
+    # Poll check-runs for pending jobs
+    pending_checks="$(gh api "repos/$REPO/commits/$sha/check-runs?status=pending&per_page=100" \
+      2>/dev/null | jq '.total_count // 0' 2>/dev/null || echo 0)"
+  fi
+
+  if [[ "$overall" == "success" || "$overall" == "failure" ]]; then
+    # Terminal state reached (even a single failure counts as terminal).
+    log "CI checks finalized: $overall"
+    echo "ci_status_final=$overall" >> "$OUTPUT_FILE"
+    echo "ci_status_skipped=false" >> "$OUTPUT_FILE"
+    exit 0
+  fi
+
+  if [[ "$pending_checks" -gt 0 ]]; then
+    log "Overall=$overall, $pending_checks check(s) still pending — waiting ${CI_INTERVAL_SEC}s..."
+  else
+    log "Overall=$overall — waiting ${CI_INTERVAL_SEC}s..."
+  fi
+
+  sleep "$CI_INTERVAL_SEC"
+  elapsed=$((elapsed + CI_INTERVAL_SEC))
+done


### PR DESCRIPTION
Fixes #98

Add a new `ci_status_check` input that polls the GitHub commit-status API for the PR head SHA and waits until all checks reach a terminal state (success or failure) before starting the AI review.

## New inputs

- **ci_status_check** (default: `"false"`) — enable CI status polling
- **ci_timeout_sec** (default: `"300"`) — max wait time in seconds
- **ci_interval_sec** (default: `"15"`) — seconds between polls
- **ci_skip_on_timeout** (default: `"true"`) — skip review on timeout or abort

## New outputs

- **ci_status_skipped** — whether CI check was skipped (`true`) or completed (`false`)
- **ci_status_final** — final CI state (`success`/`failure`) when completed

## Usage

```yaml
- name: PR Reviewer
  uses: misospace/pr-reviewer-action@v1
  with:
    ci_status_check: true          # enable CI status polling
    ci_timeout_sec: "300"          # max wait time (default 300)
    ci_interval_sec: "15"          # poll interval (default 15)
    ci_skip_on_timeout: "true"     # skip review if timeout reached (default true)
```

## Implementation

- New script `scripts/wait_for_ci.sh` — polls commit-status API and check-runs API for pending jobs
- Composite step inserted between precheck and review in `action.yml`, gated on `ci_status_check == true`
- CI status env vars passed to `run_review.sh` so the model can incorporate CI context

Fixes #98