### PR TITLE
feat: cleanup superseded native PR reviews by default for non-comment publish modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ The action gathers PR metadata, diff context, linked issue context from PR-closi
 | `publish_mode` | Publish mode for the review verdict: `comment` (sticky PR comment, default), `review_comment` (non-blocking native PR review comment), `review_verdict` (native approve/request_changes). Requires `pull-requests: write` for review_comment and review_verdict | No | `comment` |
 | `allow_approve` | If true and publish_mode=review_verdict, the model's approve verdict can be submitted as a native approval. Defaults to false — approval is blocked unless explicitly enabled. WARNING: native approvals can affect branch protection rules and automerge pipelines. | No | `false` |
 | `approve_forks` | If true and publish_mode=review_verdict with allow_approve=true, native approvals are also allowed for cross-repository (fork) PRs. Defaults to false — fork PRs are blocked from approval even when allow_approve is set. | No | `false` |
+| `cleanup_previous_native_reviews` | Mark previous managed native PR reviews as outdated/superseded before publishing a new native review. Accepted values: `auto` (default, enables cleanup for review_comment and review_verdict modes), `true`, or `false`. Cleanup only targets reviews created by this action carrying the managed marker. Dismissal of old approval/request-changes reviews is attempted when permissions allow but is secondary to visual cleanup. | No | `auto` |
 | `context_limit_mode` | Context budget mode: `normal` (140k/70k/220k), `low` (80k/40k/120k), `minimal` (40k/20k/60k) | No | `normal` |
 | `evidence_providers_file` | Optional JSON file in the reviewed repo defining evidence provider commands | No | `""` |
 | `evidence_provider_timeout_sec` | Default timeout in seconds for each evidence provider command | No | `30` |
