### PR TITLE
fix: make skip-if-unchanged and incremental review actually work

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,7 @@ jobs:
         run: ruby -e 'require "yaml"; YAML.load_file("examples/workflow-self-hosted.yml"); YAML.load_file("examples/workflow-cloud.yml")'
 
       - name: Check shell scripts
-        run: bash -n scripts/check_review_needed.sh && bash -n scripts/run_review.sh && bash -n tests/smoke_test.sh && bash -n tests/test_check_review_needed.sh && bash -n tests/test_approval_guardrails.sh && bash -n tests/test_tool_harness_enforcement.sh
+        run: bash -n scripts/check_review_needed.sh && bash -n scripts/run_review.sh && bash -n tests/smoke_test.sh && bash -n tests/test_check_review_needed.sh && bash -n tests/test_approval_guardrails.sh && bash -n tests/test_tool_harness_enforcement.sh && bash -n tests/test_cleanup_previous_native_reviews.sh
 
       - name: Check Python scripts
         run: python3 -m py_compile scripts/image_digest_analysis.py scripts/run_evidence_providers.py scripts/run_tool_harness.py tests/mock_openai_server.py tests/test_model_parsing.py tests/test_redact.py tests/test_strip_metadata_markers.py tests/test_evidence_providers.py
@@ -52,3 +52,6 @@ jobs:
 
       - name: Run tool harness enforcement tests
         run: bash tests/test_tool_harness_enforcement.sh
+
+      - name: Run native review cleanup + marker emission tests
+        run: bash tests/test_cleanup_previous_native_reviews.sh

--- a/action.yml
+++ b/action.yml
@@ -300,6 +300,7 @@ runs:
         REPO: ${{ inputs.repo || github.repository }}
         PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
         COMMENT_MARKER: ${{ inputs.comment_marker }}
+        PUBLISH_MODE: ${{ inputs.publish_mode }}
         REVIEW_SCOPE: ${{ inputs.review_scope }}
         SKIP_IF_DIFF_UNCHANGED: ${{ inputs.skip_if_diff_unchanged }}
         ACTION_REF: ${{ github.action_ref }}
