### PR TITLE
refactor: extract shared publish helpers to deduplicate native review cleanup (#116)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -413,40 +413,31 @@ runs:
         REVIEW_MARKDOWN: ${{ steps.review.outputs.review_markdown }}
         ANALYSIS_ENGINE: ${{ steps.review.outputs.analysis_engine }}
         COMMENT_MARKER: ${{ inputs.comment_marker }}
+        GITHUB_ACTION_PATH: ${{ github.action_path }}
       run: |
         set -euo pipefail
-        # Sanitize model output: strip internal metadata markers that the model
-        # might have generated, preventing fake markers from interfering with precheck.
-        printf '%s\n' "$REVIEW_MARKDOWN" > review-markdown.raw.md
-        python3 "${{ github.action_path }}/scripts/strip_metadata_markers.py" review-markdown.raw.md
-        # Neutralize upstream PR/issue/commit references so GitHub does not auto-link them.
-        python3 "${{ github.action_path }}/scripts/sanitize_review_markdown.py" review-markdown.raw.md
+        source "${GITHUB_ACTION_PATH}/scripts/publish_helpers.sh"
 
+        # Sanitize model output
+        sanitize_review_markdown "review-markdown.raw.md"
 
-        if [ -z "${PR_NUMBER:-}" ]; then
-          echo "publish_review_comment=true requires a pull_request event or explicit pr_number" >&2
-          exit 1
-        fi
+        # Validate PR number
+        validate_pr_number "review_comment"
 
-        if [ "$VERDICT" = "request_changes" ]; then
-          VERDICT_PREFIX="⚠️ **Automated recommendation: REQUEST CHANGES**"
-        else
-          VERDICT_PREFIX="✅ **Automated recommendation: APPROVE**"
-        fi
-
-        # Resolve effective scope from precheck
+        # Resolve effective scope and review result
         EFFECTIVE_SCOPE="${{ steps.precheck.outputs.effective_review_scope || 'full' }}"
-
-        # Determine review result for metadata marker
         REVIEW_RESULT="clean"
         if [ "$VERDICT" = "request_changes" ]; then
           REVIEW_RESULT="issues"
         fi
 
         # Build metadata marker
-        METADATA_MARKER="<!-- ai-pr-reviewer:{\"version\":1,\"head_sha\":\"${HEAD_SHA:-unknown}\",\"base_sha\":\"${{ github.event.pull_request.base.sha || '' }}\",\"review_scope\":\"${EFFECTIVE_SCOPE}\",\"review_result\":\"${REVIEW_RESULT}\"}"
-        if [ "$EFFECTIVE_SCOPE" = "incremental" ] && [ -n "${{ steps.precheck.outputs.previous_head_sha:-}}" ]; then
-          METADATA_MARKER="${METADATA_MARKER%,*},\"previous_head_sha\":\"${{ steps.precheck.outputs.previous_head_sha }}\"}"
+        METADATA_MARKER="$(build_metadata_marker "${{ github.event.pull_request.base.sha || '' }}" "${{ steps.precheck.outputs.previous_head_sha:-}}")"
+
+        if [ "$VERDICT" = "request_changes" ]; then
+          VERDICT_PREFIX="⚠️ **Automated recommendation: REQUEST CHANGES**"
+        else
+          VERDICT_PREFIX="✅ **Automated recommendation: APPROVE**"
         fi
 
         {
@@ -478,75 +469,30 @@ runs:
         REVIEW_MARKDOWN: ${{ steps.review.outputs.review_markdown }}
         ANALYSIS_ENGINE: ${{ steps.review.outputs.analysis_engine }}
         CLEANUP_PREVIOUS_NATIVE_REVIEWS: ${{ inputs.cleanup_previous_native_reviews }}
+        GITHUB_ACTION_PATH: ${{ github.action_path }}
       run: |
         set -euo pipefail
-        # Sanitize model output: strip internal metadata markers that the model
-        # might have generated, preventing fake markers from interfering with precheck.
-        printf '%s\n' "$REVIEW_MARKDOWN" > review-comment-markdown.raw.md
-        python3 "${{ github.action_path }}/scripts/strip_metadata_markers.py" review-comment-markdown.raw.md
-        # Neutralize upstream PR/issue/commit references so GitHub does not auto-link them.
-        python3 "${{ github.action_path }}/scripts/sanitize_review_markdown.py" review-comment-markdown.raw.md
+        source "${GITHUB_ACTION_PATH}/scripts/publish_helpers.sh"
 
+        # Sanitize model output
+        sanitize_review_markdown "review-comment-markdown.raw.md"
 
-        if [ -z "${PR_NUMBER:-}" ]; then
-          echo "publish_mode=review_comment requires a pull_request event or explicit pr_number" >&2
-          exit 1
-        fi
+        # Validate PR number
+        validate_pr_number "mode=review_comment"
 
-        # Resolve cleanup flag: auto enables for review_comment mode
-        CLEANUP_NATIVE_REVIEWS=false
-        case "$(printf '%s' "${CLEANUP_PREVIOUS_NATIVE_REVIEWS:-auto}" | tr '[:upper:]' '[:lower:]')" in
-          true) CLEANUP_NATIVE_REVIEWS=true ;;
-          false) CLEANUP_NATIVE_REVIEWS=false ;;
-          auto|"") CLEANUP_NATIVE_REVIEWS=true ;;
-          *) echo "Invalid cleanup_previous_native_reviews value; expected auto, true, or false" >&2; exit 1 ;;
-        esac
+        # Resolve cleanup flag and execute cleanup
+        CLEANUP_NATIVE_REVIEWS="$(resolve_cleanup_flag "${CLEANUP_PREVIOUS_NATIVE_REVIEWS:-auto}" "review_comment")"
+        cleanup_native_reviews "$CLEANUP_NATIVE_REVIEWS"
 
