### PR TITLE
fix: preserve standards file in full when truncating review corpus

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,19 +37,21 @@ publish_review_comment         → sanitizes markdown → builds managed comment
 
 ## Review corpus sections (in order)
 
-1. Changed Manifest Context (Helm/K8s manifests)
-2. PR Metadata (JSON from `gh pr view`)
-3. Linked Issue Context (from Fixes/Closes references in PR body)
-4. PR Files (truncated JSON with patches)
-5. Version Hints from Diff
-6. PR Diff (truncated)
-7. Linked Sources (fetched URLs, GitHub releases/compare metadata)
-8. Evidence Providers (user-defined command output)
-9. Tool Harness Findings (planned + executed tool results)
-10. Image Digest Provenance
-11. Repository Impact Scan (git grep hits for extracted terms)
-12. Repository History (git log context for extracted terms)
-13. Repository Standards and Conventions (from CLAUDE.md, AGENTS.md, etc.)
+1. Repository Standards and Conventions (from CLAUDE.md, AGENTS.md, etc.) — always included in full
+2. Changed Manifest Context (Helm/K8s manifests)
+3. PR Metadata (JSON from `gh pr view`)
+4. Linked Issue Context (from Fixes/Closes references in PR body)
+5. PR Files (truncated JSON with patches)
+6. Version Hints from Diff
+7. PR Diff (truncated)
+8. Linked Sources (fetched URLs, GitHub releases/compare metadata)
+9. Evidence Providers (user-defined command output)
+10. Tool Harness Findings (planned + executed tool results)
+11. Image Digest Provenance
+12. Repository Impact Scan (git grep hits for extracted terms)
+13. Repository History (git log context for extracted terms)
+
+Note: `MAX_CORPUS` truncation applies only to sections 2-13; the standards section (1) is always preserved in full.
 
 ## Running tests
 

