### PR TITLE
fix(ci): stop blocking PRs with tool harness enforcement

### DIFF
--- a/.github/workflows/ai-pr-review.yaml
+++ b/.github/workflows/ai-pr-review.yaml
@@ -38,8 +38,8 @@ jobs:
         uses: misospace/pr-reviewer-action@f838c5b49d72d11dd33cfee6e29b85a28b5aa8df # v1.0.18
         with:
           github_token: ${{ steps.app-token.outputs.token }}
-          ai_primary_retries: '8'
-          ai_primary_retry_delay_sec: '15'
+          ai_primary_retries: "8"
+          ai_primary_retry_delay_sec: "15"
           ai_base_url: ${{ vars.LITELLM_URL }}
           ai_api_format: ${{ vars.PRIMARY_FORMAT }}
           ai_model: ${{ vars.PRIMARY_MODEL }}
@@ -50,15 +50,13 @@ jobs:
           ai_fallback_api_key: ${{ secrets.LITELLM_API_KEY }}
           context_limit_mode: normal
           tool_mode: plan_execute_once
-          tool_max_requests: '4'
-          tool_planning_timeout_sec: '45'
-          tool_planning_max_context_bytes: '15000'
-          tool_planning_max_tokens: '300'
-          tool_max_response_bytes: '12000'
+          tool_max_requests: "4"
+          tool_planning_timeout_sec: "45"
+          tool_planning_max_context_bytes: "15000"
+          tool_planning_max_tokens: "300"
+          tool_max_response_bytes: "12000"
           tool_allowed_gh_api_repos: misospace/pr-reviewer-action
-          tool_request_timeout_sec: '15'
-          tool_failure_enforcement: 'true'
-          tool_min_successful_requests: '1'
-          tool_enable_for_forks: 'false'
+          tool_request_timeout_sec: "15"
+          tool_enable_for_forks: "false"
           publish_mode: review_verdict
-          allow_approve: 'true'
+          allow_approve: "true"


### PR DESCRIPTION
## Problem

The AI PR review workflow has `tool_failure_enforcement: true`, which means the action will force `request_changes` on PRs when the tool harness cannot gather sufficient evidence. Since the action is pinned to `v1.0.18` (pre-PR #121 which fixed fail-closed semantics), enforcement here is actually broken — but even when it works, tool harness enforcement is too strict for a general-purpose review where the model may not always need or be able to call tools.

For repos using `publish_mode: review_verdict` with `allow_approve: true`, this blocks PRs from being merged when the review can't collect tool evidence.

## Change

Removes `tool_failure_enforcement` and `tool_min_successful_requests` from the workflow inputs. The action defaults (`"false"` and `"0"`) apply instead, making the tool harness explicitly best-effort:

- The AI review still runs and evaluates code changes
- The tool harness still attempts to collect evidence when the planner decides to
- But tool failures no longer force `request_changes`
- Remaining tools (standards file, linked sources, image digest analysis, etc.) are unaffected

## Related

Same fix applied across all misospace repos to unblock PR automation.