-        # Cleanup previous managed native reviews if enabled
-        if [ "$CLEANUP_NATIVE_REVIEWS" = "true" ]; then
-          echo "Cleaning up previous managed native reviews for #$PR_NUMBER"
-          CURRENT_ACTOR="$(gh api user --jq .login 2>/dev/null || echo "")"
-          if [ -n "$CURRENT_ACTOR" ]; then
-            PREV_REVIEWS="$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" --paginate --jq '.[] | select(.user.login == "'"$CURRENT_ACTOR"'" and (.body | contains("<!-- ai-pr-reviewer -->"))) | .id' 2>/dev/null || echo "")"
-            if [ -n "$PREV_REVIEWS" ]; then
-              while IFS= read -r REVIEW_ID; do
-                if [ -z "$REVIEW_ID" ]; then continue; fi
-                # Dismiss approval/request-changes reviews to stop stale verdicts from counting
-                REVIEW_STATE="$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews/$REVIEW_ID" --jq '.state // ""' 2>/dev/null || echo "")"
-                if [ "$REVIEW_STATE" = "APPROVED" ] || [ "$REVIEW_STATE" = "CHANGES_REQUESTED" ]; then
-                  if gh api "repos/$REPO/pulls/$PR_NUMBER/reviews/$REVIEW_ID/dismissals" --method PUT -f message="Superseded by a newer automated review for this pull request." --jq '.id' >/dev/null 2>&1; then
-                    echo "  Dismissed outdated managed review #$REVIEW_ID ($REVIEW_STATE)"
-                  else
-                    echo "  WARN: Could not dismiss review #$REVIEW_ID (may require additional permissions)" >&2
-                  fi
-                fi
-                # Update body to compact outdated stub (best-effort)
-                OUTDATED_BODY="$(printf '<!-- ai-pr-reviewer -->\n_Outdated: superseded by a newer automated review._')"
-                if ! gh api "repos/$REPO/pulls/$PR_NUMBER/reviews/$REVIEW_ID" --method PATCH -f body="$OUTDATED_BODY" >/dev/null 2>&1; then
-                  echo "  WARN: Could not update review #$REVIEW_ID body (submitted reviews may be read-only)" >&2
-                else
-                  echo "  Marked review #$REVIEW_ID as outdated/superseded"
-                fi
-              done <<< "$PREV_REVIEWS"
-            else
-              echo "  No previous managed native reviews found for #$PR_NUMBER"
-            fi
-          else
-            echo "  WARN: Could not determine current actor; skipping cleanup" >&2
-          fi
-        fi
-
-        # Resolve effective scope from precheck
+        # Resolve effective scope and review result
         EFFECTIVE_SCOPE="${{ steps.precheck.outputs.effective_review_scope || 'full' }}"
