### PR TITLE
fix: use neutral text in tool harness planning corpus

### DIFF
--- a/scripts/run_review.sh
+++ b/scripts/run_review.sh
@@ -695,9 +695,18 @@ else
 fi
 
 if [ ! -f tool-harness.md ]; then
-  cat > tool-harness.md <<'EOF'
+  case "$(printf '%s' "$TOOL_MODE" | tr '[:upper:]' '[:lower:]')" in
+    plan_execute_once)
+      cat > tool-harness.md <<'EOF'
+Tool harness planning pending.
+EOF
+      ;;
+    *)
+      cat > tool-harness.md <<'EOF'
 Tool harness disabled.
 EOF
+      ;;
+  esac
 fi
 
 if [ ! -f tool-harness.json ]; then

--- a/tests/smoke_test.sh
+++ b/tests/smoke_test.sh
@@ -540,6 +540,37 @@ else
 fi
 
 echo ""
+echo "=== Tool harness planning corpus: plan_execute_once uses neutral text ==="
+
+# Simulate the initial tool-harness.md creation logic from run_review.sh
+create_default_tool_harness() {
+  local tool_mode="$1"
+  local output_file="$2"
+
+  case "$(printf '%s' "$tool_mode" | tr '[:upper:]' '[:lower:]')" in
+    plan_execute_once)
+      cat > "$output_file" <<'EOF'
+Tool harness planning pending.
+EOF
+      ;;
+    *)
+      cat > "$output_file" <<'EOF'
+Tool harness disabled.
+EOF
+      ;;
+  esac
+}
+
+# Test: plan_execute_once should NOT contain "disabled"
+create_default_tool_harness "plan_execute_once" "$TMPDIR/th-planning.md"
+check "planning mode has neutral text" "$(cat "$TMPDIR/th-planning.md")" "Tool harness planning pending."
+check "planning mode does not say disabled" "$(grep -c 'disabled' "$TMPDIR/th-planning.md" || true)" "0"
+
+# Test: off mode should still contain "disabled"
+create_default_tool_harness "off" "$TMPDIR/th-disabled.md"
+check "off mode has disabled text" "$(cat "$TMPDIR/th-disabled.md")" "Tool harness disabled."
+
+echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="
 
 if [[ "$FAIL" -gt 0 ]]; then


### PR DESCRIPTION
## Problem

When `tool_mode=plan_execute_once` is enabled, `scripts/run_review.sh` builds the first `review-corpus.md` before running the tool harness. At that point, it creates a default `tool-harness.md` containing:

```md
Tool harness disabled.
```

That placeholder then appears in the exact corpus passed to the tool planner. So the planner is asked to plan tool usage while also seeing a `# Tool Harness Findings` section that says the harness is disabled.

This is confusing context for local/smaller models and can contribute to planner responses with zero tool calls or inconsistent tool-use behavior.

## Fix

When `TOOL_MODE=plan_execute_once`, the initial `tool-harness.md` now contains:

```md
Tool harness planning pending.
```

When `TOOL_MODE=off`, the final review corpus still includes a clear "Tool harness disabled." message as before.

## Changes

- **`scripts/run_review.sh`**: Conditionally set the default tool-harness text based on TOOL_MODE before the first corpus build
- **`tests/smoke_test.sh`**: Added regression test verifying the planning corpus does not contain misleading disabled text when the harness is enabled

Fixes #101