### PR TITLE
feat: JSON mode + temperature/token-param inputs (OpenAI-compatible)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ The classification is purely rule-based — no model calls are involved. It uses
 | `ai_model` | Model name for the primary analysis pass | Yes | - |
 | `ai_api_key` | Optional API key for the primary AI endpoint. OpenAI format sends `Authorization: Bearer`; Anthropic format sends `x-api-key` | No | `""` |
 | `ai_max_tokens` | Maximum completion tokens for primary and fallback final review calls. Required by Anthropic-compatible APIs | No | `4096` |
+| `ai_temperature` | Sampling temperature for the review model. Empty string omits the field (some newer cloud models reject non-default temperature) | No | `0.1` |
+| `ai_response_format` | Structured-output mode for OpenAI-compatible endpoints (incl. LiteLLM): `off`, `json_object`, or `json_schema` (enforces the verdict/review_markdown schema). Ignored for `anthropic`. Improves reliability with smaller local models | No | `off` |
+| `ai_tokens_param` | Token-limit field name for OpenAI-compatible requests: `max_tokens` or `max_completion_tokens` (newer OpenAI reasoning models). Ignored for `anthropic` | No | `max_tokens` |
 | `anthropic_version` | `anthropic-version` header used for Anthropic-compatible requests | No | `2023-06-01` |
 | `ai_fallback_base_url` | Optional fallback AI API base URL | No | `""` |
 | `ai_fallback_api_format` | Fallback API request/response format; defaults to `ai_api_format` when blank | No | `""` |

--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,26 @@ inputs:
     description: Maximum completion tokens for the primary and fallback final review calls
     required: false
     default: "4096"
+  ai_temperature:
+    description: >-
+      Sampling temperature for the review model. Default "0.1". Set to an empty string to
+      omit the field entirely (some newer cloud models reject any non-default temperature).
+    required: false
+    default: "0.1"
+  ai_response_format:
+    description: >-
+      Structured-output mode for OpenAI-compatible endpoints (including LiteLLM): off (default),
+      json_object, or json_schema (enforces a verdict/review_markdown schema). Ignored for the
+      anthropic format. Improves output reliability with smaller local models. Applies to both
+      the primary and fallback review calls.
+    required: false
+    default: "off"
+  ai_tokens_param:
+    description: >-
+      Token-limit field name for OpenAI-compatible requests: max_tokens (default) or
+      max_completion_tokens (required by newer OpenAI reasoning models). Ignored for anthropic.
+    required: false
+    default: "max_tokens"
   anthropic_version:
     description: Anthropic API version header used when ai_api_format or ai_fallback_api_format is anthropic
     required: false
@@ -362,6 +382,9 @@ runs:
         AI_MODEL: ${{ inputs.ai_model }}
         AI_API_KEY: ${{ inputs.ai_api_key }}
         AI_MAX_TOKENS: ${{ inputs.ai_max_tokens }}
+        AI_TEMPERATURE: ${{ inputs.ai_temperature }}
+        AI_RESPONSE_FORMAT: ${{ inputs.ai_response_format }}
+        AI_TOKENS_PARAM: ${{ inputs.ai_tokens_param }}
         ANTHROPIC_VERSION: ${{ inputs.anthropic_version }}
         AI_FALLBACK_BASE_URL: ${{ inputs.ai_fallback_base_url }}
         AI_FALLBACK_API_FORMAT: ${{ inputs.ai_fallback_api_format }}

--- a/scripts/model_call.sh
+++ b/scripts/model_call.sh
@@ -80,3 +80,73 @@ curl_model() {
 
   return 0
 }