-
-        # Determine review result for metadata marker
         REVIEW_RESULT="clean"
         if [ "$VERDICT" = "request_changes" ]; then
           REVIEW_RESULT="issues"
         fi
 
         # Build metadata marker
-        METADATA_MARKER="<!-- ai-pr-reviewer:{\"version\":1,\"head_sha\":\"${HEAD_SHA:-unknown}\",\"base_sha\":\"${{ github.event.pull_request.base.sha || '' }}\",\"review_scope\":\"${EFFECTIVE_SCOPE}\",\"review_result\":\"${REVIEW_RESULT}\"}"
+        METADATA_MARKER="$(build_metadata_marker "${{ github.event.pull_request.base.sha || '' }}" "")"
 
         # Build the review body with managed marker
         BODY_FILE="review-comment-body.md"
@@ -581,83 +527,35 @@ runs:
         ALLOW_APPROVE: ${{ inputs.allow_approve }}
         APPROVE_FORKS: ${{ inputs.approve_forks }}
         CLEANUP_PREVIOUS_NATIVE_REVIEWS: ${{ inputs.cleanup_previous_native_reviews }}
+        GITHUB_ACTION_PATH: ${{ github.action_path }}
       run: |
         set -euo pipefail
-        # Sanitize model output: strip internal metadata markers that the model
-        # might have generated, preventing fake markers from interfering with precheck.
-        printf '%s\n' "$REVIEW_MARKDOWN" > review-verdict-markdown.raw.md
-        python3 "${{ github.action_path }}/scripts/strip_metadata_markers.py" review-verdict-markdown.raw.md
-        # Neutralize upstream PR/issue/commit references so GitHub does not auto-link them.
-        python3 "${{ github.action_path }}/scripts/sanitize_review_markdown.py" review-verdict-markdown.raw.md
+        source "${GITHUB_ACTION_PATH}/scripts/publish_helpers.sh"
 
+        # Sanitize model output
+        sanitize_review_markdown "review-verdict-markdown.raw.md"
 
-        if [ -z "${PR_NUMBER:-}" ]; then
-          echo "publish_mode=review_verdict requires a pull_request event or explicit pr_number" >&2
-          exit 1
-        fi
+        # Validate PR number
+        validate_pr_number "mode=review_verdict"
 
