### PR TITLE
fix: repair v1.1 action runtime failures

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -437,7 +437,7 @@ runs:
         fi
 
         # Build metadata marker
-        METADATA_MARKER="$(build_metadata_marker "${{ github.event.pull_request.base.sha || '' }}" "${{ steps.precheck.outputs.previous_head_sha:-}}")"
+        METADATA_MARKER="$(build_metadata_marker "${{ github.event.pull_request.base.sha || '' }}" "${{ steps.precheck.outputs.previous_head_sha || '' }}")"
 
         if [ "$VERDICT" = "request_changes" ]; then
           VERDICT_PREFIX="⚠️ **Automated recommendation: REQUEST CHANGES**"
@@ -552,8 +552,8 @@ runs:
 
         # Resolve effective scope and review result
         EFFECTIVE_SCOPE="${{ steps.precheck.outputs.effective_review_scope || 'full' }}"
-        PREVIOUS_HEAD_SHA="${{ steps.precheck.outputs.previous_head_sha:-}}"
-        BASELINE_CLEAN="${{ steps.precheck.outputs.baseline_clean:-false }}"
+        PREVIOUS_HEAD_SHA="${{ steps.precheck.outputs.previous_head_sha || '' }}"
+        BASELINE_CLEAN="${{ steps.precheck.outputs.baseline_clean || 'false' }}"
         REVIEW_RESULT="clean"
         if [ "$VERDICT" = "request_changes" ]; then
           REVIEW_RESULT="issues"

--- a/scripts/check_review_needed.sh
+++ b/scripts/check_review_needed.sh
@@ -7,6 +7,8 @@ COMMENT_MARKER="${COMMENT_MARKER:-<!-- ai-pr-reviewer -->}"
 SKIP_IF_DIFF_UNCHANGED="${SKIP_IF_DIFF_UNCHANGED:-true}"
 OUTPUT_FILE="${GITHUB_OUTPUT:-/dev/null}"
 REVIEW_SCOPE="${REVIEW_SCOPE:-auto}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export PYTHONPATH="${SCRIPT_DIR}/..${PYTHONPATH:+:${PYTHONPATH}}"
 
 if [[ -z "$REPO" || -z "$PR_NUMBER" ]]; then
   echo "Missing REPO or PR_NUMBER for review precheck" >&2
@@ -319,4 +321,3 @@ echo "baseline_clean=$BASELINE_CLEAN" >> "$OUTPUT_FILE"
 echo "diff_fingerprint=$broad_fingerprint" >> "$OUTPUT_FILE"
 echo "should_review=$should_review" >> "$OUTPUT_FILE"
 echo "skip_reason=$skip_reason" >> "$OUTPUT_FILE"
-

--- a/scripts/run_review.sh
+++ b/scripts/run_review.sh
@@ -48,6 +48,7 @@ enrichment_budget_ok() {
 }
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export PYTHONPATH="${SCRIPT_DIR}/..${PYTHONPATH:+:${PYTHONPATH}}"
 REPO="${REPO:-${GITHUB_REPOSITORY:-}}"
 PR_NUMBER="${PR_NUMBER:-}"
 AI_BASE_URL="${AI_BASE_URL:-}"

--- a/tests/test_action_python_path.py
+++ b/tests/test_action_python_path.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def test_runtime_scripts_export_action_root_pythonpath() -> None:
+    for script_name in ("run_review.sh", "check_review_needed.sh"):
+        script = (ROOT / "scripts" / script_name).read_text(encoding="utf-8")
+        assert 'export PYTHONPATH="${SCRIPT_DIR}/..${PYTHONPATH:+:${PYTHONPATH}}"' in script


### PR DESCRIPTION
## Summary

- replace shell-style `${{ steps.precheck.outputs.previous_head_sha:-... }}` defaults with valid GitHub expression `||` defaults
- fix the same invalid expression pattern for `baseline_clean`
- add the action checkout root to `PYTHONPATH` for runtime scripts so `pr_reviewer.*` imports work when the composite action runs from the caller repo

## Validation

- `python3 -m pytest -q` — 321 passed
- parsed `action.yml` with PyYAML
- verified no remaining `${{ ... :- ... }}` expressions in `action.yml`
- `git diff --check`

## Release

Tagged and released as `v1.1.2`; moved `v1` to this hotfix commit.
