### PR TITLE
fix: model-call reliability — distinguish failure classes, capture HTTP error bodies

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,7 @@ jobs:
         run: ruby -e 'require "yaml"; YAML.load_file("examples/workflow-self-hosted.yml"); YAML.load_file("examples/workflow-cloud.yml")'
 
       - name: Check shell scripts
-        run: bash -n scripts/check_review_needed.sh && bash -n scripts/run_review.sh && bash -n tests/smoke_test.sh && bash -n tests/test_check_review_needed.sh && bash -n tests/test_approval_guardrails.sh && bash -n tests/test_tool_harness_enforcement.sh && bash -n tests/test_cleanup_previous_native_reviews.sh
+        run: bash -n scripts/check_review_needed.sh && bash -n scripts/run_review.sh && bash -n scripts/model_call.sh && bash -n tests/smoke_test.sh && bash -n tests/test_check_review_needed.sh && bash -n tests/test_approval_guardrails.sh && bash -n tests/test_tool_harness_enforcement.sh && bash -n tests/test_cleanup_previous_native_reviews.sh && bash -n tests/test_model_call.sh
 
       - name: Check Python scripts
         run: python3 -m py_compile scripts/image_digest_analysis.py scripts/run_evidence_providers.py scripts/run_tool_harness.py tests/mock_openai_server.py tests/test_model_parsing.py tests/test_redact.py tests/test_strip_metadata_markers.py tests/test_evidence_providers.py
@@ -55,3 +55,6 @@ jobs:
 
       - name: Run native review cleanup + marker emission tests
         run: bash tests/test_cleanup_previous_native_reviews.sh
+
+      - name: Run model-call (curl_model) tests
+        run: bash tests/test_model_call.sh

--- a/scripts/model_call.sh
+++ b/scripts/model_call.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Model HTTP call helper, sourced by run_review.sh.
+#
+# Kept in its own file so the curl/HTTP-status handling can be unit-tested
+# (tests/test_model_call.sh) — the main driver has no end-to-end harness, and
+# this is the part with the subtlest behaviour (transport vs HTTP errors).
+
+# curl_model BASE_URL API_KEY API_FORMAT PAYLOAD_FILE OUTPUT_FILE \
+#            [STREAM] [REQUEST_TIMEOUT_SEC] [CONNECT_TIMEOUT_SEC]
+#
+# Writes the response body to OUTPUT_FILE. Returns:
+#   0   on HTTP 2xx/3xx (body in OUTPUT_FILE)
+#   22  on HTTP >= 400  (body in OUTPUT_FILE, a redacted head is logged to stderr)
+#   N   curl's own non-zero exit code on a transport error (timeout, DNS, reset)
+#
+# Unlike `curl -f`, the response body is preserved on HTTP errors so a local
+# endpoint's "context length exceeded" / "model not found" message is visible
+# instead of silently discarded and retried.
+curl_model() {
+  local base_url="$1" api_key="$2" api_format="$3" payload_file="$4" output_file="$5"
+  local stream="${6:-false}" request_timeout_sec="${7:-300}" connect_timeout_sec="${8:-30}"
+
+  local endpoint
+  local auth_header=()
+  if [[ "$api_format" == "anthropic" ]]; then
+    endpoint="$base_url/messages"
+    auth_header=( -H "anthropic-version: ${ANTHROPIC_VERSION:-2023-06-01}" )
+    if [[ -n "$api_key" ]]; then
+      auth_header+=( -H "x-api-key: $api_key" )
+    fi
+  else
+    endpoint="$base_url/chat/completions"
+    if [[ -n "$api_key" ]]; then
+      auth_header=( -H "Authorization: Bearer $api_key" )
+    fi
+  fi
+
+  local args=(
+    -q
+    -sS
+    -L
+    "$endpoint"
+    -H "Content-Type: application/json"
+    --data "@$payload_file"
+    --max-time "$request_timeout_sec"
+    --connect-timeout "$connect_timeout_sec"
+    -o "$output_file"
+    -w '%{http_code}'
+  )
+
+  args+=( "${auth_header[@]}" )
+
+  if [[ "$stream" == "true" ]]; then
+    args+=( --no-buffer )
+    if [[ "$api_format" == "anthropic" ]]; then
+      args+=( -H "Accept: text/event-stream" )
+    fi
+  fi
+
+  local http_code curl_rc=0
+  http_code="$(curl "${args[@]}")" || curl_rc=$?
+
+  if [[ "$curl_rc" -ne 0 ]]; then
+    echo "  curl transport error (exit ${curl_rc}) calling model endpoint" >&2
+    return "$curl_rc"
+  fi
+
+  if [[ "${http_code:-0}" -ge 400 ]]; then
+    echo "  model endpoint returned HTTP ${http_code}" >&2
+    if [[ -s "$output_file" ]]; then
+      # Log a short head so operators can see the real error. Redact obvious
+      # credential-looking tokens defensively in case a proxy echoes a header.
+      printf '  response body (first 600 bytes): ' >&2
+      head -c 600 "$output_file" \
+        | sed -E 's/([Bb]earer|x-api-key|api[_-]?key|token|secret)([":= ]+)[A-Za-z0-9._-]+/\1\2[REDACTED]/g' >&2
+      echo >&2
+    fi
+    return 22
+  fi
+
+  return 0
+}