-        # Resolve cleanup flag: auto enables for review_verdict mode
-        CLEANUP_NATIVE_REVIEWS=false
-        case "$(printf '%s' "${CLEANUP_PREVIOUS_NATIVE_REVIEWS:-auto}" | tr '[:upper:]' '[:lower:]')" in
-          true) CLEANUP_NATIVE_REVIEWS=true ;;
-          false) CLEANUP_NATIVE_REVIEWS=false ;;
-          auto|"") CLEANUP_NATIVE_REVIEWS=true ;;
-          *) echo "Invalid cleanup_previous_native_reviews value; expected auto, true, or false" >&2; exit 1 ;;
-        esac
-
-        # Cleanup previous managed native reviews if enabled
-        if [ "$CLEANUP_NATIVE_REVIEWS" = "true" ]; then
-          echo "Cleaning up previous managed native reviews for #$PR_NUMBER"
-          CURRENT_ACTOR="$(gh api user --jq .login 2>/dev/null || echo "")"
-          if [ -n "$CURRENT_ACTOR" ]; then
-            PREV_REVIEWS="$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" --paginate --jq '.[] | select(.user.login == "'"$CURRENT_ACTOR"'" and (.body | contains("<!-- ai-pr-reviewer -->"))) | .id' 2>/dev/null || echo "")"
-            if [ -n "$PREV_REVIEWS" ]; then
-              while IFS= read -r REVIEW_ID; do
-                if [ -z "$REVIEW_ID" ]; then continue; fi
-                # Dismiss approval/request-changes reviews to stop stale verdicts from counting
-                REVIEW_STATE="$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews/$REVIEW_ID" --jq '.state // ""' 2>/dev/null || echo "")"
-                if [ "$REVIEW_STATE" = "APPROVED" ] || [ "$REVIEW_STATE" = "CHANGES_REQUESTED" ]; then
-                  if gh api "repos/$REPO/pulls/$PR_NUMBER/reviews/$REVIEW_ID/dismissals" --method PUT -f message="Superseded by a newer automated review for this pull request." --jq '.id' >/dev/null 2>&1; then
-                    echo "  Dismissed outdated managed review #$REVIEW_ID ($REVIEW_STATE)"
-                  else
-                    echo "  WARN: Could not dismiss review #$REVIEW_ID (may require additional permissions)" >&2
-                  fi
-                fi
-                # Update body to compact outdated stub (best-effort)
-                OUTDATED_BODY="$(printf '<!-- ai-pr-reviewer -->\n_Outdated: superseded by a newer automated review._')"
-                if ! gh api "repos/$REPO/pulls/$PR_NUMBER/reviews/$REVIEW_ID" --method PATCH -f body="$OUTDATED_BODY" >/dev/null 2>&1; then
-                  echo "  WARN: Could not update review #$REVIEW_ID body (submitted reviews may be read-only)" >&2
-                else
-                  echo "  Marked review #$REVIEW_ID as outdated/superseded"
-                fi
-              done <<< "$PREV_REVIEWS"
-            else
-              echo "  No previous managed native reviews found for #$PR_NUMBER"
-            fi
-          else
-            echo "  WARN: Could not determine current actor; skipping cleanup" >&2
-          fi
-        fi
+        # Resolve cleanup flag and execute cleanup
+        CLEANUP_NATIVE_REVIEWS="$(resolve_cleanup_flag "${CLEANUP_PREVIOUS_NATIVE_REVIEWS:-auto}" "review_verdict")"
+        cleanup_native_reviews "$CLEANUP_NATIVE_REVIEWS"
 
         # Determine if the PR is from a fork
         IS_FORK_PR="$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '((.head.repo.full_name // "") != (.base.repo.full_name // ""))' 2>/dev/null || echo false)"
 
-        # Resolve effective scope from precheck
+        # Resolve effective scope and review result
         EFFECTIVE_SCOPE="${{ steps.precheck.outputs.effective_review_scope || 'full' }}"
         PREVIOUS_HEAD_SHA="${{ steps.precheck.outputs.previous_head_sha:-}}"
         BASELINE_CLEAN="${{ steps.precheck.outputs.baseline_clean:-false }}"
-
-        # Determine review result for metadata marker
         REVIEW_RESULT="clean"
         if [ "$VERDICT" = "request_changes" ]; then
           REVIEW_RESULT="issues"
         fi
 
         # Build metadata marker with verdict safety for incremental