--- a/scripts/run_review.sh
+++ b/scripts/run_review.sh
@@ -754,6 +754,7 @@ fi
 build_review_corpus() {
   local corpus_type="${1:-full}"  # 'full' or 'incremental'
 
+  # Build non-standards body first (this is the portion subject to truncation)
   {
     echo "# Changed Manifest Context"
     cat manifest-context.md
@@ -822,8 +823,17 @@ build_review_corpus() {
     echo "# Repository History"
     cat repo-history.truncated.md
     echo
+  } > review-corpus.body.md
+
+  # Truncate only the non-standards body to MAX_CORPUS
+  head -c "$MAX_CORPUS" review-corpus.body.md > review-corpus.body.truncated.md
+
+  # Prepend standards section in full, then append truncated body
+  {
     echo "# Repository Standards and Conventions ($STANDARDS_FILE)"
     cat standards-context.md
+    echo
+    cat review-corpus.body.truncated.md
   } > review-corpus.md
 }
 
@@ -835,7 +845,7 @@ if [[ "$EFFECTIVE_SCOPE" == "incremental" && -n "$PREVIOUS_HEAD_SHA" ]]; then
 else
   build_review_corpus "full"
 fi
-head -c "$MAX_CORPUS" review-corpus.md > review-corpus.truncated.md
+cp review-corpus.md review-corpus.truncated.md
 
 if [[ "$(printf '%s' "$TOOL_MODE" | tr '[:upper:]' '[:lower:]')" == "plan_execute_once" ]]; then
   if [[ "$IS_FORK_PR" == "true" ]] && [[ "$(printf '%s' "$TOOL_ENABLE_FOR_FORKS" | tr '[:upper:]' '[:lower:]')" != "true" ]]; then
@@ -858,7 +868,7 @@ EOF
     fi
   fi
   build_review_corpus
-  head -c "$MAX_CORPUS" review-corpus.md > review-corpus.truncated.md
+  cp review-corpus.md review-corpus.truncated.md
 fi
 
 log "Analyzing with $AI_MODEL using $AI_API_FORMAT API format..."

--- a/tests/test_corpus_standards_survival.sh
+++ b/tests/test_corpus_standards_survival.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Dependency preflight
+for dep in python3; do
+  if ! command -v "$dep" &>/dev/null; then
+    echo "SKIP: $dep is not available — cannot run test_corpus_standards_survival.sh" >&2
+    exit 0
+  fi
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+PASS=0
+FAIL=0
+
+check() {
+  local desc="$1" result="$2" expected="$3"
+  if [[ "$result" == "$expected" ]]; then
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc (got '$result', expected '$expected')"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+check_contains() {
+  local desc="$1" file="$2" needle="$3"
+  if grep -qF "$needle" "$file"; then
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc (needle '$needle' not found in $file)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+check_not_contains() {
+  local desc="$1" file="$2" needle="$3"
+  if ! grep -qF "$needle" "$file"; then
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc (needle '$needle' unexpectedly found in $file)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# ── Setup ─────────────────────────────────────────────────────────────
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# MAX_CORPUS for normal mode is 220 KB
+MAX_CORPUS=220000
+
+# Create a small standards file (~1 KB) with unique marker
+STANDARDS_MARKER="UNIQUE-STANDARDS-MARKER-abc123xyz"
+{
+  echo "# Repository Standards and Conventions"
+  echo "Derived from AGENTS.md for this repository."
+  echo ""
+  echo "$STANDARDS_MARKER"
+  echo "This is a critical convention that must always be preserved in the review corpus,"
+  echo "even when the diff is very large and exceeds MAX_CORPUS byte limits."
+} > "$TMPDIR/standards-context.md"
+
+# Create a body file larger than MAX_CORPUS (~250 KB of dummy content)
+BODY_MARKER="UNIQUE-BODY-MARKER-def456uvw"
+python3 -c "
+import sys
+marker = '$BODY_MARKER'
+line = 'x' * 79 + chr(10)
+buf = '# PR Diff (truncated)\n\`\`\`diff\n' + marker + chr(10)
+target = 250000
+while len(buf) < target:
+    buf += line
+buf += '\`\`\`\n'
+sys.stdout.write(buf)
+" > "$TMPDIR/review-corpus.body.md"
+
+BODY_SIZE=$(wc -c < "$TMPDIR/review-corpus.body.md")
+STANDARDS_SIZE=$(wc -c < "$TMPDIR/standards-context.md")
+
+echo "Body size: $BODY_SIZE bytes (exceeds MAX_CORPUS=$MAX_CORPUS)"
+echo "Standards size: $STANDARDS_SIZE bytes"
+
+# ── Test 1: New truncation logic preserves standards ───────────────────
+# Simulate the new build_review_corpus logic:
+#   head -c "$MAX_CORPUS" review-corpus.body.md > review-corpus.body.truncated.md
+#   { echo "# Repository Standards..."; cat standards-context.md; echo; cat body.truncated; } > review-corpus.md
+
+head -c "$MAX_CORPUS" "$TMPDIR/review-corpus.body.md" > "$TMPDIR/review-corpus.body.truncated.md"
+
+{
+  echo "# Repository Standards and Conventions (AGENTS.md)"
+  cat "$TMPDIR/standards-context.md"
+  echo
+  cat "$TMPDIR/review-corpus.body.truncated.md"
+} > "$TMPDIR/review-corpus.md"
+
+check_contains "Standards marker present in final corpus (new logic)" \
+  "$TMPDIR/review-corpus.md" "$STANDARDS_MARKER"
+
+check_contains "Body marker present in final corpus (new logic)" \
+  "$TMPDIR/review-corpus.md" "$BODY_MARKER"
+
+CORPUS_SIZE=$(wc -c < "$TMPDIR/review-corpus.md")
+echo "Final corpus size: $CORPUS_SIZE bytes (MAX_CORPUS + standards = ~$(( MAX_CORPUS + STANDARDS_SIZE )) expected)"
+
+# Verify final corpus exceeds MAX_CORPUS (standards + truncated body)
+if [[ "$CORPUS_SIZE" -gt "$MAX_CORPUS" ]]; then
+  echo "  PASS: Final corpus exceeds MAX_CORPUS (standards preserved in full)"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: Final corpus does not exceed MAX_CORPUS ($CORPUS_SIZE <= $MAX_CORPUS)"
+  FAIL=$((FAIL + 1))
+fi
+
+# ── Test 2: Old truncation logic would have lost standards ─────────────
+# Simulate the old build_review_corpus logic where standards was appended last:
+#   { body sections; echo "# Standards"; cat standards-context.md; } > review-corpus.old.md
+#   head -c "$MAX_CORPUS" review-corpus.old.md > review-corpus.truncated.old.md
+
+{
+  cat "$TMPDIR/review-corpus.body.md"
+  echo
+  echo "# Repository Standards and Conventions (AGENTS.md)"
+  cat "$TMPDIR/standards-context.md"
+} > "$TMPDIR/review-corpus.old.md"
+
+head -c "$MAX_CORPUS" "$TMPDIR/review-corpus.old.md" > "$TMPDIR/review-corpus.truncated.old.md"
+
+check_not_contains "Standards marker absent from old truncated corpus (old logic)" \
+  "$TMPDIR/review-corpus.truncated.old.md" "$STANDARDS_MARKER"
+
+# ── Test 3: Standards at beginning survives even extreme truncation ────
+# With MAX_CORPUS=100, standards (~200 bytes) should still be partially present
+# since it's prepended before the truncated body. The key assertion is that
+# the standards header appears regardless of how small MAX_CORPUS gets.
+
+SMALL_MAX=500
+
+head -c "$SMALL_MAX" "$TMPDIR/review-corpus.body.md" > "$TMPDIR/small-body.truncated.md"
+
+{
+  echo "# Repository Standards and Conventions (AGENTS.md)"
+  cat "$TMPDIR/standards-context.md"
+  echo
+  cat "$TMPDIR/small-body.truncated.md"
+} > "$TMPDIR/small-corpus.md"
+
+check_contains "Standards present even with extreme truncation (MAX=500)" \
+  "$TMPDIR/small-corpus.md" "$STANDARDS_MARKER"
+
+# ── Results ───────────────────────────────────────────────────────────
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi


### PR DESCRIPTION
Fixes #124

## Problem

In `scripts/run_review.sh`, `build_review_corpus` assembled the standards section last (section 13). The corpus was then truncated from the head to `MAX_CORPUS` bytes (`head -c "$MAX_CORPUS"`). On large PRs, the standards file was the first section to be cut — exactly on the PRs where convention enforcement matters most.

## Solution

Restructure `build_review_corpus` to:

1. Write non-standards sections (manifest context, PR metadata, diff, etc.) to a body file
2. Truncate only the body to `MAX_CORPUS` bytes
3. Prepend the standards section in full before the truncated body

The final `review-corpus.md` always contains the complete standards file, followed by the truncated non-standards content. External truncation calls (`head -c "$MAX_CORPUS" review-corpus.md`) are replaced with `cp` since the file is already truncated internally.

## Changes

- **`scripts/run_review.sh`**: Restructured `build_review_corpus` to separate standards from corpus body; removed external truncation calls
- **`AGENTS.md`**: Updated review corpus section ordering (standards is now section 1) and added note about truncation scope