+
+# build_model_request API_FORMAT MODEL SYSTEM USER CORPUS_FILE OUTPUT_FILE [STREAM]
+#
+# Reads globals (with safe defaults so the historical behaviour is preserved):
+#   AI_MAX_TOKENS     completion-token cap (default 4096)
+#   AI_TEMPERATURE    sampling temperature; empty => omit the field entirely
+#                     (some newer cloud models reject any non-default value)
+#   AI_RESPONSE_FORMAT  OpenAI-compatible structured output: off|json_object|json_schema
+#   AI_TOKENS_PARAM     OpenAI token-limit field name: max_tokens|max_completion_tokens
+#
+# response_format and the token-field name apply only to OpenAI-format requests
+# (incl. LiteLLM). Anthropic always sends max_tokens and has no response_format.
+build_model_request() {
+  local api_format="$1"
+  local model="$2"
+  local system="$3"
+  local user="$4"
+  local corpus_file="$5"
+  local output_file="$6"
+  local stream="${7:-false}"
+
+  local max_tokens="${AI_MAX_TOKENS:-4096}"
+
+  # temperature: empty string omits the field; otherwise pass through as JSON.
+  local temp_json="null"
+  if [[ -n "${AI_TEMPERATURE-}" ]]; then
+    temp_json="$AI_TEMPERATURE"
+  fi
+
+  if [[ "$api_format" == "anthropic" ]]; then
+    jq -n \
+      --arg model "$model" \
+      --arg system "$system" \
+      --arg user "$user" \
+      --argjson max_tokens "$max_tokens" \
+      --argjson stream "$stream" \
+      --argjson temp "$temp_json" \
+      --rawfile corpus "$corpus_file" \
+      '{model:$model,max_tokens:$max_tokens,stream:$stream,system:$system,messages:[{role:"user",content:($user + "\n\n" + $corpus)}]}
+       + (if $temp == null then {} else {temperature:$temp} end)' > "$output_file"
+  else
+    local tok_field="max_tokens"
+    if [[ "${AI_TOKENS_PARAM:-max_tokens}" == "max_completion_tokens" ]]; then
+      tok_field="max_completion_tokens"
+    fi
+
+    local rf_json="null"
+    case "${AI_RESPONSE_FORMAT:-off}" in
+      json_object)
+        rf_json='{"type":"json_object"}' ;;
+      json_schema)
+        rf_json='{"type":"json_schema","json_schema":{"name":"pr_review","strict":true,"schema":{"type":"object","properties":{"verdict":{"type":"string","enum":["approve","request_changes"]},"review_markdown":{"type":"string"}},"required":["verdict","review_markdown"],"additionalProperties":false}}}' ;;
+    esac
+
+    jq -n \
+      --arg model "$model" \
+      --arg system "$system" \
+      --arg user "$user" \
+      --argjson max_tokens "$max_tokens" \
+      --argjson stream "$stream" \
+      --arg tokfield "$tok_field" \
+      --argjson temp "$temp_json" \
+      --argjson rf "$rf_json" \
+      --rawfile corpus "$corpus_file" \
+      '{model:$model,stream:$stream,messages:[{role:"system",content:$system},{role:"user",content:($user + "\n\n" + $corpus)}]}
+       + {($tokfield): $max_tokens}
+       + (if $temp == null then {} else {temperature:$temp} end)
+       + (if $rf == null then {} else {response_format:$rf} end)' > "$output_file"
+  fi
+}

--- a/scripts/run_review.sh
+++ b/scripts/run_review.sh
@@ -56,6 +56,11 @@ AI_API_FORMAT="${AI_API_FORMAT:-openai}"
 AI_MODEL="${AI_MODEL:-}"
 AI_API_KEY="${AI_API_KEY:-}"
 AI_MAX_TOKENS="${AI_MAX_TOKENS:-4096}"
+# Single-dash default: an explicitly empty AI_TEMPERATURE is preserved (it means
+# "omit the field"); only an unset value falls back to 0.1.
+AI_TEMPERATURE="${AI_TEMPERATURE-0.1}"
+AI_RESPONSE_FORMAT="${AI_RESPONSE_FORMAT:-off}"
+AI_TOKENS_PARAM="${AI_TOKENS_PARAM:-max_tokens}"
 ANTHROPIC_VERSION="${ANTHROPIC_VERSION:-2023-06-01}"
 AI_FALLBACK_BASE_URL="${AI_FALLBACK_BASE_URL:-}"
 AI_FALLBACK_API_FORMAT="${AI_FALLBACK_API_FORMAT:-}"
@@ -169,6 +174,28 @@ if [[ ! "$AI_MAX_TOKENS" =~ ^[0-9]+$ || "$AI_MAX_TOKENS" -lt 1 ]]; then
   AI_MAX_TOKENS=4096
 fi
 
