### PR TITLE
fix: fail closed when tool_min_successful_requests set but planner returns zero tools

### DIFF
--- a/pr_reviewer/enforcement.py
+++ b/pr_reviewer/enforcement.py
@@ -180,9 +180,6 @@ def apply_tool_min_successful_enforcement(
     bool
         True if enforcement was applied, False otherwise.
     """
-    if not _harness_requested_tools(tool_harness_path):
-        return False, ""
-
     successful = _count_successful_requests(tool_harness_path)
     if successful >= min_required:
         return False, ""

--- a/tests/test_enforcement.py
+++ b/tests/test_enforcement.py
@@ -225,7 +225,7 @@ class TestApplyToolMinSuccessfulEnforcement:
         result = apply_tool_min_successful_enforcement(2, str(harness_path), str(output_path))
         assert result == (False, "")
 
-    def test_no_op_when_no_tools_requested(self, tmp_path):
+    def test_enforces_when_zero_tools_requested_and_min_gt_zero(self, tmp_path):
         harness = {"planned_request_count": 0, "executed_request_count": 0}
         output = {"verdict": "approve", "review_markdown": "OK"}
 
@@ -235,6 +235,22 @@ class TestApplyToolMinSuccessfulEnforcement:
         output_path.write_text(json.dumps(output))
 
         result = apply_tool_min_successful_enforcement(2, str(harness_path), str(output_path))
+        assert result[0] is True
+        assert "insufficient evidence" in result[1]
+        updated = json.loads(output_path.read_text())
+        assert updated["verdict"] == "request_changes"
+        assert "only 0 succeeded" in updated["review_markdown"]
+
+    def test_no_op_when_zero_tools_and_min_is_zero(self, tmp_path):
+        harness = {"planned_request_count": 0, "executed_request_count": 0}
+        output = {"verdict": "approve", "review_markdown": "OK"}
+
+        harness_path = tmp_path / "tool-harness.json"
+        output_path = tmp_path / "ai-output.json"
+        harness_path.write_text(json.dumps(harness))
+        output_path.write_text(json.dumps(output))
+
+        result = apply_tool_min_successful_enforcement(0, str(harness_path), str(output_path))
         assert result == (False, "")
 
 


### PR DESCRIPTION
Fixes #105

Remove the `_harness_requested_tools()` guard from `apply_tool_min_successful_enforcement` so that zero planned/executed tool requests is treated as zero successful requests. When `tool_min_successful_requests > 0`, this now correctly forces `request_changes` instead of silently passing.

### Changes
- **pr_reviewer/enforcement.py**: Removed the `_harness_requested_tools()` early-return guard from `apply_tool_min_successful_enforcement()`. The function now falls through to the `successful >= min_required` check, which correctly fails when 0 successful tools exist and min > 0.
- **tests/test_enforcement.py**: Replaced `test_no_op_when_no_tools_requested` with two tests:
  - `test_enforces_when_zero_tools_requested_and_min_gt_zero`: verifies enforcement triggers when planner returns 0 tools but min_required > 0
  - `test_no_op_when_zero_tools_and_min_is_zero`: verifies no-op when min_required is 0 (backward compatible)

### Acceptance criteria
- With `tool_failure_enforcement=true` and `tool_min_successful_requests=1`, a harness result with zero planned/executed tools forces `request_changes`. ✅
- The review markdown clearly explains that zero tool evidence was gathered despite the minimum requirement. ✅
- Existing behavior remains unchanged when `tool_min_successful_requests=0`. ✅
- Regression tests added for all four scenarios from issue #105.