-        METADATA_MARKER="<!-- ai-pr-reviewer:{\"version\":1,\"head_sha\":\"${HEAD_SHA:-unknown}\",\"base_sha\":\"${{ github.event.pull_request.base.sha || '' }}\",\"review_scope\":\"${EFFECTIVE_SCOPE}\",\"review_result\":\"${REVIEW_RESULT}\"}"
-        if [ "$EFFECTIVE_SCOPE" = "incremental" ] && [ -n "$PREVIOUS_HEAD_SHA" ]; then
-          METADATA_MARKER="${METADATA_MARKER%,*},\"previous_head_sha\":\"${PREVIOUS_HEAD_SHA}\"}"
-        fi
+        METADATA_MARKER="$(build_metadata_marker "${{ github.event.pull_request.base.sha || '' }}" "$PREVIOUS_HEAD_SHA")"
 
         # Evaluate approval guardrails with baseline check for incremental
         ALLOW_APPROVE_BOOL="$(printf '%s' "$ALLOW_APPROVE" | tr '[:upper:]' '[:lower:]')"

--- a/scripts/publish_helpers.sh
+++ b/scripts/publish_helpers.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Shared helpers for publish steps in action.yml.
+# Source this script from each publish step, then call the functions.
+
+# Sanitize model output: strip metadata markers and neutralize upstream references.
+# Args: $1 = output file path
+# Writes sanitized markdown to the output file using $REVIEW_MARKDOWN env var.
+sanitize_review_markdown() {
+  local output_file="$1"
+  printf '%s\n' "$REVIEW_MARKDOWN" > "$output_file"
+  python3 "${GITHUB_ACTION_PATH}/scripts/strip_metadata_markers.py" "$output_file"
+  python3 "${GITHUB_ACTION_PATH}/scripts/sanitize_review_markdown.py" "$output_file"
+}
+
+# Resolve cleanup flag based on input value and publish mode.
+# Args: $1 = CLEANUP_PREVIOUS_NATIVE_REVIEWS input, $2 = PUBLISH_MODE
+# Outputs: "true" or "false" to stdout
+resolve_cleanup_flag() {
+  local cleanup_input="$1"
+  local publish_mode="$2"
+  local result=false
+
+  case "$(printf '%s' "$cleanup_input" | tr '[:upper:]' '[:lower:]')" in
+    true) result=true ;;
+    false) result=false ;;
+    auto|"")
+      if [ "$publish_mode" = "review_comment" ] || [ "$publish_mode" = "review_verdict" ]; then
+        result=true
+      else
+        result=false
+      fi
+      ;;
+    *) echo "Invalid cleanup_previous_native_reviews value; expected auto, true, or false" >&2; return 1 ;;
+  esac
+
+  printf '%s' "$result"
+}
+
+# Cleanup previous managed native reviews.
+# Requires env: GH_TOKEN, REPO, PR_NUMBER
+# Args: $1 = resolved cleanup flag ("true"/"false")
+cleanup_native_reviews() {
+  local should_cleanup="$1"
+  if [ "$should_cleanup" != "true" ]; then
+    return 0
+  fi
+
+  echo "Cleaning up previous managed native reviews for #$PR_NUMBER"
+  CURRENT_ACTOR="$(gh api user --jq .login 2>/dev/null || echo "")"
+  if [ -n "$CURRENT_ACTOR" ]; then
+    PREV_REVIEWS="$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" --paginate --jq '.[] | select(.user.login == "'"$CURRENT_ACTOR"'" and (.body | contains("<!-- ai-pr-reviewer -->"))) | .id' 2>/dev/null || echo "")"
+    if [ -n "$PREV_REVIEWS" ]; then
+      while IFS= read -r REVIEW_ID; do
+        if [ -z "$REVIEW_ID" ]; then continue; fi
+        # Dismiss approval/request-changes reviews to stop stale verdicts from counting
+        REVIEW_STATE="$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews/$REVIEW_ID" --jq '.state // ""' 2>/dev/null || echo "")"
+        if [ "$REVIEW_STATE" = "APPROVED" ] || [ "$REVIEW_STATE" = "CHANGES_REQUESTED" ]; then
+          if gh api "repos/$REPO/pulls/$PR_NUMBER/reviews/$REVIEW_ID/dismissals" --method PUT -f message="Superseded by a newer automated review for this pull request." --jq '.id' >/dev/null 2>&1; then
+            echo "  Dismissed outdated managed review #$REVIEW_ID ($REVIEW_STATE)"
+          else
+            echo "  WARN: Could not dismiss review #$REVIEW_ID (may require additional permissions)" >&2
+          fi
+        fi
+        # Update body to compact outdated stub (best-effort)
+        OUTDATED_BODY="$(printf '<!-- ai-pr-reviewer -->\n_Outdated: superseded by a newer automated review._')"
+        if ! gh api "repos/$REPO/pulls/$PR_NUMBER/reviews/$REVIEW_ID" --method PATCH -f body="$OUTDATED_BODY" >/dev/null 2>&1; then
+          echo "  WARN: Could not update review #$REVIEW_ID body (submitted reviews may be read-only)" >&2
+        else
+          echo "  Marked review #$REVIEW_ID as outdated/superseded"
+        fi
+      done <<< "$PREV_REVIEWS"
+    else
+      echo "  No previous managed native reviews found for #$PR_NUMBER"
+    fi
+  else
+    echo "  WARN: Could not determine current actor; skipping cleanup" >&2
+  fi
+}
+
+# Build metadata marker JSON string.
+# Requires env: HEAD_SHA, EFFECTIVE_SCOPE, REVIEW_RESULT
+# Args: $1 = base_sha, $2 = previous_head_sha (optional, empty if not incremental)
+# Outputs: metadata marker string to stdout
+build_metadata_marker() {
+  local base_sha="$1"
+  local previous_head_sha="${2:-}"
+
+  local marker="<!-- ai-pr-reviewer:{\"version\":1,\"head_sha\":\"${HEAD_SHA:-unknown}\",\"base_sha\":\"${base_sha}\",\"review_scope\":\"${EFFECTIVE_SCOPE}\",\"review_result\":\"${REVIEW_RESULT}\"}"
+  if [ "$EFFECTIVE_SCOPE" = "incremental" ] && [ -n "$previous_head_sha" ]; then
+    marker="${marker%,*},\"previous_head_sha\":\"${previous_head_sha}\"}"
+  fi
+  printf '%s' "$marker"
+}
+
+# Validate that PR_NUMBER is set.
+# Requires env: PR_NUMBER
+# Args: $1 = mode description for error message
+validate_pr_number() {
+  local mode_desc="$1"
+  if [ -z "${PR_NUMBER:-}" ]; then
+    echo "publish_${mode_desc} requires a pull_request event or explicit pr_number" >&2
+    exit 1
+  fi
+}