--- a/scripts/run_review.sh
+++ b/scripts/run_review.sh
@@ -235,52 +235,9 @@ if [[ ! "$TOOL_MIN_SUCCESSFUL_REQUESTS" =~ ^[0-9]+$ ]]; then
   TOOL_MIN_SUCCESSFUL_REQUESTS=0
 fi
 
-curl_model() {
-  local base_url="$1"
-  local api_key="$2"
-  local api_format="$3"
-  local payload_file="$4"
-  local output_file="$5"
-  local stream="${6:-false}"
-  local request_timeout_sec="${7:-300}"
-  local connect_timeout_sec="${8:-30}"
-
-  local endpoint
-  local auth_header=()
-  if [[ "$api_format" == "anthropic" ]]; then
-    endpoint="$base_url/messages"
-    auth_header=( -H "anthropic-version: $ANTHROPIC_VERSION" )
-    if [[ -n "$api_key" ]]; then
-      auth_header+=( -H "x-api-key: $api_key" )
-    fi
-  else
-    endpoint="$base_url/chat/completions"
-    if [[ -n "$api_key" ]]; then
-      auth_header=( -H "Authorization: Bearer $api_key" )
-    fi
-  fi
-
-  local args=(
-    -q
-    -fsSL
-    "$endpoint"
-    -H "Content-Type: application/json"
-    --data "@$payload_file"
-    --max-time "$request_timeout_sec"
-    --connect-timeout "$connect_timeout_sec"
-  )
-
-  args+=( "${auth_header[@]}" )
-
-  if [[ "$stream" == "true" ]]; then
-    args+=( --no-buffer )
-    if [[ "$api_format" == "anthropic" ]]; then
-      args+=( -H "Accept: text/event-stream" )
-    fi
-  fi
-
-  curl "${args[@]}" > "$output_file"
-}
+# curl_model is defined in scripts/model_call.sh so its HTTP-status handling
+# can be unit-tested independently of the main driver.
+source "${SCRIPT_DIR}/model_call.sh"
 
 build_model_request() {
   local api_format="$1"
@@ -973,18 +930,43 @@ build_model_request \
 
 PRIMARY_OK=0
 ATTEMPT=1
+PARSE_FAILS=0
+# A response that arrives but won't parse/validate is usually deterministic at
+# temperature 0.1 — re-sending the same corpus rarely helps. Cap those attempts
+# low and fall through to the fallback model instead of burning the full
+# transport-retry budget. Transport/HTTP failures keep the full budget.
+PARSE_FAIL_CAP=2
+RETRY_DELAY="$AI_PRIMARY_RETRY_DELAY_SEC"
 while [ "$ATTEMPT" -le "$AI_PRIMARY_RETRIES" ]; do
   echo "Primary model attempt ${ATTEMPT}/${AI_PRIMARY_RETRIES}: $AI_MODEL @ $AI_BASE_URL ($AI_API_FORMAT)"
-  if curl_model "$AI_BASE_URL" "$AI_API_KEY" "$AI_API_FORMAT" ai-request.primary.json ai-response.primary.json "$STREAM_BOOL" "$AI_REQUEST_TIMEOUT_SEC" "$AI_CONNECT_TIMEOUT_SEC" && \
-    { [[ "$STREAM_BOOL" != "true" ]] || reassemble_sse_response ai-response.primary.json "$AI_API_FORMAT"; } && \
-    parse_and_validate ai-response.primary.json; then
-    PRIMARY_OK=1
-    break
-  fi
+  if curl_model "$AI_BASE_URL" "$AI_API_KEY" "$AI_API_FORMAT" ai-request.primary.json ai-response.primary.json "$STREAM_BOOL" "$AI_REQUEST_TIMEOUT_SEC" "$AI_CONNECT_TIMEOUT_SEC"; then
+    if { [[ "$STREAM_BOOL" != "true" ]] || reassemble_sse_response ai-response.primary.json "$AI_API_FORMAT"; } && \
+      parse_and_validate ai-response.primary.json; then
+      PRIMARY_OK=1
+      break
+    fi
 
-  echo "Primary model attempt $ATTEMPT failed; waiting ${AI_PRIMARY_RETRY_DELAY_SEC}s" >&2
-  ATTEMPT=$((ATTEMPT + 1))
-  sleep "$AI_PRIMARY_RETRY_DELAY_SEC"
+    PARSE_FAILS=$((PARSE_FAILS + 1))
+    echo "Primary attempt $ATTEMPT: response received but parse/validate failed (parse failure ${PARSE_FAILS}/${PARSE_FAIL_CAP})" >&2
+    if [ -s ai-response.primary.json ]; then
+      printf '  response head (first 400 bytes): ' >&2
+      head -c 400 ai-response.primary.json >&2 || true
+      echo >&2
+    fi
+    if [ "$PARSE_FAILS" -ge "$PARSE_FAIL_CAP" ]; then
+      echo "Reached parse-failure cap; not retrying primary further" >&2
+      break
+    fi
+    ATTEMPT=$((ATTEMPT + 1))
+    sleep "$RETRY_DELAY"
+  else
+    # Transport or HTTP error (curl_model already logged the details/body).
+    echo "Primary attempt $ATTEMPT failed (connection/HTTP); waiting ${RETRY_DELAY}s" >&2
+    ATTEMPT=$((ATTEMPT + 1))
+    sleep "$RETRY_DELAY"
+    RETRY_DELAY=$((RETRY_DELAY * 2))
+    [ "$RETRY_DELAY" -gt 120 ] && RETRY_DELAY=120
+  fi
 done
 
 if [ "$PRIMARY_OK" -eq 1 ]; then

--- a/tests/test_max_tokens.py
+++ b/tests/test_max_tokens.py
@@ -21,8 +21,12 @@ def test_openai_payload_includes_max_tokens():
 
 
 def test_openai_uses_chat_completions_endpoint():
-    """OpenAI-compatible requests must target /chat/completions."""
-    with open("scripts/run_review.sh") as f:
+    """OpenAI-compatible requests must target /chat/completions.
+
+    curl_model (which builds the endpoint) lives in scripts/model_call.sh,
+    sourced by run_review.sh.
+    """
+    with open("scripts/model_call.sh") as f:
         content = f.read()
 
     assert "chat/completions" in content
@@ -30,7 +34,7 @@ def test_openai_uses_chat_completions_endpoint():
 
 def test_anthropic_uses_messages_endpoint():
     """Anthropic requests must target /messages."""
-    with open("scripts/run_review.sh") as f:
+    with open("scripts/model_call.sh") as f:
         content = f.read()
 
     assert "/messages" in content

--- a/tests/test_model_call.sh
+++ b/tests/test_model_call.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Tests for scripts/model_call.sh curl_model(): HTTP-status handling, body
+# preservation, and exit-code contract, driven by a mock `curl` on PATH.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# shellcheck source=/dev/null
+source "$ROOT_DIR/scripts/model_call.sh"
+
+PASS=0
+FAIL=0
+check() {
+  local desc="$1" result="$2" expected="$3"
+  if [[ "$result" == "$expected" ]]; then
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc (got '$result', expected '$expected')"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+mkdir -p "$TMPDIR/bin"
+
+# Mock curl: honours -o <file> and the MOCK_CURL_MODE env var, writes a body,
+# prints an HTTP status to stdout (as -w '%{http_code}' would), or fails.
+cat > "$TMPDIR/bin/curl" <<'MOCK'
+#!/usr/bin/env bash
+out=""
+prev=""
+for a in "$@"; do
+  if [ "$prev" = "-o" ]; then out="$a"; fi
+  prev="$a"
+done
+case "${MOCK_CURL_MODE:-ok}" in
+  ok)
+    [ -n "$out" ] && printf '{"choices":[{"message":{"content":"hi"}}]}' > "$out"
+    printf '200'; exit 0 ;;
+  http_error)
+    [ -n "$out" ] && printf '{"error":{"message":"context length exceeded"}}' > "$out"
+    printf '400'; exit 0 ;;
+  transport)
+    printf '000'; exit 7 ;;
+esac
+printf '200'; exit 0
+MOCK
+chmod +x "$TMPDIR/bin/curl"
+
+PAYLOAD="$TMPDIR/payload.json"
+echo '{}' > "$PAYLOAD"
+
+run_curl_model() {
+  local mode="$1" out="$2"
+  (
+    PATH="$TMPDIR/bin:$PATH" MOCK_CURL_MODE="$mode" \
+      curl_model "http://x/v1" "" "openai" "$PAYLOAD" "$out" "false" "5" "2" >/dev/null 2>&1
+  )
+}
+
+echo "=== Test: HTTP 200 → rc 0, body written ==="
+OUT="$TMPDIR/ok.json"
+rc=0; run_curl_model ok "$OUT" || rc=$?
+check "rc is 0 on success" "$rc" "0"
+check "body written on success" "$([ -s "$OUT" ] && echo yes || echo no)" "yes"
+
+echo ""
+echo "=== Test: HTTP 400 → rc 22, error body preserved ==="
+OUT="$TMPDIR/err.json"
+rc=0; run_curl_model http_error "$OUT" || rc=$?
+check "rc is 22 on HTTP >= 400" "$rc" "22"
+check "error body preserved (not discarded)" \
+  "$(grep -q 'context length exceeded' "$OUT" && echo yes || echo no)" "yes"
+
+echo ""
+echo "=== Test: transport error → curl exit code propagated ==="
+OUT="$TMPDIR/transport.json"
+rc=0; run_curl_model transport "$OUT" || rc=$?
+check "rc is 7 (curl transport exit) on connection failure" "$rc" "7"
+
+echo ""
+echo "=== Test: error body head is logged on HTTP error ==="
+OUT="$TMPDIR/err2.json"
+LOG="$(PATH="$TMPDIR/bin:$PATH" MOCK_CURL_MODE=http_error \
+  curl_model "http://x/v1" "" "openai" "$PAYLOAD" "$OUT" "false" "5" "2" 2>&1 >/dev/null || true)"
+check "HTTP error is logged to stderr" \
+  "$(printf '%s' "$LOG" | grep -q 'HTTP 400' && echo yes || echo no)" "yes"
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
**PR A of the remaining audit work.** Targets the retry-path pain visible in real configs (LiteLLM, `ai_primary_retries: 8`, 30+ min job timeouts).

