### PR TITLE
fix: avoid shell substitution in review publish body

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -438,6 +438,10 @@ runs:
 
         # Build metadata marker
         METADATA_MARKER="$(build_metadata_marker "${{ github.event.pull_request.base.sha || '' }}" "${{ steps.precheck.outputs.previous_head_sha || '' }}")"
+        ANALYSIS_SCOPE_SUFFIX=""
+        if [ "$EFFECTIVE_SCOPE" = "incremental" ]; then
+          ANALYSIS_SCOPE_SUFFIX=" (incremental delta review)"
+        fi
 
         if [ "$VERDICT" = "request_changes" ]; then
           VERDICT_PREFIX="⚠️ **Automated recommendation: REQUEST CHANGES**"
@@ -455,7 +459,7 @@ runs:
           fi
           echo "$VERDICT_PREFIX"
           echo
-          echo "_Analysis engine: ${ANALYSIS_ENGINE}_$(if [ \"$EFFECTIVE_SCOPE\" = \"incremental\" ]; then echo \" (incremental delta review)\"; fi)_"
+          printf '_Analysis engine: %s%s_\n' "$ANALYSIS_ENGINE" "$ANALYSIS_SCOPE_SUFFIX"
           echo
           cat review-markdown.raw.md
         } > review-comment.md
@@ -498,6 +502,10 @@ runs:
 
         # Build metadata marker
         METADATA_MARKER="$(build_metadata_marker "${{ github.event.pull_request.base.sha || '' }}" "")"
+        ANALYSIS_SCOPE_SUFFIX=""
+        if [ "$EFFECTIVE_SCOPE" = "incremental" ]; then
+          ANALYSIS_SCOPE_SUFFIX=" (incremental delta review)"
+        fi
 
         # Build the review body with managed marker
         BODY_FILE="review-comment-body.md"
@@ -505,7 +513,7 @@ runs:
           echo "$METADATA_MARKER"
           echo "# AI Automated Review"
           echo
-          echo "_Analysis engine: ${ANALYSIS_ENGINE}_$(if [ \"$EFFECTIVE_SCOPE\" = \"incremental\" ]; then echo \" (incremental delta review)\"; fi)_"
+          printf '_Analysis engine: %s%s_\n' "$ANALYSIS_ENGINE" "$ANALYSIS_SCOPE_SUFFIX"
           echo
           cat review-comment-markdown.raw.md
         } > "$BODY_FILE"
@@ -561,6 +569,10 @@ runs:
 
         # Build metadata marker with verdict safety for incremental
         METADATA_MARKER="$(build_metadata_marker "${{ github.event.pull_request.base.sha || '' }}" "$PREVIOUS_HEAD_SHA")"
+        ANALYSIS_SCOPE_SUFFIX=""
+        if [ "$EFFECTIVE_SCOPE" = "incremental" ]; then
+          ANALYSIS_SCOPE_SUFFIX=" (incremental delta review)"
+        fi
 
         # Evaluate approval guardrails with baseline check for incremental
         ALLOW_APPROVE_BOOL="$(printf '%s' "$ALLOW_APPROVE" | tr '[:upper:]' '[:lower:]')"
@@ -595,7 +607,7 @@ runs:
             echo "_Full PR review._"
           fi
           echo
-          echo "_Analysis engine: ${ANALYSIS_ENGINE}_$(if [ \"$EFFECTIVE_SCOPE\" = \"incremental\" ]; then echo \" (incremental delta review)\"; fi)_"
+          printf '_Analysis engine: %s%s_\n' "$ANALYSIS_ENGINE" "$ANALYSIS_SCOPE_SUFFIX"
           echo
           cat review-verdict-markdown.raw.md
         } > "$BODY_FILE"