+# AI_TEMPERATURE: empty means "omit the field"; otherwise must be numeric.
+if [[ -n "$AI_TEMPERATURE" && ! "$AI_TEMPERATURE" =~ ^[0-9]+(\.[0-9]+)?$ ]]; then
+  error "Invalid AI_TEMPERATURE '$AI_TEMPERATURE'; defaulting to 0.1"
+  AI_TEMPERATURE=0.1
+fi
+
+case "$AI_RESPONSE_FORMAT" in
+  off|json_object|json_schema) ;;
+  *)
+    error "Invalid AI_RESPONSE_FORMAT '$AI_RESPONSE_FORMAT'; defaulting to off"
+    AI_RESPONSE_FORMAT=off
+    ;;
+esac
+
+case "$AI_TOKENS_PARAM" in
+  max_tokens|max_completion_tokens) ;;
+  *)
+    error "Invalid AI_TOKENS_PARAM '$AI_TOKENS_PARAM'; defaulting to max_tokens"
+    AI_TOKENS_PARAM=max_tokens
+    ;;
+esac
+
 if [[ -n "$AI_FALLBACK_BASE_URL" && -z "$AI_FALLBACK_MODEL" ]]; then
   error "AI_FALLBACK_MODEL is required when AI_FALLBACK_BASE_URL is set"
   exit 1
@@ -239,35 +266,8 @@ fi
 # can be unit-tested independently of the main driver.
 source "${SCRIPT_DIR}/model_call.sh"
 