@@ -450,6 +451,7 @@ runs:
         fi
 
         {
+          echo "$COMMENT_MARKER"
           echo "$METADATA_MARKER"
           if [ -n "${HEAD_SHA:-}" ]; then
             echo "<!-- ai-pr-review-sha:${HEAD_SHA} -->"
@@ -477,6 +479,8 @@ runs:
         VERDICT: ${{ steps.review.outputs.verdict }}
         REVIEW_MARKDOWN: ${{ steps.review.outputs.review_markdown }}
         ANALYSIS_ENGINE: ${{ steps.review.outputs.analysis_engine }}
+        COMMENT_MARKER: ${{ inputs.comment_marker }}
+        BROAD_FINGERPRINT: ${{ steps.precheck.outputs.diff_fingerprint }}
         CLEANUP_PREVIOUS_NATIVE_REVIEWS: ${{ inputs.cleanup_previous_native_reviews }}
         GITHUB_ACTION_PATH: ${{ github.action_path }}
       run: |
@@ -510,7 +514,14 @@ runs:
         # Build the review body with managed marker
         BODY_FILE="review-comment-body.md"
         {
+          echo "$COMMENT_MARKER"
           echo "$METADATA_MARKER"
+          if [ -n "${HEAD_SHA:-}" ]; then
+            echo "<!-- ai-pr-review-sha:${HEAD_SHA} -->"
+          fi
+          if [ -n "${BROAD_FINGERPRINT:-}" ]; then
+            echo "<!-- ai-pr-review-fingerprint:${BROAD_FINGERPRINT} -->"
+          fi
           echo "# AI Automated Review"
           echo
           printf '_Analysis engine: %s%s_\n' "$ANALYSIS_ENGINE" "$ANALYSIS_SCOPE_SUFFIX"
@@ -541,6 +552,8 @@ runs:
         ANALYSIS_ENGINE: ${{ steps.review.outputs.analysis_engine }}
         ALLOW_APPROVE: ${{ inputs.allow_approve }}
         APPROVE_FORKS: ${{ inputs.approve_forks }}
+        COMMENT_MARKER: ${{ inputs.comment_marker }}
+        BROAD_FINGERPRINT: ${{ steps.precheck.outputs.diff_fingerprint }}
         CLEANUP_PREVIOUS_NATIVE_REVIEWS: ${{ inputs.cleanup_previous_native_reviews }}
         GITHUB_ACTION_PATH: ${{ github.action_path }}
       run: |
@@ -600,7 +613,14 @@ runs:
         # Build the review body with managed marker
         BODY_FILE="review-verdict-body.md"
         {
+          echo "$COMMENT_MARKER"
           echo "$METADATA_MARKER"
+          if [ -n "${HEAD_SHA:-}" ]; then
+            echo "<!-- ai-pr-review-sha:${HEAD_SHA} -->"
+          fi
+          if [ -n "${BROAD_FINGERPRINT:-}" ]; then
+            echo "<!-- ai-pr-review-fingerprint:${BROAD_FINGERPRINT} -->"
+          fi
           echo "# AI Automated Review"
           echo
           if [ "$EFFECTIVE_SCOPE" = "incremental" ]; then

--- a/scripts/check_review_needed.sh
+++ b/scripts/check_review_needed.sh
@@ -7,6 +7,7 @@ COMMENT_MARKER="${COMMENT_MARKER:-<!-- ai-pr-reviewer -->}"
 SKIP_IF_DIFF_UNCHANGED="${SKIP_IF_DIFF_UNCHANGED:-true}"
 OUTPUT_FILE="${GITHUB_OUTPUT:-/dev/null}"
 REVIEW_SCOPE="${REVIEW_SCOPE:-auto}"
+PUBLISH_MODE="${PUBLISH_MODE:-comment}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 export PYTHONPATH="${SCRIPT_DIR}/..${PYTHONPATH:+:${PYTHONPATH}}"
 
@@ -16,7 +17,9 @@ if [[ -z "$REPO" || -z "$PR_NUMBER" ]]; then
 fi
 
 # ── Diff fingerprint (unchanged) ──────────────────────────────────────
-current_fingerprint="$(gh pr diff "$PR_NUMBER" --repo "$REPO" | git patch-id --stable | awk 'NR == 1 { print $1 }')"
+# Tolerate a failing `gh pr diff` (network/auth blip) under `set -o pipefail`
+# so the precheck degrades to a fresh review instead of aborting the action.
+current_fingerprint="$( { gh pr diff "$PR_NUMBER" --repo "$REPO" || true; } | git patch-id --stable | awk 'NR == 1 { print $1 }' || true)"
 if [[ -z "$current_fingerprint" ]]; then
   current_fingerprint="empty-diff"
 fi
@@ -157,16 +160,39 @@ config_hash="$(compute_config_hash)"
 # Broader fingerprint = patch_id + config_hash (pipe-delimited)
 broad_fingerprint="${current_fingerprint}|cfg:${config_hash}"
 
-# ── Last review comment lookup ────────────────────────────────────────
-last_comment_body="$({
-  gh api "repos/$REPO/issues/$PR_NUMBER/comments?per_page=100" | \
+# ── Last managed review body lookup ───────────────────────────────────
+# The managed body lives in a different place depending on publish mode:
+# `comment` and `review_comment` write an issue comment; `review_verdict`
+# submits a native PR review. Look in the right place so skip-if-unchanged
+# and incremental scope can find prior state in every mode.
+last_managed_comment_body() {
+  gh api "repos/$REPO/issues/$PR_NUMBER/comments?per_page=100" 2>/dev/null | \
     jq -r --arg marker "$COMMENT_MARKER" '
       [ .[] | select((.body // "") | contains($marker)) ]
       | sort_by(.updated_at // .created_at)
       | last
       | .body // empty
     '
-} || true)"
+}
+
+last_managed_review_body() {
+  gh api "repos/$REPO/pulls/$PR_NUMBER/reviews?per_page=100" 2>/dev/null | \
+    jq -r --arg marker "$COMMENT_MARKER" '
+      [ .[] | select((.body // "") | contains($marker)) ]
+      | sort_by(.submitted_at // "")
+      | last
+      | .body // empty
+    '
+}
+
+case "$(printf '%s' "$PUBLISH_MODE" | tr '[:upper:]' '[:lower:]')" in
+  review_verdict)
+    last_comment_body="$(last_managed_review_body || true)"
+    ;;
+  *)
+    last_comment_body="$(last_managed_comment_body || true)"
+    ;;
+esac
 
 # Extract the PR head SHA and broad fingerprint from the last published comment.
 # ai-pr-review-sha: stored for future out-of-date detection (not yet used in skip logic).
@@ -314,9 +340,14 @@ if [[ -n "$last_comment_body" ]]; then
   extract_review_metadata "$last_comment_body"
 fi
 
-# Get current PR head/base SHAs
-CURRENT_HEAD_SHA="$(jq -r '.headRefOid' pr.json 2>/dev/null || echo "")"
-CURRENT_BASE_SHA="$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.base.sha' 2>/dev/null || echo "")"
+# Get current PR head/base SHAs. pr.json is not created until run_review.sh
+# runs (a later step), so reading it here always yielded an empty head SHA and
+# the force-push ancestor guard below never ran. Fetch both from the API in a
+# single call instead.
+pr_head_base_json="$(gh api "repos/$REPO/pulls/$PR_NUMBER" 2>/dev/null || true)"
+[[ -n "$pr_head_base_json" ]] || pr_head_base_json='{}'
+CURRENT_HEAD_SHA="$(printf '%s' "$pr_head_base_json" | jq -r '.head.sha // ""' 2>/dev/null || echo "")"
+CURRENT_BASE_SHA="$(printf '%s' "$pr_head_base_json" | jq -r '.base.sha // ""' 2>/dev/null || echo "")"
 
 # Resolve effective review scope
 resolve_review_scope "$REVIEW_SCOPE" "$LAST_HEAD_SHA" "$LAST_BASE_SHA" \

--- a/tests/test_check_review_needed.sh
+++ b/tests/test_check_review_needed.sh
@@ -49,7 +49,9 @@ case "$1" in
     esac
     ;;
   "api")
-    if echo "$*" | grep -q 'comments'; then
+    if echo "$*" | grep -q 'reviews'; then
+      [ -f /tmp/testfp_reviews.json ] && cat /tmp/testfp_reviews.json
+    elif echo "$*" | grep -q 'comments'; then
       cat /tmp/testfp_comments.json
     fi
     ;;
@@ -94,9 +96,19 @@ run_precheck() {
     TOOL_ENABLE_FOR_FORKS="${TOOL_ENABLE_FOR_FORKS:-false}" \
     SKIP_IF_DIFF_UNCHANGED="${SKIP_IF_DIFF_UNCHANGED:-true}" \
     COMMENT_MARKER="${COMMENT_MARKER:-<!-- ai-pr-reviewer -->}" \
+    PUBLISH_MODE="${PUBLISH_MODE:-comment}" \
     bash "$PRECHECK_SCRIPT"
   )
   cat "$output_file"
+}
+
+set_reviews() {
+  local body="$1"
+  python3 <<PYEOF > /tmp/testfp_reviews.json
+import json
+body = """${body}"""
+print(json.dumps([{"body": body, "submitted_at": "2024-01-01T00:00:00Z"}]))
+PYEOF
 }
 
 set_comments() {
@@ -221,6 +233,32 @@ unset ACTION_REF
 RESULT="$(run_precheck)"
 
 check "should_review=false when everything matches" "$(echo "$RESULT" | grep '^should_review=' | head -1 | cut -d= -f2)" "false"
+
+# ── Test 11: review_verdict mode reads prior state from PR reviews ────
+echo ""
+echo "=== Test 11: review_verdict mode finds the fingerprint in a PR review → skip ==="
+unset ACTION_REF
+rm -f /tmp/testfp_reviews.json
+set_empty_comments
+OUTPUT_FP_RV="$(PUBLISH_MODE=review_verdict run_precheck)"
+BROAD_FP_RV="$(echo "$OUTPUT_FP_RV" | grep '^diff_fingerprint=' | head -1 | cut -d= -f2)"
+set_reviews "<!-- ai-pr-reviewer -->
+<!-- ai-pr-review-fingerprint:${BROAD_FP_RV} -->
+APPROVE"
+RESULT="$(PUBLISH_MODE=review_verdict run_precheck)"
+check "should_review=false when a PR review fingerprint matches (review_verdict)" "$(echo "$RESULT" | grep '^should_review=' | head -1 | cut -d= -f2)" "false"
+
+# ── Test 12: review_verdict ignores issue comments for prior state ───
+echo ""
+echo "=== Test 12: review_verdict does not read issue comments for prior state ==="
+rm -f /tmp/testfp_reviews.json
+# The matching fingerprint is only in an issue comment now; with no PR review
+# carrying it, review_verdict mode must fall back to a fresh review.
+set_comments "<!-- ai-pr-reviewer -->
+<!-- ai-pr-review-fingerprint:${BROAD_FP_RV} -->
+APPROVE"
+RESULT="$(PUBLISH_MODE=review_verdict run_precheck)"
+check "should_review=true when only an issue comment matches (review_verdict)" "$(echo "$RESULT" | grep '^should_review=' | head -1 | cut -d= -f2)" "true"
 
 echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="

--- a/tests/test_cleanup_previous_native_reviews.sh
+++ b/tests/test_cleanup_previous_native_reviews.sh
@@ -131,6 +131,22 @@ STICKY_COMMENT_BODY=$(awk '/Publish review comment$/,/^    - name: Publish revie
 check_contains "sticky comment mode uses COMMENT_MARKER variable" \
   "$STICKY_COMMENT_BODY" "COMMENT_MARKER"
 
+# Every published body must carry the bare COMMENT_MARKER and the fingerprint
+# marker, otherwise the precheck cannot find prior state and skip-if-unchanged /
+# incremental scope silently never trigger (regression guard).
+check_contains "sticky comment body emits the bare COMMENT_MARKER" \
+  "$STICKY_COMMENT_BODY" 'echo "$COMMENT_MARKER"'
+check_contains "sticky comment body emits the fingerprint marker" \
+  "$STICKY_COMMENT_BODY" "ai-pr-review-fingerprint"
+check_contains "review_comment body emits the bare COMMENT_MARKER" \
+  "$BODY_CONTENT_REVIEW_COMMENT" 'echo "$COMMENT_MARKER"'
+check_contains "review_comment body emits the fingerprint marker" \
+  "$BODY_CONTENT_REVIEW_COMMENT" "ai-pr-review-fingerprint"
+check_contains "review_verdict body emits the bare COMMENT_MARKER" \
+  "$BODY_CONTENT_REVIEW_VERDICT" 'echo "$COMMENT_MARKER"'
+check_contains "review_verdict body emits the fingerprint marker" \
+  "$BODY_CONTENT_REVIEW_VERDICT" "ai-pr-review-fingerprint"
+
 echo ""
 echo "=== Helper script validation ==="
 


### PR DESCRIPTION
The managed-comment marker chain was broken end to end — nothing was ever skipped, and every review ran as a full review in every publish mode.

## Root causes
1. **The bare marker was never emitted.** The precheck (issue comments) and `cleanup_native_reviews` (PR reviews) both search for `<!-- ai-pr-reviewer -->`, but every publish body emitted only the `<!-- ai-pr-reviewer:{json} -->` metadata marker — which does not contain the bare string. Prior state was never found, so skip and incremental never engaged and native-review cleanup no-op'd.
2. **Fingerprint markers only in `comment` mode.** `review_comment` / `review_verdict` bodies omitted the sha + fingerprint markers, so skip-if-unchanged couldn't work there even once the body was found.
3. **`review_verdict` state lives in a PR review, not a comment.** The precheck only scanned issue comments, so in the dogfooded mode it could never find prior state.
4. **Force-push guard was dead code.** `CURRENT_HEAD_SHA` was read from `pr.json`, which `run_review.sh` only creates in a later step — so it was always empty and the rebase/force-push ancestor check never ran.

## Changes
- **`action.yml`** — emit the bare `COMMENT_MARKER` + sha + fingerprint markers in all three publish bodies; wire `COMMENT_MARKER` and `BROAD_FINGERPRINT` into the `review_comment` and `review_verdict` steps; pass `PUBLISH_MODE` into the precheck.
- **`check_review_needed.sh`** — look up prior managed state from PR reviews when `publish_mode=review_verdict` and from issue comments otherwise; fetch head/base SHAs from the API in one call (drops the broken `pr.json` dependency, so the force-push guard runs); tolerate a failing `gh pr diff` under `pipefail` so the precheck degrades to a fresh review instead of aborting the action.

## Tests
- `test_check_review_needed.sh`: +2 tests covering the `review_verdict` reviews-scan path (finds a fingerprint in a PR review → skips; ignores issue comments in that mode). This suite runs in CI.
- `test_cleanup_previous_native_reviews.sh`: +6 regression guards asserting every publish body emits the bare marker and the fingerprint marker — and **wired this suite into CI**, which previously did not run it (a test blind spot).
- Full suite green locally: 386 pytest + all bash suites.

> Note: CI still runs only some bash suites explicitly; `test_review_scope.sh`, `test_verdict_safety.sh`, `test_ci_status_check.sh`, and `test_standards_file_resolution.sh` aren't wired in. Worth a follow-up.
