### PR TITLE
fix: harden response parsing & SSE reassembly for local models

### DIFF
--- a/pr_reviewer/response_parser.py
+++ b/pr_reviewer/response_parser.py
@@ -109,6 +109,67 @@ def _try_decode_json(text: str) -> Any | None:
 
 
 # ---------------------------------------------------------------------------
+# Verdict normalisation, truncation, and stream-error detection
+# ---------------------------------------------------------------------------
+
+# finish_reason / stop_reason values that indicate the model hit the token cap.
+_TRUNCATION_REASONS = {"length", "max_tokens", "max_output_tokens"}
+
+_APPROVE_VERDICTS = {"approve", "approved", "approval", "lgtm"}
+_REQUEST_CHANGES_VERDICTS = {
+    "request_changes", "request_change", "requestchanges",
+    "changes_requested", "change_requested", "needs_changes",
+    "needs_change", "reject", "rejected",
+}
+
+
+def _normalize_verdict(value: Any) -> str | None:
+    """Map common local-model verdict spellings to the canonical value.
+
+    Weaker models frequently return ``"Approve"``, ``"approved"``,
+    ``"request changes"``, ``"REQUEST_CHANGES"`` and similar. Returns
+    ``"approve"``, ``"request_changes"``, or ``None`` if unrecognised.
+    """
+    if not isinstance(value, str):
+        return None
+    collapsed = "_".join(value.strip().lower().split()).replace("-", "_")
+    if collapsed in _APPROVE_VERDICTS:
+        return "approve"
+    if collapsed in _REQUEST_CHANGES_VERDICTS:
+        return "request_changes"
+    return None
+
+
+def _finish_reason(response: dict[str, Any]) -> str | None:
+    """Best-effort extraction of the model's stop/finish reason."""
+    choices = response.get("choices")
+    if isinstance(choices, list) and choices and isinstance(choices[0], dict):
+        fr = choices[0].get("finish_reason")
+        if isinstance(fr, str):
+            return fr
+    sr = response.get("stop_reason")
+    if isinstance(sr, str):
+        return sr
+    return None
+
+
+def _surface_stream_error(response: dict[str, Any]) -> None:
+    """Raise SystemExit if the response carries a transport/stream error.
+
+    The SSE reassembler records provider error events under an ``error`` key so
+    a mid-stream error is reported instead of looking like empty output.
+    """
+    err = response.get("error")
+    if not err:
+        return
+    if isinstance(err, dict):
+        msg = err.get("message") or json.dumps(err)
+    else:
+        msg = str(err)
+    raise SystemExit(f"Model endpoint returned an error: {msg}")
+
+
+# ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
 