-build_model_request() {
-  local api_format="$1"
-  local model="$2"
-  local system="$3"
-  local user="$4"
-  local corpus_file="$5"
-  local output_file="$6"
-  local stream="${7:-false}"
-
-  if [[ "$api_format" == "anthropic" ]]; then
-    jq -n \
-      --arg model "$model" \
-      --arg system "$system" \
-      --arg user "$user" \
-      --argjson max_tokens "$AI_MAX_TOKENS" \
-      --argjson stream "$stream" \
-      --rawfile corpus "$corpus_file" \
-      '{model:$model,max_tokens:$max_tokens,stream:$stream,system:$system,messages:[{role:"user",content:($user + "\n\n" + $corpus)}],temperature:0.1}' > "$output_file"
-  else
-    jq -n \
-      --arg model "$model" \
-      --arg system "$system" \
-      --arg user "$user" \
-      --argjson max_tokens "$AI_MAX_TOKENS" \
-      --argjson stream "$stream" \
-      --rawfile corpus "$corpus_file" \
-      '{model:$model,max_tokens:$max_tokens,stream:$stream,messages:[{role:"system",content:$system},{role:"user",content:($user + "\n\n" + $corpus)}],temperature:0.1}' > "$output_file"
-  fi
-}
+# build_model_request is defined in scripts/model_call.sh (sourced above) so the
+# request-payload shaping can be unit-tested independently of the main driver.
 
 reassemble_sse_response() {
   local response_file="$1"

--- a/tests/test_max_tokens.py
+++ b/tests/test_max_tokens.py
@@ -2,8 +2,11 @@
 
 
 def test_anthropic_payload_includes_max_tokens():
-    """Anthropic-compatible payloads must include max_tokens."""
-    with open("scripts/run_review.sh") as f:
+    """Anthropic-compatible payloads must include max_tokens.
+
+    build_model_request lives in scripts/model_call.sh (sourced by run_review.sh).
+    """
+    with open("scripts/model_call.sh") as f:
         content = f.read()
 
     assert "anthropic" in content
@@ -12,12 +15,13 @@ def test_anthropic_payload_includes_max_tokens():
 
 
 def test_openai_payload_includes_max_tokens():
-    """OpenAI-compatible payloads must include max_tokens (issue #38)."""
-    with open("scripts/run_review.sh") as f:
+    """OpenAI-compatible payloads must include the token limit (issue #38)."""
+    with open("scripts/model_call.sh") as f:
         content = f.read()
 
-    # Both branches should contain max_tokens:$max_tokens in their jq expressions
-    assert "max_tokens:$max_tokens" in content
+    # The OpenAI branch sends the limit under a configurable field name, while
+    # the anthropic branch keeps the literal max_tokens key.
+    assert "max_tokens:$max_tokens" in content or "($tokfield): $max_tokens" in content
 
 
 def test_openai_uses_chat_completions_endpoint():

--- a/tests/test_model_call.sh
+++ b/tests/test_model_call.sh
@@ -91,5 +91,44 @@ check "HTTP error is logged to stderr" \
   "$(printf '%s' "$LOG" | grep -q 'HTTP 400' && echo yes || echo no)" "yes"
 
 echo ""
+echo "=== build_model_request: payload shaping ==="
+CORPUS="$TMPDIR/corpus.md"
+printf 'CORPUS BODY' > "$CORPUS"
+REQ="$TMPDIR/req.json"
+
+( AI_MAX_TOKENS=4096; AI_TEMPERATURE=0.1; AI_RESPONSE_FORMAT=off; AI_TOKENS_PARAM=max_tokens
+  build_model_request openai m "sys" "usr" "$CORPUS" "$REQ" false )
+check "openai default: temperature included" "$(jq -r '.temperature' "$REQ")" "0.1"
+check "openai default: max_tokens key present" "$(jq -r 'has("max_tokens")' "$REQ")" "true"
+check "openai default: no response_format" "$(jq -r 'has("response_format")' "$REQ")" "false"
+check "openai: corpus appended to user message" \
+  "$(jq -r '.messages[1].content' "$REQ" | grep -q 'CORPUS BODY' && echo yes || echo no)" "yes"
+
+( AI_MAX_TOKENS=4096; AI_RESPONSE_FORMAT=json_object
+  build_model_request openai m "sys" "usr" "$CORPUS" "$REQ" false )
+check "openai json_object: response_format.type" "$(jq -r '.response_format.type' "$REQ")" "json_object"
+
+( AI_MAX_TOKENS=4096; AI_RESPONSE_FORMAT=json_schema
+  build_model_request openai m "sys" "usr" "$CORPUS" "$REQ" false )
+check "openai json_schema: response_format.type" "$(jq -r '.response_format.type' "$REQ")" "json_schema"
+check "openai json_schema: required keys" \
+  "$(jq -r '.response_format.json_schema.schema.required | sort | join(",")' "$REQ")" "review_markdown,verdict"
+
+( AI_MAX_TOKENS=4096; AI_TOKENS_PARAM=max_completion_tokens
+  build_model_request openai m "sys" "usr" "$CORPUS" "$REQ" false )
+check "openai: uses max_completion_tokens" "$(jq -r 'has("max_completion_tokens")' "$REQ")" "true"
+check "openai: drops max_tokens when using max_completion_tokens" "$(jq -r 'has("max_tokens")' "$REQ")" "false"
+
+( AI_MAX_TOKENS=4096; AI_TEMPERATURE=""
+  build_model_request openai m "sys" "usr" "$CORPUS" "$REQ" false )
+check "openai: temperature omitted when empty" "$(jq -r 'has("temperature")' "$REQ")" "false"
+
+( AI_MAX_TOKENS=4096; AI_TEMPERATURE=0.1; AI_RESPONSE_FORMAT=json_object
+  build_model_request anthropic m "sys" "usr" "$CORPUS" "$REQ" false )
+check "anthropic: max_tokens present" "$(jq -r 'has("max_tokens")' "$REQ")" "true"
+check "anthropic: no response_format (unsupported)" "$(jq -r 'has("response_format")' "$REQ")" "false"
+check "anthropic: system field present" "$(jq -r 'has("system")' "$REQ")" "true"
+
+echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
**PR B** (follows the merged #167). Structured-output + sampling controls for smaller local models behind OpenAI-compatible proxies (LiteLLM, llama.cpp, vLLM), where free-form JSON emission is the dominant failure mode. All three inputs default to the current behaviour.

## New inputs
- **`ai_response_format`** — `off` (default) | `json_object` | `json_schema`. For OpenAI-format requests, adds `response_format` so the endpoint constrains output; `json_schema` enforces a strict `{verdict, review_markdown}` schema. Ignored for `anthropic`. LiteLLM (your setup) supports both.
- **`ai_temperature`** — default `"0.1"`; empty string **omits** the field (newer cloud models reject non-default temperature).
- **`ai_tokens_param`** — `max_tokens` (default) | `max_completion_tokens` (newer OpenAI reasoning models reject `max_tokens`).

## Structure
- `build_model_request` parameterised in `scripts/model_call.sh` (added in #167) so payload shaping is **unit-testable**. Applies to **both** primary and fallback calls.
- Validation + safe defaults in `run_review.sh` (empty temperature preserved via single-dash default; invalid values warn and fall back).

## Tests
- +13 `build_model_request` cases in `tests/test_model_call.sh` (json_object/json_schema/temperature-omit/max_completion_tokens/anthropic-no-response_format), parsing actual jq output.
- Updated `test_max_tokens.py` location assertions. 399 pytest + all bash suites pass.
