### PR TITLE
fix: use gh pr comment for review_comment mode (visible in PR UI)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -524,7 +524,9 @@ runs:
           echo "Submitting non-blocking review comment (approve) for #$PR_NUMBER"
         fi
 
-        gh pr review "$PR_NUMBER" --repo "$REPO" --comment --body-file "$BODY_FILE"
+        # NOTE: gh pr review --comment creates a COMMENTED review that is NOT visible in the PR UI timeline.
+        # Use gh pr comment instead for visibility, with --edit-last/--create-if-none for sticky behavior.
+        gh pr comment "$PR_NUMBER" --repo "$REPO" --edit-last --create-if-none --body-file "$BODY_FILE"
 
     - name: Publish review verdict (native PR review)
       if: inputs.publish_mode == 'review_verdict' && steps.precheck.outputs.should_review == 'true'


### PR DESCRIPTION
## Problem

`review_comment` publish mode used `gh pr review --comment` which creates a COMMENTED review. GitHub does NOT display the body of COMMENTED reviews in the PR timeline/UI — they appear as "Commented" but the actual review text is invisible to humans.

## Fix

Replace with `gh pr comment --edit-last --create-if-none` for sticky, visible PR comments. This gives the same managed-marker behavior and cleanup support, but actually shows the review content in the PR UI.

## Testing

- All 322 tests pass
- Action YAML syntax validated