@@ -131,6 +192,8 @@ def parse_response(response: dict[str, Any]) -> dict[str, Any]:
         If no JSON can be extracted, or the result is not a dict with the
         expected fields.
     """
+    _surface_stream_error(response)
+
     raw = _extract_content(response)
     if isinstance(raw, list):
         text = "".join(raw).strip()
@@ -147,26 +210,40 @@ def parse_response(response: dict[str, Any]) -> dict[str, Any]:
     if isinstance(parsed, list) and len(parsed) == 1 and isinstance(parsed[0], dict):
         parsed = parsed[0]
 
+    # A truncated generation is the most common cause of parse/validation
+    # failure on small local models. Surface it explicitly so the operator
+    # knows to raise ai_max_tokens rather than chasing a generic parse error.
+    finish = _finish_reason(response)
+    trunc = (
+        " (model output appears truncated at the token limit; increase ai_max_tokens)"
+        if finish in _TRUNCATION_REASONS
+        else ""
+    )
+
     if not isinstance(parsed, dict):
         raise SystemExit(
-            f"Expected JSON object but got {type(parsed).__name__}"
+            f"Expected JSON object but got {type(parsed).__name__}{trunc}"
         )
 
     # Validate required keys
     if "verdict" not in parsed:
-        raise SystemExit("Parsed JSON missing required key 'verdict'")
+        raise SystemExit(f"Parsed JSON missing required key 'verdict'{trunc}")
     if "review_markdown" not in parsed:
-        raise SystemExit("Parsed JSON missing required key 'review_markdown'")
+        raise SystemExit(f"Parsed JSON missing required key 'review_markdown'{trunc}")
 
-    verdict = parsed.get("verdict")
-    if verdict not in ("approve", "request_changes"):
+    raw_verdict = parsed.get("verdict")
+    verdict = _normalize_verdict(raw_verdict)
+    if verdict is None:
         raise SystemExit(
-            f"Expected verdict to be 'approve' or 'request_changes', got '{verdict}'"
+            f"Expected verdict to be 'approve' or 'request_changes', got '{raw_verdict}'"
         )
+    # Write back the canonical value so downstream consumers (jq -r '.verdict')
+    # always see 'approve' or 'request_changes'.
+    parsed["verdict"] = verdict
 
     markdown = parsed.get("review_markdown")
     if not isinstance(markdown, str) or not markdown.strip():
-        raise SystemExit("Parsed JSON has empty or missing 'review_markdown'")
+        raise SystemExit(f"Parsed JSON has empty or missing 'review_markdown'{trunc}")
 
     return parsed
 

--- a/pr_reviewer/sse_reassembler.py
+++ b/pr_reviewer/sse_reassembler.py
@@ -31,8 +31,27 @@ def reassemble_sse(response_text: str, api_format: str) -> dict:
     content_parts: list[str] = []
 
     if api_format == "anthropic":
-        return _reassemble_anthropic(lines, content_parts)
-    return _reassemble_openai(lines, content_parts)
+        result = _reassemble_anthropic(lines, content_parts)
+    else:
+        result = _reassemble_openai(lines, content_parts)
+
+    # Some local servers (llama.cpp/vLLM/ollama under load, or a proxy) return a
+    # plain JSON error body — sometimes with HTTP 200 — instead of an SSE stream.
+    # Without this, the reassembler yields empty content that looks like a
+    # successful-but-blank completion, masking the real failure and burning the
+    # whole retry budget. If we recovered no content and no error, try parsing
+    # the whole body as a JSON error.
+    if not result["choices"][0]["message"]["content"] and "error" not in result:
+        stripped = response_text.strip()
+        if stripped:
+            try:
+                whole = json.loads(stripped)
+            except (json.JSONDecodeError, ValueError):
+                whole = None
+            if isinstance(whole, dict) and whole.get("error"):
+                result["error"] = whole["error"]
+
+    return result
 
 
 def _reassemble_anthropic(lines: list[str], content_parts: list[str]) -> dict:
@@ -42,6 +61,7 @@ def _reassemble_anthropic(lines: list[str], content_parts: list[str]) -> dict:
     model: str | None = None
     input_tokens = 0
     output_tokens = 0
+    error_payload = None
 
     for line in lines:
         line = line.strip()
@@ -56,6 +76,9 @@ def _reassemble_anthropic(lines: list[str], content_parts: list[str]) -> dict:
             continue
 
         etype = event.get("type", "")
+        if etype == "error":
+            error_payload = event.get("error") or event
+            continue
         if etype == "message_start":
             message_id = event.get("message", {}).get("id")
             model = event.get("message", {}).get("model")
@@ -76,7 +99,7 @@ def _reassemble_anthropic(lines: list[str], content_parts: list[str]) -> dict:
                 output_tokens += usage.get("output_tokens", 0)
 
     content_text = "".join(content_parts)
-    return {
+    result = {
         "id": message_id or "",
         "object": "chat.completion",
         "model": model or "",
@@ -91,6 +114,9 @@ def _reassemble_anthropic(lines: list[str], content_parts: list[str]) -> dict:
             "total_tokens": input_tokens + output_tokens,
         },
     }
+    if error_payload is not None:
+        result["error"] = error_payload
+    return result
 
 
 def _reassemble_openai(lines: list[str], content_parts: list[str]) -> dict:
@@ -99,6 +125,7 @@ def _reassemble_openai(lines: list[str], content_parts: list[str]) -> dict:
     usage_prompt_tokens = 0
     usage_completion_tokens = 0
     id_val = ""
+    error_payload = None
 
     for line in lines:
         line = line.strip()
@@ -110,6 +137,10 @@ def _reassemble_openai(lines: list[str], content_parts: list[str]) -> dict:
         try:
             chunk = json.loads(data)
         except json.JSONDecodeError:
+            continue
+
+        if isinstance(chunk, dict) and chunk.get("error"):
+            error_payload = chunk["error"]
             continue
 
         id_val = chunk.get("id", id_val)
@@ -130,7 +161,7 @@ def _reassemble_openai(lines: list[str], content_parts: list[str]) -> dict:
             usage_completion_tokens += usage.get("completion_tokens", 0)
 
     content_text = "".join(content_parts)
-    return {
+    result = {
         "id": id_val,
         "object": "chat.completion",
         "model": model or "",
@@ -145,6 +176,9 @@ def _reassemble_openai(lines: list[str], content_parts: list[str]) -> dict:
             "total_tokens": usage_prompt_tokens + usage_completion_tokens,
         },
     }
+    if error_payload is not None:
+        result["error"] = error_payload
+    return result
 
 
 def reassemble_sse_file(response_path: str, api_format: str) -> dict:

--- a/tests/test_response_parser.py
+++ b/tests/test_response_parser.py
@@ -259,5 +259,70 @@ class TestParseResponseFile:
         assert "typo" in result["review_markdown"]
 
 
+# ---------------------------------------------------------------------------
+# Verdict normalisation, truncation, and stream-error handling
+# ---------------------------------------------------------------------------
+
+def _exit_msg(resp: dict) -> str:
+    """Call parse_response expecting SystemExit; return the message."""
+    try:
+        parse_response(resp)
+    except SystemExit as exc:
+        return str(exc)
+    raise AssertionError("expected SystemExit but parse_response returned")
+
+
+class TestVerdictNormalization:
+    @staticmethod
+    def _resp(verdict: str, finish_reason: str = "stop") -> dict:
+        return {
+            "choices": [{
+                "message": {"content": json.dumps(
+                    {"verdict": verdict, "review_markdown": "# ok"}
+                )},
+                "finish_reason": finish_reason,
+            }],
+        }
+
+    def test_capitalized_approve(self):
+        assert parse_response(self._resp("Approve"))["verdict"] == "approve"
+
+    def test_approved_synonym(self):
+        assert parse_response(self._resp("APPROVED"))["verdict"] == "approve"
+
+    def test_spaced_request_changes(self):
+        assert parse_response(self._resp("Request Changes"))["verdict"] == "request_changes"
+
+    def test_changes_requested_synonym(self):
+        assert parse_response(self._resp("changes_requested"))["verdict"] == "request_changes"
+
+    def test_unknown_verdict_still_rejected(self):
+        assert "Expected verdict" in _exit_msg(self._resp("maybe"))
+
+
+class TestTruncationAndStreamError:
+    def test_truncation_hint_openai_length(self):
+        # Unparseable (truncated) content with finish_reason=length.
+        resp = {"choices": [{"message": {"content": '{"verdict": "approve"'},
+                             "finish_reason": "length"}]}
+        assert "truncated" in _exit_msg(resp)
+
+    def test_truncation_hint_anthropic_max_tokens(self):
+        resp = {"content": [{"type": "text", "text": '{"verdict":'}],
+                "stop_reason": "max_tokens"}
+        assert "truncated" in _exit_msg(resp)
+
+    def test_no_truncation_hint_when_finished_normally(self):
+        resp = {"choices": [{"message": {"content": "no json here"},
+                             "finish_reason": "stop"}]}
+        assert "truncated" not in _exit_msg(resp)
+
+    def test_stream_error_surfaced(self):
+        resp = {"error": {"message": "context length exceeded"},
+                "choices": [{"message": {"content": ""}}]}
+        msg = _exit_msg(resp)
+        assert "context length exceeded" in msg
+
+
 if __name__ == "__main__":
     unittest_main()

--- a/tests/test_sse_reassembler.py
+++ b/tests/test_sse_reassembler.py
@@ -168,5 +168,33 @@ class TestReassembleSSEToFile:
         assert result["choices"][0]["message"]["content"] == "Written"
 
 
+class TestStreamErrorDetection:
+    def test_openai_error_event(self):
+        result = reassemble_sse(_make_sse_line({"error": {"message": "boom"}}), "openai")
+        assert result.get("error") == {"message": "boom"}
+        assert result["choices"][0]["message"]["content"] == ""
+
+    def test_anthropic_error_event(self):
+        result = reassemble_sse(
+            _make_sse_line({"type": "error", "error": {"message": "overloaded"}}),
+            "anthropic",
+        )
+        assert result.get("error") == {"message": "overloaded"}
+
+    def test_non_sse_json_error_body(self):
+        # No 'data:' lines at all — a plain JSON error body (sometimes HTTP 200).
+        body = json.dumps({"error": {"message": "model not found"}})
+        result = reassemble_sse(body, "openai")
+        assert result.get("error") == {"message": "model not found"}
+
+    def test_no_false_error_on_valid_stream(self):
+        lines = [
+            _make_sse_line({"id": "c", "choices": [{"delta": {"content": "hi"}, "finish_reason": "stop"}]}),
+        ]
+        result = reassemble_sse("\n".join(lines), "openai")
+        assert "error" not in result
+        assert result["choices"][0]["message"]["content"] == "hi"
+
+
 if __name__ == "__main__":
     unittest_main()


### PR DESCRIPTION
Three reliability fixes targeting weaker / self-hosted endpoints. Today all three failure modes surface as a generic "could not parse" error that's retried up to `ai_primary_retries` times with the full corpus — slow and opaque.

## Changes
- **Verdict normalization** (`response_parser.py`): weaker models routinely emit `"Approve"`, `"approved"`, `"Request Changes"`, `"REQUEST_CHANGES"`, `"changes_requested"`, etc. These now map to the canonical `approve` / `request_changes`, and the canonical value is written back so downstream `jq -r '.verdict'` is unaffected. Unknown verdicts are still rejected.
- **Truncation detection** (`response_parser.py`): when JSON extraction or key validation fails, the parser checks `finish_reason == "length"` (OpenAI) / `stop_reason == "max_tokens"` (Anthropic) and raises a clear *"model output appears truncated at the token limit; increase ai_max_tokens"* instead of a generic parse error. (Small models hit the 4096-token cap mid-JSON often, given the six-section review contract.)
- **Stream error surfacing** (`sse_reassembler.py` + `response_parser.py`): captures OpenAI `data: {"error": ...}` chunks, Anthropic `error` events, and plain non-SSE JSON error bodies returned with HTTP 200, recording them under an `error` key. `parse_response` now raises with that message rather than treating the empty content as a successful-but-blank completion (which previously masked the real failure and burned the whole retry budget).

## Tests
- +13 tests: verdict synonyms (both directions + rejection), truncation hints for OpenAI and Anthropic shapes, and error detection for OpenAI error chunk / Anthropic error event / non-SSE error body / no-false-positive on a valid stream.
- Full suite: **399 passed** (was 386). Pure-Python change; no shell touched.

Independent of #165 (different files).
