### PR TITLE
fix: respect tool_request_timeout_sec across tool harness helpers

### DIFF
--- a/scripts/run_tool_harness.py
+++ b/scripts/run_tool_harness.py
@@ -246,7 +246,7 @@ def run_chat_completion(
     return parsed.get("choices", [{}])[0].get("message", {}).get("content", "")
 
 
-def fetch_url(url, allowed_hosts):
+def fetch_url(url, allowed_hosts, request_timeout=25):
     """Fetch a URL and return its text content (or None on failure)."""
     parsed = urllib.parse.urlparse(url)
     host = parsed.hostname or ""
@@ -259,7 +259,7 @@ def fetch_url(url, allowed_hosts):
             url,
             headers={"User-Agent": "ai-pr-reviewer/1.0"},
         )
-        with urllib.request.urlopen(req, timeout=25) as resp:
+        with urllib.request.urlopen(req, timeout=request_timeout) as resp:
             raw = resp.read()
             text = raw.decode("utf-8", errors="replace")
             return text[:5000]
@@ -292,7 +292,7 @@ def read_file(path, workspace_root):
         return {"error": str(exc)}
 
 
-def git_grep(pattern, workspace_root):
+def git_grep(pattern, workspace_root, request_timeout=15):
     """Run git grep and return matched lines."""
     try:
         result = subprocess.run(
@@ -300,19 +300,19 @@ def git_grep(pattern, workspace_root):
             cwd=workspace_root,
             capture_output=True,
             text=True,
-            timeout=15,
+            timeout=request_timeout,
         )
         if result.returncode not in (0, 1):
             return {"error": f"git grep failed: {result.stderr.strip()}"}
         lines = result.stdout.strip().splitlines()[:60]
         return {"matches": lines}
     except subprocess.TimeoutExpired:
-        return {"error": "git grep timed out after 15s"}
+        return {"error": f"git grep timed out after {request_timeout}s"}
     except Exception as exc:
         return {"error": str(exc)}
 
 
-def gh_api(endpoint, allowed_repos, current_repo):
+def gh_api(endpoint, allowed_repos, current_repo, request_timeout=25):
     """Make a GitHub API call with path/endpoint restrictions."""
     token = os.getenv("GH_TOKEN") or os.getenv("GITHUB_TOKEN", "")
     if not token:
@@ -358,7 +358,7 @@ def gh_api(endpoint, allowed_repos, current_repo):
                 "User-Agent": "ai-pr-reviewer/1.0",
             },
         )
-        with urllib.request.urlopen(req, timeout=25) as resp:
+        with urllib.request.urlopen(req, timeout=request_timeout) as resp:
             raw = resp.read()
             data = json.loads(raw.decode("utf-8", errors="replace"))
             return {"data": data}
@@ -368,7 +368,7 @@ def gh_api(endpoint, allowed_repos, current_repo):
         return {"error": str(exc)}
 
 
-def web_fetch(url, allowed_hosts):
+def web_fetch(url, allowed_hosts, request_timeout=25):
     """Fetch a URL using the same host-allowlist logic."""
     parsed = urllib.parse.urlparse(url)
     host = parsed.hostname or ""
@@ -381,7 +381,7 @@ def web_fetch(url, allowed_hosts):
             url,
             headers={"User-Agent": "ai-pr-reviewer/1.0"},
         )
-        with urllib.request.urlopen(req, timeout=25) as resp:
+        with urllib.request.urlopen(req, timeout=request_timeout) as resp:
             raw = resp.read()
             text = raw.decode("utf-8", errors="replace")
             return {"content": text[:10000]}
@@ -389,7 +389,7 @@ def web_fetch(url, allowed_hosts):
         return {"error": str(exc)}
 
 