--- a/tests/test_cleanup_previous_native_reviews.sh
+++ b/tests/test_cleanup_previous_native_reviews.sh
@@ -120,11 +120,11 @@ ACTION_YML="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/action.yml"
 BODY_CONTENT_REVIEW_COMMENT=$(awk '/Publish review comment \(non-blocking\)/,/^    - name: Publish review verdict/' "$ACTION_YML")
 BODY_CONTENT_REVIEW_VERDICT=$(awk '/Publish review verdict/,0' "$ACTION_YML")
 
-check_contains "review_comment body includes <!-- ai-pr-reviewer --> marker" \
-  "$BODY_CONTENT_REVIEW_COMMENT" "<!-- ai-pr-reviewer -->"
+check_contains "review_comment step uses METADATA_MARKER in body" \
+  "$BODY_CONTENT_REVIEW_COMMENT" "METADATA_MARKER"
 
-check_contains "review_verdict body includes <!-- ai-pr-reviewer --> marker" \
-  "$BODY_CONTENT_REVIEW_VERDICT" "<!-- ai-pr-reviewer -->"
+check_contains "review_verdict step uses METADATA_MARKER in body" \
+  "$BODY_CONTENT_REVIEW_VERDICT" "METADATA_MARKER"
 
 # Check that review_comment body does NOT have the marker in the sticky comment mode (comment mode)
 STICKY_COMMENT_BODY=$(awk '/Publish review comment$/,/^    - name: Publish review comment \(non-blocking\)/' "$ACTION_YML")