## Changes
- **Extract `curl_model` → `scripts/model_call.sh`** (sourced by `run_review.sh`) so its HTTP-status handling is unit-testable. The main driver has no end-to-end harness and the smoke test reimplements its logic, so the model call had zero coverage.
- **Capture HTTP error bodies** (`model_call.sh`): drop `curl -f`, capture the status with `-w '%{http_code}'`. On HTTP ≥ 400 the body is now preserved and a redacted head is logged. Previously `-fsSL` discarded it, so a LiteLLM/vLLM `"context length exceeded"` or `"model not found"` was invisible and retried blindly. Return contract: `0` (2xx/3xx), `22` (HTTP error), curl's own code (transport error).
- **Failure-class discrimination** (retry loop): a response that arrives but fails parse/validate is capped at **2** attempts (deterministic at temperature 0.1) and falls through to the fallback, instead of re-sending the full ~corpus up to 8×. Transport/HTTP errors keep the full retry budget and now use **exponential backoff** (capped 120s). The response head is logged on parse failure.

## Tests
- New `tests/test_model_call.sh` (mock `curl`): success → rc 0 + body; HTTP 400 → rc 22 + body preserved; transport error → curl exit propagated; error logged to stderr. Wired into CI along with `model_call.sh`.
- Updated `test_max_tokens.py` endpoint-location assertions to read `model_call.sh`.
- 399 pytest + all bash suites pass; happy path unchanged.

Independent of #165/#166 (different files).