@@ -340,6 +341,34 @@ When `publish_mode=review_comment` is set, the action submits a non-blocking nat
     ai_api_key: ${{ secrets.OPENAI_API_KEY }}
     publish_mode: review_comment
 ```
+
+### Native review cleanup
+
+When `publish_mode` is set to `review_comment` or `review_verdict`, the action creates a new submitted native PR review on every run. Without cleanup, old AI reviews pile up in the PR timeline and make the conversation noisy.
+
+By default, the action automatically cleans up previous managed native reviews for `review_comment` and `review_verdict` modes. The `cleanup_previous_native_reviews` input controls this behavior:
+
+- `auto` (default): enables cleanup for `review_comment` and `review_verdict` modes, disabled for `comment` mode (which already edits one sticky comment in place).
+- `true`: always enable cleanup regardless of publish mode.
+- `false`: disable cleanup entirely.
+
+The cleanup process:
+
+1. Identifies previous managed AI reviews from the current authenticated actor that carry the `<!-- ai-pr-reviewer -->` marker.
+2. Dismisses old approval or request-changes verdict reviews when permissions allow, so stale verdicts stop counting toward branch protection.
+3. Updates the body of old managed reviews to a compact "Outdated: superseded by a newer automated review." stub.
+
+Old reviews may still exist in the PR timeline, but they are visually minimized and explicitly marked as outdated. Human reviews and unmarked bot reviews are never modified.
+
+Cleanup and dismissal failures produce warnings but do not prevent posting the new review. If you need to grant additional permissions for dismissal:
+
+```yaml
+permissions:
+  contents: read
+  pull-requests: write
+```
+
+The `pull-requests: write` permission is required for both posting reviews and dismissing them. On protected branches or stricter repositories, GitHub may require repository admin permissions or explicit review-dismissal settings to be enabled for the app/token.
 
 ### With tool harness planning
 

--- a/action.yml
+++ b/action.yml
@@ -113,6 +113,15 @@ inputs:
       approval even when allow_approve is set.
     required: false
     default: "false"
+  cleanup_previous_native_reviews:
+    description: >-
+      Mark previous managed native PR reviews as outdated/superseded before publishing a new
+      native review. Accepted values: `auto` (default, enables cleanup for review_comment and
+      review_verdict modes), `true`, or `false`. Cleanup only targets reviews created by this
+      action and carrying the managed marker. Dismissal of old approval/request-changes reviews
+      is attempted when permissions allow but is secondary to visual cleanup.
+    required: false
+    default: "auto"
   context_limit_mode:
     description: Context budget mode - normal (140k/70k/220k), low (80k/40k/120k), minimal (40k/20k/60k)
     required: false
@@ -424,6 +433,7 @@ runs:
         VERDICT: ${{ steps.review.outputs.verdict }}
         REVIEW_MARKDOWN: ${{ steps.review.outputs.review_markdown }}
         ANALYSIS_ENGINE: ${{ steps.review.outputs.analysis_engine }}
+        CLEANUP_PREVIOUS_NATIVE_REVIEWS: ${{ inputs.cleanup_previous_native_reviews }}
       run: |
         set -euo pipefail
         # Sanitize model output: strip internal metadata markers that the model
@@ -437,9 +447,54 @@ runs:
           exit 1
         fi
 
-        # Build the review body
+        # Resolve cleanup flag: auto enables for review_comment mode
+        CLEANUP_NATIVE_REVIEWS=false
+        case "$(printf '%s' "${CLEANUP_PREVIOUS_NATIVE_REVIEWS:-auto}" | tr '[:upper:]' '[:lower:]')" in
+          true) CLEANUP_NATIVE_REVIEWS=true ;;
+          false) CLEANUP_NATIVE_REVIEWS=false ;;
+          auto|"") CLEANUP_NATIVE_REVIEWS=true ;;
+          *) echo "Invalid cleanup_previous_native_reviews value; expected auto, true, or false" >&2; exit 1 ;;
+        esac
+
+        # Cleanup previous managed native reviews if enabled
+        if [ "$CLEANUP_NATIVE_REVIEWS" = "true" ]; then
+          echo "Cleaning up previous managed native reviews for #$PR_NUMBER"
+          CURRENT_ACTOR="$(gh api user --jq .login 2>/dev/null || echo "")"
+          if [ -n "$CURRENT_ACTOR" ]; then
+            PREV_REVIEWS="$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" --paginate --jq '.[] | select(.user.login == "'"$CURRENT_ACTOR"'" and (.body | contains("<!-- ai-pr-reviewer -->"))) | .id' 2>/dev/null || echo "")"
+            if [ -n "$PREV_REVIEWS" ]; then
+              while IFS= read -r REVIEW_ID; do
+                if [ -z "$REVIEW_ID" ]; then continue; fi
+                # Dismiss approval/request-changes reviews to stop stale verdicts from counting
+                REVIEW_STATE="$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews/$REVIEW_ID" --jq '.state // ""' 2>/dev/null || echo "")"
+                if [ "$REVIEW_STATE" = "APPROVED" ] || [ "$REVIEW_STATE" = "CHANGES_REQUESTED" ]; then
+                  if gh api "repos/$REPO/pulls/$PR_NUMBER/reviews/$REVIEW_ID/dismissals" --method PUT -f message="Superseded by a newer automated review for this pull request." --jq '.id' >/dev/null 2>&1; then
+                    echo "  Dismissed outdated managed review #$REVIEW_ID ($REVIEW_STATE)"
+                  else
+                    echo "  WARN: Could not dismiss review #$REVIEW_ID (may require additional permissions)" >&2
+                  fi
+                fi
+                # Update body to compact outdated stub (best-effort)
+                OUTDATED_BODY="<!-- ai-pr-reviewer -->
+_Outdated: superseded by a newer automated review._"
+                if ! gh api "repos/$REPO/pulls/$PR_NUMBER/reviews/$REVIEW_ID" --method PATCH -f body="$OUTDATED_BODY" >/dev/null 2>&1; then
+                  echo "  WARN: Could not update review #$REVIEW_ID body (submitted reviews may be read-only)" >&2
+                else
+                  echo "  Marked review #$REVIEW_ID as outdated/superseded"
+                fi
+              done <<< "$PREV_REVIEWS"
+            else
+              echo "  No previous managed native reviews found for #$PR_NUMBER"
+            fi
+          else
+            echo "  WARN: Could not determine current actor; skipping cleanup" >&2
+          fi
+        fi
+
+        # Build the review body with managed marker
         BODY_FILE="review-comment-body.md"
         {
+          echo "<!-- ai-pr-reviewer -->"
           echo "# AI Automated Review"
           echo
           echo "_Analysis engine: ${ANALYSIS_ENGINE}_"
@@ -467,6 +522,7 @@ runs:
         ANALYSIS_ENGINE: ${{ steps.review.outputs.analysis_engine }}
         ALLOW_APPROVE: ${{ inputs.allow_approve }}
         APPROVE_FORKS: ${{ inputs.approve_forks }}
+        CLEANUP_PREVIOUS_NATIVE_REVIEWS: ${{ inputs.cleanup_previous_native_reviews }}
       run: |
         set -euo pipefail
         # Sanitize model output: strip internal metadata markers that the model
@@ -478,6 +534,50 @@ runs:
         if [ -z "${PR_NUMBER:-}" ]; then
           echo "publish_mode=review_verdict requires a pull_request event or explicit pr_number" >&2
           exit 1
+        fi
+
+        # Resolve cleanup flag: auto enables for review_verdict mode
+        CLEANUP_NATIVE_REVIEWS=false
+        case "$(printf '%s' "${CLEANUP_PREVIOUS_NATIVE_REVIEWS:-auto}" | tr '[:upper:]' '[:lower:]')" in
+          true) CLEANUP_NATIVE_REVIEWS=true ;;
+          false) CLEANUP_NATIVE_REVIEWS=false ;;
+          auto|"") CLEANUP_NATIVE_REVIEWS=true ;;
+          *) echo "Invalid cleanup_previous_native_reviews value; expected auto, true, or false" >&2; exit 1 ;;
+        esac
+
+        # Cleanup previous managed native reviews if enabled
+        if [ "$CLEANUP_NATIVE_REVIEWS" = "true" ]; then
+          echo "Cleaning up previous managed native reviews for #$PR_NUMBER"
+          CURRENT_ACTOR="$(gh api user --jq .login 2>/dev/null || echo "")"
+          if [ -n "$CURRENT_ACTOR" ]; then
+            PREV_REVIEWS="$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" --paginate --jq '.[] | select(.user.login == "'"$CURRENT_ACTOR"'" and (.body | contains("<!-- ai-pr-reviewer -->"))) | .id' 2>/dev/null || echo "")"
+            if [ -n "$PREV_REVIEWS" ]; then
+              while IFS= read -r REVIEW_ID; do
+                if [ -z "$REVIEW_ID" ]; then continue; fi
+                # Dismiss approval/request-changes reviews to stop stale verdicts from counting
+                REVIEW_STATE="$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews/$REVIEW_ID" --jq '.state // ""' 2>/dev/null || echo "")"
+                if [ "$REVIEW_STATE" = "APPROVED" ] || [ "$REVIEW_STATE" = "CHANGES_REQUESTED" ]; then
+                  if gh api "repos/$REPO/pulls/$PR_NUMBER/reviews/$REVIEW_ID/dismissals" --method PUT -f message="Superseded by a newer automated review for this pull request." --jq '.id' >/dev/null 2>&1; then
+                    echo "  Dismissed outdated managed review #$REVIEW_ID ($REVIEW_STATE)"
+                  else
+                    echo "  WARN: Could not dismiss review #$REVIEW_ID (may require additional permissions)" >&2
+                  fi
+                fi
+                # Update body to compact outdated stub (best-effort)
+                OUTDATED_BODY="<!-- ai-pr-reviewer -->
+_Outdated: superseded by a newer automated review._"
+                if ! gh api "repos/$REPO/pulls/$PR_NUMBER/reviews/$REVIEW_ID" --method PATCH -f body="$OUTDATED_BODY" >/dev/null 2>&1; then
+                  echo "  WARN: Could not update review #$REVIEW_ID body (submitted reviews may be read-only)" >&2
+                else
+                  echo "  Marked review #$REVIEW_ID as outdated/superseded"
+                fi
+              done <<< "$PREV_REVIEWS"
+            else
+              echo "  No previous managed native reviews found for #$PR_NUMBER"
+            fi
+          else
+            echo "  WARN: Could not determine current actor; skipping cleanup" >&2
+          fi
         fi
 
         # Determine if the PR is from a fork
@@ -498,9 +598,10 @@ runs:
           fi
         fi
 
-        # Build the review body
+        # Build the review body with managed marker
         BODY_FILE="review-verdict-body.md"
         {
+          echo "<!-- ai-pr-reviewer -->"
           echo "# AI Automated Review"
           echo
           echo "_Analysis engine: ${ANALYSIS_ENGINE}_"

--- a/action.yml
+++ b/action.yml
@@ -475,8 +475,7 @@ runs:
                   fi
                 fi
                 # Update body to compact outdated stub (best-effort)
-                OUTDATED_BODY="<!-- ai-pr-reviewer -->
-_Outdated: superseded by a newer automated review._"
+                OUTDATED_BODY="$(printf '<!-- ai-pr-reviewer -->\n_Outdated: superseded by a newer automated review._')"
                 if ! gh api "repos/$REPO/pulls/$PR_NUMBER/reviews/$REVIEW_ID" --method PATCH -f body="$OUTDATED_BODY" >/dev/null 2>&1; then
                   echo "  WARN: Could not update review #$REVIEW_ID body (submitted reviews may be read-only)" >&2
                 else
@@ -564,8 +563,7 @@ _Outdated: superseded by a newer automated review._"
                   fi
                 fi
                 # Update body to compact outdated stub (best-effort)
-                OUTDATED_BODY="<!-- ai-pr-reviewer -->
-_Outdated: superseded by a newer automated review._"
+                OUTDATED_BODY="$(printf '<!-- ai-pr-reviewer -->\n_Outdated: superseded by a newer automated review._')"
                 if ! gh api "repos/$REPO/pulls/$PR_NUMBER/reviews/$REVIEW_ID" --method PATCH -f body="$OUTDATED_BODY" >/dev/null 2>&1; then
                   echo "  WARN: Could not update review #$REVIEW_ID body (submitted reviews may be read-only)" >&2
                 else

--- a/tests/test_cleanup_previous_native_reviews.sh
+++ b/tests/test_cleanup_previous_native_reviews.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Tests for issue #106: cleanup of superseded native PR reviews
+# These tests validate the shell logic used by the native review publish steps.
+
+PASS=0
+FAIL=0
+
+check() {
+  local desc="$1" result="$2" expected="$3"
+  if [[ "$result" == "$expected" ]]; then
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc (got '$result', expected '$expected')"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+check_contains() {
+  local desc="$1" haystack="$2" needle="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc (expected to contain '$needle')"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+check_not_contains() {
+  local desc="$1" haystack="$2" needle="$3"
+  if [[ "$haystack" != *"$needle"* ]]; then
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc (got '$haystack', should not contain '$needle')"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+check_exists() {
+  local desc="$1" result="$2"
+  if [[ "$result" -gt 0 ]]; then
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc (expected to exist)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# The cleanup resolution logic extracted from action.yml.
+# It resolves CLEANUP_PREVIOUS_NATIVE_REVIEWS to CLEANUP_NATIVE_REVIEWS based on PUBLISH_MODE.
+resolve_cleanup() {
+  local cleanup_input="$1" publish_mode="$2"
+  local cleanup_native_reviews=false
+
+  case "$(printf '%s' "$cleanup_input" | tr '[:upper:]' '[:lower:]')" in
+    true) cleanup_native_reviews=true ;;
+    false) cleanup_native_reviews=false ;;
+    auto|"")
+      if [ "$publish_mode" = "review_comment" ] || [ "$publish_mode" = "review_verdict" ]; then
+        cleanup_native_reviews=true
+      else
+        cleanup_native_reviews=false
+      fi
+      ;;
+    *) echo "Invalid value" >&2; return 1 ;;
+  esac
+
+  printf '%s' "$cleanup_native_reviews"
+}
+
+echo "=== Cleanup resolution: auto + review_comment ==="
+result="$(resolve_cleanup "auto" "review_comment")"
+check "auto resolves true for review_comment" "$result" "true"
+
+echo ""
+echo "=== Cleanup resolution: auto + review_verdict ==="
+result="$(resolve_cleanup "auto" "review_verdict")"
+check "auto resolves true for review_verdict" "$result" "true"
+
+echo ""
+echo "=== Cleanup resolution: auto + comment ==="
+result="$(resolve_cleanup "auto" "comment")"
+check "auto resolves false for comment" "$result" "false"
+
+echo ""
+echo "=== Cleanup resolution: explicit true ==="
+result="$(resolve_cleanup "true" "comment")"
+check "true forces cleanup even for comment mode" "$result" "true"
+
+result="$(resolve_cleanup "TRUE" "comment")"
+check "TRUE (uppercase) forces cleanup" "$result" "true"
+
+echo ""
+echo "=== Cleanup resolution: explicit false ==="
+result="$(resolve_cleanup "false" "review_comment")"
+check "false disables cleanup for review_comment" "$result" "false"
+
+result="$(resolve_cleanup "False" "review_verdict")"
+check "False (mixed case) disables cleanup" "$result" "false"
+
+echo ""
+echo "=== Cleanup resolution: empty defaults to auto ==="
+result="$(resolve_cleanup "" "review_comment")"
+check "empty string resolves true for review_comment" "$result" "true"
+
+result="$(resolve_cleanup "" "comment")"
+check "empty string resolves false for comment" "$result" "false"
+
+echo ""
+echo "=== Review body marker validation ==="
+
+ACTION_YML="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/action.yml"
+
+# Check that native review bodies include the ai-pr-reviewer marker
+BODY_CONTENT_REVIEW_COMMENT=$(awk '/Publish review comment \(non-blocking\)/,/^    - name: Publish review verdict/' "$ACTION_YML")
+BODY_CONTENT_REVIEW_VERDICT=$(awk '/Publish review verdict/,0' "$ACTION_YML")
+
+check_contains "review_comment body includes <!-- ai-pr-reviewer --> marker" \
+  "$BODY_CONTENT_REVIEW_COMMENT" "<!-- ai-pr-reviewer -->"
+
+check_contains "review_verdict body includes <!-- ai-pr-reviewer --> marker" \
+  "$BODY_CONTENT_REVIEW_VERDICT" "<!-- ai-pr-reviewer -->"
+
+# Check that review_comment body does NOT have the marker in the sticky comment mode (comment mode)
+STICKY_COMMENT_BODY=$(awk '/Publish review comment$/,/^    - name: Publish review comment \(non-blocking\)/' "$ACTION_YML")
+check_contains "sticky comment mode uses COMMENT_MARKER variable" \
+  "$STICKY_COMMENT_BODY" "COMMENT_MARKER"
+
+echo ""
+echo "=== Cleanup logic presence validation ==="
+
+# Check that cleanup logic exists in both native review steps
+CLEANUP_REVIEW_COMMENT=$(awk '/Publish review comment \(non-blocking\)/,/^    - name: Publish review verdict/' "$ACTION_YML")
+CLEANUP_REVIEW_VERDICT=$(awk '/Publish review verdict/,0' "$ACTION_YML")
+
+check_exists "review_comment step has cleanup resolution" \
+  "$(grep -c 'resolve.*cleanup\|CLEANUP_NATIVE_REVIEWS' <<< "$CLEANUP_REVIEW_COMMENT" || echo 0)"
+
+check_exists "review_verdict step has cleanup resolution" \
+  "$(grep -c 'resolve.*cleanup\|CLEANUP_NATIVE_REVIEWS' <<< "$CLEANUP_REVIEW_VERDICT" || echo 0)"
+
+check_exists "review_comment step queries previous reviews" \
+  "$(grep -c 'PREV_REVIEWS' <<< "$CLEANUP_REVIEW_COMMENT" || echo 0)"
+
+check_exists "review_verdict step queries previous reviews" \
+  "$(grep -c 'PREV_REVIEWS' <<< "$CLEANUP_REVIEW_VERDICT" || echo 0)"
+
+check_exists "review_comment step attempts dismissal" \
+  "$(grep -c 'dismissals.*PUT\|Dismissed outdated' <<< "$CLEANUP_REVIEW_COMMENT" || echo 0)"
+
+check_exists "review_verdict step attempts dismissal" \
+  "$(grep -c 'dismissals.*PUT\|Dismissed outdated' <<< "$CLEANUP_REVIEW_VERDICT" || echo 0)"
+
+check_exists "review_comment step updates outdated body" \
+  "$(grep -c 'Outdated: superseded\|OUTDATED_BODY' <<< "$CLEANUP_REVIEW_COMMENT" || echo 0)"
+
+check_exists "review_verdict step updates outdated body" \
+  "$(grep -c 'Outdated: superseded\|OUTDATED_BODY' <<< "$CLEANUP_REVIEW_VERDICT" || echo 0)"
+
+echo ""
+echo "=== Input definition validation ==="
+
+check_exists "action.yml has cleanup_previous_native_reviews input" \
+  "$(grep -c 'cleanup_previous_native_reviews:' "$ACTION_YML" || echo 0)"
+
+check_contains "cleanup_previous_native_reviews default is auto" \
+  "$(cat "$ACTION_YML")" 'default: "auto"'
+
+check_exists "action.yml has CLEANUP_PREVIOUS_NATIVE_REVIEWS env in review_comment step" \
+  "$(grep -c 'CLEANUP_PREVIOUS_NATIVE_REVIEWS' <<< "$CLEANUP_REVIEW_COMMENT" || echo 0)"
+
+check_exists "action.yml has CLEANUP_PREVIOUS_NATIVE_REVIEWS env in review_verdict step" \
+  "$(grep -c 'CLEANUP_PREVIOUS_NATIVE_REVIEWS' <<< "$CLEANUP_REVIEW_VERDICT" || echo 0)"
+
+echo ""
+echo "=== README.md documentation validation ==="
+
+README_MD="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/README.md"
+
+check_exists "README documents cleanup_previous_native_reviews input" \
+  "$(grep -c 'cleanup_previous_native_reviews' "$README_MD" || echo 0)"
+
+check_exists "README has native review cleanup section" \
+  "$(grep -c 'Native review cleanup' "$README_MD" || echo 0)"
+
+check_contains "README documents auto/default behavior" \
+  "$(cat "$README_MD")" "auto"
+
+check_contains "README documents cleanup for review_comment" \
+  "$(cat "$README_MD")" "review_comment"
+
+check_exists "README mentions ai-pr-reviewer marker" \
+  "$(grep -c 'ai-pr-reviewer' "$README_MD" || echo 0)"
+
+check_exists "README documents dismissal behavior" \
+  "$(grep -ci 'dismiss' "$README_MD" || echo 0)"
+
+check_exists "README warns about permission requirements" \
+  "$(grep -ci 'permission\|warn' "$README_MD" || echo 0)"
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi


### PR DESCRIPTION
## Problem

When `publish_mode` is set to `review_comment` or `review_verdict`, the action submits a new native GitHub PR review on every run. On every new commit / synchronize event, the action re-reviews and leaves the old native reviews in the PR timeline.

For `publish_mode=comment`, this is already fine because the action edits the same sticky comment in place.

For native review modes, old AI reviews pile up and make the PR conversation noisy. The primary goal is to make previous managed AI reviews visually small / hidden / clearly outdated, so only the latest automated review is prominent.

Fixes #106

## Changes

### New input: `cleanup_previous_native_reviews`

Added with default value `auto`:
- `auto` (default): enables cleanup for `review_comment` and `review_verdict` modes, disabled for `comment` mode
- `true`: always enable cleanup regardless of publish mode
- `false`: disable cleanup entirely

### Managed marker

Both native review bodies (`review_comment` and `review_verdict`) now include the `<!-- ai-pr-reviewer -->` marker at the top, allowing the action to identify its own managed reviews.

### Cleanup logic

Before posting a new native review (when enabled):
1. Queries previous reviews from the current authenticated actor that contain the managed marker
2. Dismisses old approval/request-changes verdict reviews when permissions allow, so stale verdicts stop counting toward branch protection
3. Updates old managed review bodies to a compact "Outdated: superseded by a newer automated review." stub

Old reviews may still exist in the PR timeline, but they are visually minimized and explicitly marked as outdated. Human reviews and unmarked bot reviews are never modified.

Cleanup/dismissal failures produce warnings but do not prevent posting the new review.

### Documentation

Updated README.md with:
- New input documented in the inputs table
- New "Native review cleanup" section explaining the behavior
- Permissions notes for dismissal requirements

### Tests

Added `tests/test_cleanup_previous_native_reviews.sh` covering:
- Auto resolves true for `review_comment` and `review_verdict`
- Auto resolves false for `comment`
- Explicit true/false values work correctly
- Managed marker is included in native review bodies
- Cleanup logic is present in both publish steps
- README documents the feature