### PR TITLE
fix: handle empty STANDARDS_FILE in fallback message

### DIFF
--- a/scripts/run_review.sh
+++ b/scripts/run_review.sh
@@ -717,7 +717,11 @@ if [ -f "$STANDARDS_FILE" ]; then
   echo >> standards-context.md
   cat "$STANDARDS_FILE" >> standards-context.md
 else
-  echo "($STANDARDS_FILE not found; standards context unavailable.)" >> standards-context.md
+  if [[ -n "$STANDARDS_FILE" ]]; then
+    echo "($STANDARDS_FILE not found; standards context unavailable.)" >> standards-context.md
+  else
+    echo "(no standards file matched any candidate; standards context unavailable.)" >> standards-context.md
+  fi
 fi
 
 if [ ! -f tool-harness.md ]; then


### PR DESCRIPTION
Fixes #126

When no candidate in `STANDARDS_FILE_CANDIDATES` matches, `STANDARDS_FILE` is empty and the fallback message read `( not found; standards context unavailable.)` — with a double space and bare `not found`.

This branches on whether `STANDARDS_FILE` is set to produce a distinct message for each case:
- **File specified but missing**: `(specified/path not found; standards context unavailable.)`
- **No candidate matched**: `(no standards file matched any candidate; standards context unavailable.)`