@@ -132,35 +132,52 @@ check_contains "sticky comment mode uses COMMENT_MARKER variable" \
   "$STICKY_COMMENT_BODY" "COMMENT_MARKER"
 
 echo ""
+echo "=== Helper script validation ==="
+
+HELPER_SCRIPT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/scripts/publish_helpers.sh"
+
+check_exists "publish_helpers.sh exists" \
+  "$(test -f "$HELPER_SCRIPT" && echo 1 || echo 0)"
+
+check_exists "publish_helpers.sh is executable" \
+  "$(test -x "$HELPER_SCRIPT" && echo 1 || echo 0)"
+
+check_contains "helper contains sanitize_review_markdown function" \
+  "$(cat "$HELPER_SCRIPT")" "sanitize_review_markdown"
+
+check_contains "helper contains resolve_cleanup_flag function" \
+  "$(cat "$HELPER_SCRIPT")" "resolve_cleanup_flag"
+
+check_contains "helper contains cleanup_native_reviews function" \
+  "$(cat "$HELPER_SCRIPT")" "cleanup_native_reviews"
+
+check_contains "helper contains build_metadata_marker function" \
+  "$(cat "$HELPER_SCRIPT")" "build_metadata_marker"
+
+echo ""
 echo "=== Cleanup logic presence validation ==="
 
-# Check that cleanup logic exists in both native review steps
-CLEANUP_REVIEW_COMMENT=$(awk '/Publish review comment \(non-blocking\)/,/^    - name: Publish review verdict/' "$ACTION_YML")
-CLEANUP_REVIEW_VERDICT=$(awk '/Publish review verdict/,0' "$ACTION_YML")
+# Verify native review steps source the helper script and call functions
+BODY_CONTENT_REVIEW_COMMENT=$(awk '/Publish review comment \(non-blocking\)/,/^    - name: Publish review verdict/' "$ACTION_YML")
+BODY_CONTENT_REVIEW_VERDICT=$(awk '/Publish review verdict/,0' "$ACTION_YML")
 
-check_exists "review_comment step has cleanup resolution" \
-  "$(grep -c 'resolve.*cleanup\|CLEANUP_NATIVE_REVIEWS' <<< "$CLEANUP_REVIEW_COMMENT" || echo 0)"
+check_contains "review_comment step sources publish_helpers.sh" \
+  "$BODY_CONTENT_REVIEW_COMMENT" "publish_helpers.sh"
 
-check_exists "review_verdict step has cleanup resolution" \
-  "$(grep -c 'resolve.*cleanup\|CLEANUP_NATIVE_REVIEWS' <<< "$CLEANUP_REVIEW_VERDICT" || echo 0)"
+check_contains "review_verdict step sources publish_helpers.sh" \
+  "$BODY_CONTENT_REVIEW_VERDICT" "publish_helpers.sh"
 
-check_exists "review_comment step queries previous reviews" \
-  "$(grep -c 'PREV_REVIEWS' <<< "$CLEANUP_REVIEW_COMMENT" || echo 0)"
+check_contains "review_comment step calls cleanup_native_reviews" \
+  "$BODY_CONTENT_REVIEW_COMMENT" "cleanup_native_reviews"
 
-check_exists "review_verdict step queries previous reviews" \
-  "$(grep -c 'PREV_REVIEWS' <<< "$CLEANUP_REVIEW_VERDICT" || echo 0)"
+check_contains "review_verdict step calls cleanup_native_reviews" \
+  "$BODY_CONTENT_REVIEW_VERDICT" "cleanup_native_reviews"
 