--- a/tests/test_action_shell_syntax.py
+++ b/tests/test_action_shell_syntax.py
@@ -1,0 +1,46 @@
+import re
+import subprocess
+import tempfile
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def _walk_steps(value):
+    if isinstance(value, dict):
+        if "run" in value:
+            yield value
+        for child in value.values():
+            yield from _walk_steps(child)
+    elif isinstance(value, list):
+        for child in value:
+            yield from _walk_steps(child)
+
+
+def _replace_github_expressions(script: str) -> str:
+    return re.sub(r"\$\{\{.*?\}\}", "GITHUB_EXPR", script, flags=re.DOTALL)
+
+
+def test_action_run_blocks_are_valid_bash_syntax() -> None:
+    action = yaml.safe_load((ROOT / "action.yml").read_text(encoding="utf-8"))
+    run_steps = list(_walk_steps(action))
+
+    assert run_steps, "expected action.yml to contain run steps"
+
+    for index, step in enumerate(run_steps, start=1):
+        name = step.get("name", f"run-step-{index}")
+        script = _replace_github_expressions(step["run"])
+        with tempfile.NamedTemporaryFile("w", suffix=".sh", encoding="utf-8") as handle:
+            handle.write(script)
+            handle.flush()
+            result = subprocess.run(
+                ["bash", "-n", handle.name],
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+        assert result.returncode == 0, f"{name} has invalid bash syntax:\n{result.stderr}"
+

--- a/tests/test_action_shell_syntax.py
+++ b/tests/test_action_shell_syntax.py
@@ -3,21 +3,40 @@ import subprocess
 import tempfile
 from pathlib import Path
 
-import yaml
-
 
 ROOT = Path(__file__).resolve().parent.parent
 
 
-def _walk_steps(value):
-    if isinstance(value, dict):
-        if "run" in value:
-            yield value
-        for child in value.values():
-            yield from _walk_steps(child)
-    elif isinstance(value, list):
-        for child in value:
-            yield from _walk_steps(child)
+def _leading_spaces(line: str) -> int:
+    return len(line) - len(line.lstrip(" "))
+
+
+def _extract_literal_run_blocks(action_yml: str) -> list[tuple[str, str]]:
+    lines = action_yml.splitlines()
+    blocks: list[tuple[str, str]] = []
+    last_step_name = "unnamed run step"
+    index = 0
+
+    while index < len(lines):
+        line = lines[index]
+        stripped = line.strip()
+        if stripped.startswith("- name:"):
+            last_step_name = stripped.removeprefix("- name:").strip().strip('"')
+        if stripped == "run: |":
+            run_indent = _leading_spaces(line)
+            block_lines: list[str] = []
+            index += 1
+            while index < len(lines):
+                candidate = lines[index]
+                if candidate.strip() and _leading_spaces(candidate) <= run_indent:
+                    break
+                block_lines.append(candidate[run_indent + 2 :] if len(candidate) > run_indent + 1 else "")
+                index += 1
+            blocks.append((last_step_name, "\n".join(block_lines)))
+            continue
+        index += 1
+
+    return blocks
 
 
 def _replace_github_expressions(script: str) -> str:
@@ -25,14 +44,12 @@ def _replace_github_expressions(script: str) -> str:
 
 
 def test_action_run_blocks_are_valid_bash_syntax() -> None:
-    action = yaml.safe_load((ROOT / "action.yml").read_text(encoding="utf-8"))
-    run_steps = list(_walk_steps(action))
+    run_steps = _extract_literal_run_blocks((ROOT / "action.yml").read_text(encoding="utf-8"))
 
     assert run_steps, "expected action.yml to contain run steps"
 
-    for index, step in enumerate(run_steps, start=1):
-        name = step.get("name", f"run-step-{index}")
-        script = _replace_github_expressions(step["run"])
+    for name, run_block in run_steps:
+        script = _replace_github_expressions(run_block)
         with tempfile.NamedTemporaryFile("w", suffix=".sh", encoding="utf-8") as handle:
             handle.write(script)
             handle.flush()
@@ -43,4 +60,3 @@ def test_action_run_blocks_are_valid_bash_syntax() -> None:
                 check=False,
             )
         assert result.returncode == 0, f"{name} has invalid bash syntax:\n{result.stderr}"
-


### PR DESCRIPTION
## Summary

- replace fragile inline command substitution in review publish body generation with explicit suffix variables and `printf`
- fix publish failures when `ANALYSIS_ENGINE` includes parenthesized provider text
- add a dependency-free shell-syntax regression test for every `run:` block in `action.yml`

## Validation

- `python3 -m pytest -q` — 322 passed
- `git diff --check`

## Release

Tagged and released as `v1.1.4`; moved `v1` to this hotfix commit.
