### PR TITLE
fix: restore comment_marker input and add action/README consistency test

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,10 +83,13 @@ Before publishing, the action runs `scripts/sanitize_review_markdown.py` on the 
 | `ai_fallback_connect_timeout_sec` | Timeout in seconds for the fallback model API connection (`curl --connect-timeout`). Defaults to `ai_connect_timeout_sec` when blank. | No | `""` |
 | `ai_stream` | If true, use streaming responses to avoid timeouts behind proxies with short read timeouts (e.g. Cloudflare 100s edge timer) | No | `"true"` |
 | `ai_fallback_stream` | If set, overrides ai_stream for the fallback model; defaults to ai_stream value when blank | No | `""` |
-
 | `skip_if_diff_unchanged` | Skip the LLM review when the current PR patch matches the last managed review fingerprint | No | `true` |
-| `review_scope` | Controls whether the action reviews the full PR or only changes since the last managed review. Accepted values: `auto` (default, full on first run, incremental on later safe updates), `full` (always full review), `incremental` (delta review, falls back to full if prior metadata unavailable) | No | `auto` |
 | `comment_marker` | HTML marker for the managed PR comment | No | `<!-- ai-pr-reviewer -->` |
+| `review_scope` | Controls whether the action reviews the full PR or only changes since the last managed review. Accepted values: `auto` (default, full on first run, incremental on later safe updates), `full` (always full review), `incremental` (delta review, falls back to full if prior metadata unavailable) | No | `auto` |
+| `ci_status_check` | Wait for all CI checks to reach a terminal state before starting the AI review. Default false — immediate review. | No | `false` |
+| `ci_timeout_sec` | Maximum seconds to wait for CI checks to complete when ci_status_check=true. | No | `300` |
+| `ci_interval_sec` | Seconds between CI status polls when ci_status_check=true. | No | `15` |
+| `ci_skip_on_timeout` | If true, proceed with review after timeout instead of failing. | No | `true` |
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -210,6 +210,10 @@ inputs:
     description: If true, skip the LLM review when the effective PR diff matches the last managed review comment fingerprint
     required: false
     default: "true"
+  comment_marker:
+    description: HTML marker for the managed PR comment
+    required: false
+    default: "<!-- ai-pr-reviewer -->"
   ci_status_check:
     description: If true, wait for all CI checks to reach a terminal state before starting the AI review. Polls commit-status API for the PR head SHA. Default false — immediate review (original behavior).
     required: false

--- a/tests/test_action_inputs.py
+++ b/tests/test_action_inputs.py
@@ -1,0 +1,100 @@
+"""Tests for action.yml / README input consistency."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def parse_action_inputs():
+    """Parse declared input names from action.yml."""
+    action_yml = _REPO_ROOT / "action.yml"
+    content = action_yml.read_text()
+
+    inputs = set()
+    in_inputs_section = False
+    for line in content.splitlines():
+        # Detect the start of the inputs section
+        if re.match(r"^inputs:\s*$", line):
+            in_inputs_section = True
+            continue
+        # Detect end of inputs section (outputs, runs, etc.)
+        if in_inputs_section and re.match(r"^(outputs|runs):\s*$", line):
+            break
+        # Match input name definitions (top-level keys under inputs:)
+        if in_inputs_section:
+            m = re.match(r"^  (\w+):\s*$", line)
+            if m:
+                inputs.add(m.group(1))
+    return inputs
+
+
+def parse_readme_inputs():
+    """Parse documented input names from the README inputs table."""
+    readme = _REPO_ROOT / "README.md"
+    content = readme.read_text()
+
+    inputs = set()
+    in_table = False
+    for line in content.splitlines():
+        # Detect start of inputs table (first pipe row with Input header)
+        if "| Input |" in line:
+            in_table = True
+            continue
+        # Detect end of table (next section header or non-table line)
+        if in_table:
+            if line.startswith("## ") or (line.strip() and not line.startswith("|")):
+                in_table = False
+                break
+            # Match input name in backticks: | `input_name` |
+            m = re.search(r"\| \s*`(\w+)`\s*\|", line)
+            if m:
+                inputs.add(m.group(1))
+    return inputs
+
+
+def test_readme_inputs_in_action():
+    """Every input documented in README must be declared in action.yml."""
+    action_inputs = parse_action_inputs()
+    readme_inputs = parse_readme_inputs()
+
+    missing = readme_inputs - action_inputs
+    assert not missing, (
+        f"README documents inputs not declared in action.yml: {sorted(missing)}. "
+        f"Add them to the inputs: section of action.yml."
+    )
+
+
+def test_action_inputs_in_readme():
+    """Every input declared in action.yml should be documented in README."""
+    action_inputs = parse_action_inputs()
+    readme_inputs = parse_readme_inputs()
+
+    # Some inputs are internal/advanced and may not need README docs,
+    # but we flag them for review. Skip known internal inputs.
+    skip_internal = {
+        "anthropic_version",  # Implementation detail
+    }
+    undocumented = (action_inputs - readme_inputs) - skip_internal
+    assert not undocumented, (
+        f"action.yml declares inputs not documented in README: {sorted(undocumented)}. "
+        f"Add them to the Inputs table in README.md."
+    )
+
+
+def test_comment_marker_input_exists():
+    """Verify comment_marker input is declared (regression test for #113)."""
+    action_inputs = parse_action_inputs()
+    assert "comment_marker" in action_inputs, (
+        "comment_marker is documented in README and referenced in action.yml steps, "
+        "but is not declared as an input in action.yml."
+    )
+
+
+if __name__ == "__main__":
+    test_readme_inputs_in_action()
+    test_action_inputs_in_readme()
+    test_comment_marker_input_exists()
+    print("All action inputs tests passed!")

--- a/tests/test_action_inputs.py
+++ b/tests/test_action_inputs.py
@@ -72,10 +72,12 @@ def test_action_inputs_in_readme():
     action_inputs = parse_action_inputs()
     readme_inputs = parse_readme_inputs()
 
-    # Some inputs are internal/advanced and may not need README docs,
-    # but we flag them for review. Skip known internal inputs.
+    # Inputs that are implementation details or only relevant when using a
+    # specific API format — not user-facing configuration, so README docs
+    # are not required. When adding to this set, include a comment explaining
+    # why the input doesn't need documentation.
     skip_internal = {
-        "anthropic_version",  # Implementation detail
+        "anthropic_version",  # Only used when ai_api_format=anthropic; version header is an implementation detail
     }
     undocumented = (action_inputs - readme_inputs) - skip_internal
     assert not undocumented, (


### PR DESCRIPTION
Fixes #113

## Problem

The `comment_marker` input was documented in README.md and referenced in action.yml steps (`${{ inputs.comment_marker }}` in the precheck and publish steps), but was never declared in the `inputs:` section of action.yml. This caused the input to resolve to an empty string at runtime, breaking the sticky comment marker contract for users who wanted a custom marker.

## Changes

- **action.yml**: Added the missing `comment_marker` input declaration with default `"<!-- ai-pr-reviewer -->"`
- **README.md**: Fixed the split inputs table (blank line was breaking the markdown table) and added the undocumented `ci_status_*` inputs (`ci_status_check`, `ci_timeout_sec`, `ci_interval_sec`, `ci_skip_on_timeout`)
- **tests/test_action_inputs.py**: New test suite that validates every input documented in README.md is declared in action.yml and vice versa, preventing future drift between the two sources of truth