-check_exists "review_comment step attempts dismissal" \
-  "$(grep -c 'dismissals.*PUT\|Dismissed outdated' <<< "$CLEANUP_REVIEW_COMMENT" || echo 0)"
+check_contains "review_comment step calls resolve_cleanup_flag" \
+  "$BODY_CONTENT_REVIEW_COMMENT" "resolve_cleanup_flag"
 
-check_exists "review_verdict step attempts dismissal" \
-  "$(grep -c 'dismissals.*PUT\|Dismissed outdated' <<< "$CLEANUP_REVIEW_VERDICT" || echo 0)"
-
-check_exists "review_comment step updates outdated body" \
-  "$(grep -c 'Outdated: superseded\|OUTDATED_BODY' <<< "$CLEANUP_REVIEW_COMMENT" || echo 0)"
-
-check_exists "review_verdict step updates outdated body" \
-  "$(grep -c 'Outdated: superseded\|OUTDATED_BODY' <<< "$CLEANUP_REVIEW_VERDICT" || echo 0)"
+check_contains "review_verdict step calls resolve_cleanup_flag" \
+  "$BODY_CONTENT_REVIEW_VERDICT" "resolve_cleanup_flag"
 
 echo ""
 echo "=== Input definition validation ==="
@@ -172,10 +189,10 @@ check_contains "cleanup_previous_native_reviews default is auto" \
   "$(cat "$ACTION_YML")" 'default: "auto"'
 
 check_exists "action.yml has CLEANUP_PREVIOUS_NATIVE_REVIEWS env in review_comment step" \
-  "$(grep -c 'CLEANUP_PREVIOUS_NATIVE_REVIEWS' <<< "$CLEANUP_REVIEW_COMMENT" || echo 0)"
+  "$(grep -c 'CLEANUP_PREVIOUS_NATIVE_REVIEWS' <<< "$BODY_CONTENT_REVIEW_COMMENT" || echo 0)"
 
 check_exists "action.yml has CLEANUP_PREVIOUS_NATIVE_REVIEWS env in review_verdict step" \
-  "$(grep -c 'CLEANUP_PREVIOUS_NATIVE_REVIEWS' <<< "$CLEANUP_REVIEW_VERDICT" || echo 0)"
+  "$(grep -c 'CLEANUP_PREVIOUS_NATIVE_REVIEWS' <<< "$BODY_CONTENT_REVIEW_VERDICT" || echo 0)"
 
 echo ""
 echo "=== README.md documentation validation ==="


### PR DESCRIPTION
Fixes #116

## Summary

Extracts duplicated publish logic from `action.yml` into a shared helper script (`scripts/publish_helpers.sh`) so the `review_comment` and `review_verdict` modes cannot drift.

## Changes

- **New:** `scripts/publish_helpers.sh` — shared helper script with 5 functions:
  - `sanitize_review_markdown()` — strips metadata markers and neutralizes upstream references
  - `resolve_cleanup_flag()` — resolves `cleanup_previous_native_reviews` input against publish mode
  - `cleanup_native_reviews()` — queries, dismisses, and updates previous managed native reviews
  - `build_metadata_marker()` — constructs the JSON metadata marker for review bodies
  - `validate_pr_number()` — validates PR_NUMBER is set

- **Refactored:** All three publish steps in `action.yml` now source the helper and call shared functions:
  - Comment mode: uses `sanitize_review_markdown`, `validate_pr_number`, `build_metadata_marker`
  - `review_comment` mode: additionally uses `resolve_cleanup_flag`, `cleanup_native_reviews`
  - `review_verdict` mode: additionally uses `resolve_cleanup_flag`, `cleanup_native_reviews`

- **Updated:** `tests/test_cleanup_previous_native_reviews.sh` — validates helper script existence, function presence, and that native review steps source the helper

## Impact

- Removes ~180 lines of duplicated logic across three publish steps
- Prevents future drift between `review_comment` and `review_verdict` cleanup behavior
- All existing tests pass (35/35 cleanup tests, 22/22 approval guardrail tests)