### PR TITLE
fix: correct CI checks polling to use GitHub Checks API statuses

### DIFF
--- a/scripts/wait_for_ci.sh
+++ b/scripts/wait_for_ci.sh
@@ -83,13 +83,16 @@ while true; do
   # Determine overall state: pending | success | failure | error | neutral
   overall="$(printf '%s' "$response" | jq -r '.state // "unknown"' 2>/dev/null || echo "unknown")"
 
-  # Check for any pending checks in the check-runs API as well (the combined
-  # status API sometimes lags behind).
+  # Check for any non-completed checks in the check-runs API as well (the combined
+  # status API sometimes lags behind). GitHub Checks API statuses are:
+  # queued, in_progress, completed, requested, waiting, stale.
+  # We count all runs where status != "completed" (i.e., still running or queued).
   pending_checks=0
+  check_runs_response=""
   if [[ "$overall" != "failure" && "$overall" != "success" ]]; then
-    # Poll check-runs for pending jobs
-    pending_checks="$(gh api "repos/$REPO/commits/$sha/check-runs?status=pending&per_page=100" \
-      2>/dev/null | jq '.total_count // 0' 2>/dev/null || echo 0)"
+    # Fetch check-runs once and reuse for both pending and failed counts
+    check_runs_response="$(gh api "repos/$REPO/commits/$sha/check-runs?per_page=100" 2>/dev/null || echo "{}")"
+    pending_checks="$(printf '%s' "$check_runs_response" | jq '[.check_runs[] | select(.status != "completed")] | length' 2>/dev/null || echo 0)"
   fi
 
   if [[ "$overall" == "success" || "$overall" == "failure" ]]; then
@@ -100,8 +103,20 @@ while true; do
     exit 0
   fi
 
+  # Detect failed check runs even when the combined status API hasn't caught up yet.
+  # This handles repos that rely primarily on GitHub Checks (not legacy statuses).
+  if [[ -n "$check_runs_response" ]]; then
+    failed_checks="$(printf '%s' "$check_runs_response" | jq '[.check_runs[] | select(.status == "completed" and .conclusion == "failure")] | length' 2>/dev/null || echo 0)"
+    if [[ "$failed_checks" -gt 0 ]]; then
+      log "Detected $failed_checks failed check run(s) before combined status updated — treating as failure"
+      echo "ci_status_final=failure" >> "$OUTPUT_FILE"
+      echo "ci_status_skipped=false" >> "$OUTPUT_FILE"
+      exit 0
+    fi
+  fi
+
   if [[ "$pending_checks" -gt 0 ]]; then
-    log "Overall=$overall, $pending_checks check(s) still pending — waiting ${CI_INTERVAL_SEC}s..."
+    log "Overall=$overall, $pending_checks check(s) not yet completed — waiting ${CI_INTERVAL_SEC}s..."
   else
     log "Overall=$overall — waiting ${CI_INTERVAL_SEC}s..."
   fi

--- a/tests/test_ci_status_check.sh
+++ b/tests/test_ci_status_check.sh
@@ -148,6 +148,24 @@ else
   FAIL=$((FAIL + 1))
 fi
 
+# ── Test 13: Check-runs polling uses correct GitHub Checks API statuses ──
+echo ""
+echo "=== Test: check-runs polling counts non-completed runs ==="
+check_contains "check-runs query does NOT filter by status=pending (uses all statuses)" \
+  "$wait_content" 'check-runs?per_page=100'
+check_contains "counts non-completed check runs via jq select" \
+  "$wait_content" '.status != "completed"'
+check_contains "stores check-runs response for reuse" \
+  "$wait_content" 'check_runs_response='
+
+# ── Test 14: Failed check-run detection before combined status update ──
+echo ""
+echo "=== Test: failed check-run early detection ==="
+check_contains "detects failed check runs before combined status catches up" \
+  "$wait_content" '.conclusion == "failure"'
+check_contains "logs when failed check runs detected early" \
+  "$wait_content" 'failed check run'
+
 echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="
 


### PR DESCRIPTION
Fixes #112

## Problem

`wait_for_ci.sh` was querying the Checks API with `status=pending`, but GitHub's Checks API uses `queued`, `in_progress`, and `completed` as statuses — not `pending`. This meant repos that primarily use GitHub Checks (not legacy commit statuses) would have their in-progress check runs invisible to the polling logic, causing premature timeouts or proceeding with poor signal.

Additionally, when a check run completed with failure but the combined status API hadn't yet updated, the script would continue polling instead of immediately recognizing the failure.

## Changes

- **Remove `status=pending` filter**: Query all check-runs and count those where `status != "completed"` (covers queued, in_progress, requested, waiting, stale)
- **Early failed check detection**: Detect completed-but-failed check runs before the combined status API catches up, treating them as terminal failure
- **Single API call**: Store the check-runs response for reuse across both pending and failed checks, reducing API calls per polling iteration
- **Updated log message**: Changed "check(s) still pending" to "check(s) not yet completed"
- **New tests**: Added 5 test assertions for the new polling behavior in `test_ci_status_check.sh`

## Verification

All 36 tests pass (`bash tests/test_ci_status_check.sh`).