-def run_command(command, workspace_root):
+def run_command(command, workspace_root, request_timeout=30):
     """Execute a named read-only command definition.
 
     The planner may choose only command names from ALLOWED_COMMANDS. Raw shell
@@ -412,7 +412,7 @@ def run_command(command, workspace_root):
             cwd=workspace_root,
             capture_output=True,
             text=True,
-            timeout=30,
+            timeout=request_timeout,
         )
         return {
             "stdout": mask_secrets((result.stdout or "").strip()),
@@ -428,7 +428,7 @@ def run_command(command, workspace_root):
         if isinstance(stderr, bytes):
             stderr = stderr.decode("utf-8", errors="replace")
         return {
-            "error": "Command timed out after 30s",
+            "error": f"Command timed out after {request_timeout}s",
             "stdout": mask_secrets(stdout),
             "stderr": mask_secrets(stderr),
             "command": command_name,
@@ -448,7 +448,8 @@ def main():
     max_response_bytes = int(os.getenv("TOOL_MAX_RESPONSE_BYTES", "12000"))
     planning_timeout = int(os.getenv("TOOL_PLANNING_TIMEOUT_SEC", "30"))
     planning_max_context = int(os.getenv("TOOL_PLANNING_MAX_CONTEXT_BYTES", "50000"))
-    request_timeout = int(os.getenv("TOOL_REQUEST_TIMEOUT_SEC", "20"))
+    max_requests = env_int_bounded("TOOL_MAX_REQUESTS", 4, 1, 20)
+    request_timeout = env_int_bounded("TOOL_REQUEST_TIMEOUT_SEC", 20, 1, 300)
 
     allowed_gh_repos_raw = os.getenv("TOOL_ALLOWED_GH_API_REPOS", "")
     allowed_gh_repos = set()
@@ -580,7 +581,7 @@ def main():
         )
         planning_user = (
             f"Repository: {repo}\n"
-            f"Max requests: 4\n"
+            f"Max requests: {max_requests}\n"
             f"Allowed repos for gh_api: {', '.join(sorted(allowed_gh_api_repos)) if allowed_gh_api_repos else '(none)'}\n"
             f"Allowed hosts for web_fetch: {', '.join(allowed_hosts) if allowed_hosts else '(none)'}\n"
             f"Corpus truncated for planning: {corpus_truncated}\n\n"
@@ -633,7 +634,7 @@ def main():
             md_lines.append(f"**Planning warning:** {result['planning_warning']}")
         md_lines.append("")
 
-        for i, raw_req in enumerate(requests_list[:4]):
+        for i, raw_req in enumerate(requests_list[:max_requests]):
             if not isinstance(raw_req, dict):
                 continue
             tool_name = raw_req.get("tool", "")
@@ -659,7 +660,7 @@ def main():
                     pattern = args.get("pattern", "")
                     if not pattern:
                         raise ValueError("Missing 'pattern' argument")
-                    res = git_grep(pattern, workspace_root)
+                    res = git_grep(pattern, workspace_root, request_timeout)
                     if res.get("error"):
                         raise ValueError(res["error"])
                     matches = res.get("matches", [])
@@ -671,7 +672,7 @@ def main():
                     endpoint = args.get("endpoint", "")
                     if not endpoint:
                         raise ValueError("Missing 'endpoint' argument")
-                    res = gh_api(endpoint, allowed_gh_repos, current_repo)
+                    res = gh_api(endpoint, allowed_gh_repos, current_repo, request_timeout)
                     if res.get("error"):
                         raise ValueError(res["error"])
                     data = res.get("data")
@@ -684,7 +685,7 @@ def main():
                     url = args.get("url", "")
                     if not url:
                         raise ValueError("Missing 'url' argument")
-                    res = web_fetch(url, allowed_hosts)
+                    res = web_fetch(url, allowed_hosts, request_timeout)
                     if res.get("error"):
                         raise ValueError(res["error"])
                     content_text = res.get("content", "")
@@ -695,7 +696,7 @@ def main():
                     command = args.get("command", "")
                     if not command:
                         raise ValueError("Missing 'command' argument")
-                    res = run_command(command, workspace_root)
+                    res = run_command(command, workspace_root, request_timeout)
                     if res.get("error"):
                         raise ValueError(res["error"])
                     stdout_text = res.get("stdout", "")
@@ -778,7 +779,7 @@ def main():
     md_lines.append(f"**Planned requests:** {result['planned_request_count']}")
     md_lines.append("")
 
-    for i, call in enumerate(tool_calls[:4]):
+    for i, call in enumerate(tool_calls[:max_requests]):
         tool_name = call.get("tool", "")
         args = call.get("args", {})
 
@@ -803,7 +804,7 @@ def main():
                 pattern = args.get("pattern", "")
                 if not pattern:
                     raise ValueError("Missing 'pattern' argument")
-                res = git_grep(pattern, workspace_root)
+                res = git_grep(pattern, workspace_root, request_timeout)
                 if res.get("error"):
                     raise ValueError(res["error"])
                 matches = res.get("matches", [])
@@ -815,7 +816,7 @@ def main():
                 endpoint = args.get("endpoint", "")
                 if not endpoint:
                     raise ValueError("Missing 'endpoint' argument")
-                res = gh_api(endpoint, allowed_gh_repos, current_repo)
+                res = gh_api(endpoint, allowed_gh_repos, current_repo, request_timeout)
                 if res.get("error"):
                     raise ValueError(res["error"])
                 data = res.get("data")
@@ -828,7 +829,7 @@ def main():
                 url = args.get("url", "")
                 if not url:
                     raise ValueError("Missing 'url' argument")
-                res = web_fetch(url, allowed_hosts)
+                res = web_fetch(url, allowed_hosts, request_timeout)
                 if res.get("error"):
                     raise ValueError(res["error"])
                 content_text = res.get("content", "")
@@ -839,7 +840,7 @@ def main():
                 command = args.get("command", "")
                 if not command:
                     raise ValueError("Missing 'command' argument")
-                res = run_command(command, workspace_root)
+                res = run_command(command, workspace_root, request_timeout)
                 if res.get("error"):
                     raise ValueError(res["error"])
                 stdout_text = res.get("stdout", "")

--- a/tests/test_tool_harness_status.py
+++ b/tests/test_tool_harness_status.py
@@ -366,6 +366,174 @@ def test_run_command_error_not_allowlisted():
 
 
 # ---------------------------------------------------------------------------
+# Tests for issue #104: request_timeout parameter passing
+# ---------------------------------------------------------------------------
+
+
+def test_git_grep_uses_custom_timeout():
+    """git_grep passes the timeout value to subprocess.run."""
+    git_grep = _import_tool("git_grep")
+    mock_result = mock.Mock(returncode=1, stderr="", stdout="")
+    with mock.patch("subprocess.run", return_value=mock_result) as mock_run:
+        git_grep("pattern", "/tmp", request_timeout=42)
+    mock_run.assert_called_once_with(
+        ["git", "grep", "-n", "--", "pattern", "."],
+        cwd="/tmp",
+        capture_output=True,
+        text=True,
+        timeout=42,
+    )
+
+
+def test_git_grep_default_timeout():
+    """git_grep uses 15s default when no timeout is specified."""
+    git_grep = _import_tool("git_grep")
+    mock_result = mock.Mock(returncode=0, stderr="", stdout="")
+    with mock.patch("subprocess.run", return_value=mock_result) as mock_run:
+        git_grep("pattern", "/tmp")
+    mock_run.assert_called_once_with(
+        ["git", "grep", "-n", "--", "pattern", "."],
+        cwd="/tmp",
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+
+
+def test_git_grep_timeout_error_message():
+    """git_grep timeout error message includes the configured timeout."""
+    git_grep = _import_tool("git_grep")
+    with mock.patch(
+        "subprocess.run", side_effect=subprocess.TimeoutExpired("git", 10)
+    ):
+        result = git_grep("pattern", "/tmp", request_timeout=10)
+    assert result.get("error") == "git grep timed out after 10s"
+
+
+def test_gh_api_uses_custom_timeout():
+    """gh_api passes the timeout value to urllib.request.urlopen."""
+    gh_api = _import_tool("gh_api")
+
+    old_token = None
+    for env_var in ("GH_TOKEN", "GITHUB_TOKEN"):
+        if env_var in os.environ:
+            old_token = (env_var, os.environ[env_var])
+            del os.environ[env_var]
+
+    try:
+        os.environ["GH_TOKEN"] = "fake-token-for-testing"
+        fake_response = mock.Mock()
+        fake_response.read.return_value = b'{"data": {}}'
+        with mock.patch("urllib.request.urlopen", return_value=fake_response) as mock_urlopen:
+            gh_api("owner/repo/pulls/1", {"owner/repo"}, "owner/repo", request_timeout=42)
+        mock_urlopen.assert_called_once()
+        args, kwargs = mock_urlopen.call_args
+        assert kwargs.get("timeout") == 42, (
+            f"Expected timeout=42, got {kwargs}"
+        )
+    finally:
+        if old_token:
+            os.environ[old_token[0]] = old_token[1]
+        else:
+            del os.environ["GH_TOKEN"]
+
+
+def test_web_fetch_uses_custom_timeout():
+    """web_fetch passes the timeout value to urllib.request.urlopen."""
+    web_fetch = _import_tool("web_fetch")
+
+    fake_response = mock.Mock()
+    fake_response.read.return_value = b"content"
+    with mock.patch("urllib.request.urlopen", return_value=fake_response) as mock_urlopen:
+        web_fetch("https://github.com/test", ["github.com"], request_timeout=42)
+    mock_urlopen.assert_called_once()
+    args, kwargs = mock_urlopen.call_args
+    assert kwargs.get("timeout") == 42, (
+        f"Expected timeout=42, got {kwargs}"
+    )
+
+
+def test_run_command_uses_custom_timeout():
+    """run_command passes the timeout value to subprocess.run."""
+    run_command = _import_tool("run_command")
+    mock_result = mock.Mock(returncode=0, stdout="out", stderr="", exit_code=0)
+    with mock.patch("subprocess.run", return_value=mock_result) as mock_run:
+        run_command("git_status_short", "/tmp", request_timeout=45)
+    mock_run.assert_called_once_with(
+        ["git", "status", "--short"],
+        cwd="/tmp",
+        capture_output=True,
+        text=True,
+        timeout=45,
+    )
+
+
+def test_run_command_timeout_error_message():
+    """run_command timeout error message includes the configured timeout."""
+    run_command = _import_tool("run_command")
+    with mock.patch(
+        "subprocess.run", side_effect=subprocess.TimeoutExpired("git", 10)
+    ):
+        result = run_command("git_status_short", "/tmp", request_timeout=10)
+    assert result.get("error") == "Command timed out after 10s"
+
+
+def test_env_int_bounded_defaults():
+    """env_int_bounded returns default when env var is not set."""
+    if str(_SCRIPTS_DIR) not in sys.path:
+        sys.path.insert(0, str(_SCRIPTS_DIR))
+    from run_tool_harness import env_int_bounded
+
+    with mock.patch.dict(os.environ, {}, clear=True):
+        result = env_int_bounded("NONEXISTENT_VAR", 20, 1, 300)
+        assert result == 20
+
+
+def test_env_int_bounded_respects_value():
+    """env_int_bounded returns the configured value when valid."""
+    if str(_SCRIPTS_DIR) not in sys.path:
+        sys.path.insert(0, str(_SCRIPTS_DIR))
+    from run_tool_harness import env_int_bounded
+
+    with mock.patch.dict(os.environ, {"TOOL_REQUEST_TIMEOUT_SEC": "50"}):
+        result = env_int_bounded("TOOL_REQUEST_TIMEOUT_SEC", 20, 1, 300)
+        assert result == 50
+
+
+def test_env_int_bounded_clamps_low():
+    """env_int_bounded clamps values below minimum to min_value."""
+    if str(_SCRIPTS_DIR) not in sys.path:
+        sys.path.insert(0, str(_SCRIPTS_DIR))
+    from run_tool_harness import env_int_bounded
+
+    with mock.patch.dict(os.environ, {"TOOL_REQUEST_TIMEOUT_SEC": "0"}):
+        result = env_int_bounded("TOOL_REQUEST_TIMEOUT_SEC", 20, 1, 300)
+        assert result == 1
+
+
+def test_env_int_bounded_clamps_high():
+    """env_int_bounded clamps values above maximum to max_value."""
+    if str(_SCRIPTS_DIR) not in sys.path:
+        sys.path.insert(0, str(_SCRIPTS_DIR))
+    from run_tool_harness import env_int_bounded
+
+    with mock.patch.dict(os.environ, {"TOOL_REQUEST_TIMEOUT_SEC": "9999"}):
+        result = env_int_bounded("TOOL_REQUEST_TIMEOUT_SEC", 20, 1, 300)
+        assert result == 300
+
+
+def test_env_int_bounded_invalid_falls_back():
+    """env_int_bounded returns default when value is not an integer."""
+    if str(_SCRIPTS_DIR) not in sys.path:
+        sys.path.insert(0, str(_SCRIPTS_DIR))
+    from run_tool_harness import env_int_bounded
+
+    with mock.patch.dict(os.environ, {"TOOL_REQUEST_TIMEOUT_SEC": "not-a-number"}):
+        result = env_int_bounded("TOOL_REQUEST_TIMEOUT_SEC", 20, 1, 300)
+        assert result == 20
+
+
+# ---------------------------------------------------------------------------
 # Test: integration fixture where tool_min_successful_requests enforcement
 # fails when all planned calls produce errors
 # ---------------------------------------------------------------------------
@@ -557,6 +725,18 @@ def main():
         ("gh_api repo not allowed", test_gh_api_error_repo_not_allowed),
         ("web_fetch non-allowlisted host", test_web_fetch_error_non_allowlisted_host),
         ("run_command not allowlisted", test_run_command_error_not_allowlisted),
+        ("git_grep uses custom timeout", test_git_grep_uses_custom_timeout),
+        ("git_grep default timeout", test_git_grep_default_timeout),
+        ("git_grep timeout error message", test_git_grep_timeout_error_message),
+        ("gh_api uses custom timeout", test_gh_api_uses_custom_timeout),
+        ("web_fetch uses custom timeout", test_web_fetch_uses_custom_timeout),
+        ("run_command uses custom timeout", test_run_command_uses_custom_timeout),
+        ("run_command timeout error message", test_run_command_timeout_error_message),
+        ("env_int_bounded defaults", test_env_int_bounded_defaults),
+        ("env_int_bounded respects value", test_env_int_bounded_respects_value),
+        ("env_int_bounded clamps low", test_env_int_bounded_clamps_low),
+        ("env_int_bounded clamps high", test_env_int_bounded_clamps_high),
+        ("env_int_bounded invalid falls back", test_env_int_bounded_invalid_falls_back),
         ("enforcement fixture no successes", test_enforcement_fixture_no_successes),
         ("integration all tools fail", test_integration_all_tools_fail),
         ("integration mixed success/failure", test_integration_mixed_success_and_failure),

--- a/tests/test_tool_harness_status.py
+++ b/tests/test_tool_harness_status.py
@@ -32,6 +32,7 @@ def _import_tool(name):
     if str(_SCRIPTS_DIR) not in sys.path:
         sys.path.insert(0, str(_SCRIPTS_DIR))
     from run_tool_harness import (  # noqa: F401
+        fetch_url,
         gh_api,
         git_grep,
         read_file,
@@ -453,6 +454,36 @@ def test_web_fetch_uses_custom_timeout():
     )
 
 
+def test_fetch_url_uses_custom_timeout():
+    """fetch_url passes the timeout value to urllib.request.urlopen."""
+    fetch_url = _import_tool("fetch_url")
+
+    fake_response = mock.Mock()
+    fake_response.read.return_value = b"content"
+    with mock.patch("urllib.request.urlopen", return_value=fake_response) as mock_urlopen:
+        result = fetch_url("https://github.com/test", ["github.com"], request_timeout=35)
+    mock_urlopen.assert_called_once()
+    args, kwargs = mock_urlopen.call_args
+    assert kwargs.get("timeout") == 35, (
+        f"Expected timeout=35, got {kwargs}"
+    )
+
+
+def test_fetch_url_default_timeout():
+    """fetch_url uses 25s default when no timeout is specified."""
+    fetch_url = _import_tool("fetch_url")
+
+    fake_response = mock.Mock()
+    fake_response.read.return_value = b"content"
+    with mock.patch("urllib.request.urlopen", return_value=fake_response) as mock_urlopen:
+        result = fetch_url("https://github.com/test", ["github.com"])
+    mock_urlopen.assert_called_once()
+    args, kwargs = mock_urlopen.call_args
+    assert kwargs.get("timeout") == 25, (
+        f"Expected timeout=25, got {kwargs}"
+    )
+
+
 def test_run_command_uses_custom_timeout():
     """run_command passes the timeout value to subprocess.run."""
     run_command = _import_tool("run_command")
@@ -730,6 +761,8 @@ def main():
         ("git_grep timeout error message", test_git_grep_timeout_error_message),
         ("gh_api uses custom timeout", test_gh_api_uses_custom_timeout),
         ("web_fetch uses custom timeout", test_web_fetch_uses_custom_timeout),
+        ("fetch_url uses custom timeout", test_fetch_url_uses_custom_timeout),
+        ("fetch_url default timeout", test_fetch_url_default_timeout),
         ("run_command uses custom timeout", test_run_command_uses_custom_timeout),
         ("run_command timeout error message", test_run_command_timeout_error_message),
         ("env_int_bounded defaults", test_env_int_bounded_defaults),


### PR DESCRIPTION
## Problem

The action exposes `tool_request_timeout_sec`, but the tool harness helpers use hardcoded timeouts internally:

- `git_grep` uses a hardcoded 15s timeout
- `gh_api` uses a hardcoded 25s timeout
- `web_fetch` uses a hardcoded 25s timeout
- `run_command` uses a hardcoded 30s timeout
- `fetch_url` uses a hardcoded 25s timeout

Meanwhile, `TOOL_REQUEST_TIMEOUT_SEC` is read in `run_review.sh` / `run_tool_harness.py`, but it is not consistently passed into the helper functions that actually perform requests or subprocess calls.

## Why this matters

This makes `tool_request_timeout_sec` misleading. Users may increase it for slow GitHub/API/network calls or decrease it for fast/fail-closed local CI. If the helpers ignore it, workflow tuning does not work and debugging gets weird.

## Changes

- Add `request_timeout` parameter to all IO helper functions (`git_grep`, `gh_api`, `web_fetch`, `run_command`, `fetch_url`) with sensible defaults matching previous hardcoded values
- Use `env_int_bounded` for `TOOL_REQUEST_TIMEOUT_SEC` (bounded 1-300s) and `TOOL_MAX_REQUESTS` (bounded 1-20) in `main()`
- Pass `request_timeout` through to all helper calls in both execution paths (direct model call and file-based planning)
- Use configurable `max_requests` slice instead of hardcoded `[:4]`
- Update planning prompt to reference configurable `max_requests`

## Acceptance criteria

- `TOOL_REQUEST_TIMEOUT_SEC=1` results in helpers using 1s timeout
- `TOOL_REQUEST_TIMEOUT_SEC=60` results in helpers using 60s timeout
- Invalid values fall back to a safe default (20s)
- Values are bounded to reasonable limits (1-300s for timeout, 1-20 for max requests)
- All existing tests continue to pass

## Tests

Added 13 new tests covering:
- Custom timeout passing for git_grep, gh_api, web_fetch, run_command
- Default timeout behavior when parameter omitted
- Timeout error messages include configured value
- env_int_bounded bounds enforcement (defaults, clamping low/high, invalid fallback)

Fixes #104