### PR TITLE
Model-call reliability + OpenAI/Anthropic API compatibility

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -326,6 +326,9 @@ runs:
         ACTION_REF: ${{ github.action_ref }}
         AI_MODEL: ${{ inputs.ai_model }}
         AI_API_FORMAT: ${{ inputs.ai_api_format }}
+        AI_TEMPERATURE: ${{ inputs.ai_temperature }}
+        AI_RESPONSE_FORMAT: ${{ inputs.ai_response_format }}
+        AI_TOKENS_PARAM: ${{ inputs.ai_tokens_param }}
         AI_FALLBACK_MODEL: ${{ inputs.ai_fallback_model }}
         ANTHROPIC_VERSION: ${{ inputs.anthropic_version }}
         SYSTEM_PROMPT: ${{ inputs.system_prompt }}

--- a/scripts/check_review_needed.sh
+++ b/scripts/check_review_needed.sh
@@ -42,6 +42,18 @@ compute_config_hash() {
   if [[ -n "${AI_API_FORMAT:-}" ]]; then
     parts+=("api_format:${AI_API_FORMAT}")
   fi
+  # Sampling / output-format params affect the review, so a change forces a
+  # fresh review even on an unchanged diff. AI_TEMPERATURE may be intentionally
+  # empty (means "omit"), so include it whenever the var is set at all.
+  if [[ -n "${AI_TEMPERATURE+x}" ]]; then
+    parts+=("temperature:${AI_TEMPERATURE}")
+  fi
+  if [[ -n "${AI_RESPONSE_FORMAT:-}" ]]; then
+    parts+=("response_format:${AI_RESPONSE_FORMAT}")
+  fi
+  if [[ -n "${AI_TOKENS_PARAM:-}" ]]; then
+    parts+=("tokens_param:${AI_TOKENS_PARAM}")
+  fi
   if [[ -n "${AI_FALLBACK_MODEL:-}" ]]; then
     parts+=("fallback_model:${AI_FALLBACK_MODEL}")
   fi

--- a/tests/test_model_call.sh
+++ b/tests/test_model_call.sh
@@ -129,6 +129,56 @@ check "anthropic: max_tokens present" "$(jq -r 'has("max_tokens")' "$REQ")" "tru
 check "anthropic: no response_format (unsupported)" "$(jq -r 'has("response_format")' "$REQ")" "false"
 check "anthropic: system field present" "$(jq -r 'has("system")' "$REQ")" "true"
 
+CORPUS="$TMPDIR/corpus.md"
+printf '# corpus\nbody' > "$CORPUS"
+REQ="$TMPDIR/req.json"
+
+build_req() {
+  # Run build_model_request with a controlled env, writing to $REQ.
+  local fmt="$1"
+  ( AI_MAX_TOKENS=4096 \
+    AI_TEMPERATURE="${T_AI_TEMPERATURE-0.1}" \
+    AI_RESPONSE_FORMAT="${T_AI_RESPONSE_FORMAT:-off}" \
+    AI_TOKENS_PARAM="${T_AI_TOKENS_PARAM:-max_tokens}" \
+    build_model_request "$fmt" "m" "sys" "usr" "$CORPUS" "$REQ" "false" )
+}
+
+echo ""
+echo "=== Test: OpenAI default → max_tokens, temperature 0.1, no response_format ==="
+T_AI_TEMPERATURE=0.1 T_AI_RESPONSE_FORMAT=off T_AI_TOKENS_PARAM=max_tokens build_req openai
+check "has max_tokens" "$(jq 'has("max_tokens")' "$REQ")" "true"
+check "temperature included" "$(jq '.temperature' "$REQ")" "0.1"
+check "no response_format" "$(jq 'has("response_format")' "$REQ")" "false"
+
+echo ""
+echo "=== Test: empty AI_TEMPERATURE omits the field ==="
+T_AI_TEMPERATURE="" build_req openai
+check "temperature omitted when empty" "$(jq 'has("temperature")' "$REQ")" "false"
+
+echo ""
+echo "=== Test: response_format=json_object ==="
+T_AI_RESPONSE_FORMAT=json_object build_req openai
+check "response_format type is json_object" "$(jq -r '.response_format.type' "$REQ")" "json_object"
+
+echo ""
+echo "=== Test: response_format=json_schema enforces verdict/review_markdown ==="
+T_AI_RESPONSE_FORMAT=json_schema build_req openai
+check "response_format type is json_schema" "$(jq -r '.response_format.type' "$REQ")" "json_schema"
+check "schema requires verdict+review_markdown" \
+  "$(jq -c '.response_format.json_schema.schema.required' "$REQ")" '["verdict","review_markdown"]'
+
+echo ""
+echo "=== Test: AI_TOKENS_PARAM=max_completion_tokens (newer OpenAI models) ==="
+T_AI_TOKENS_PARAM=max_completion_tokens build_req openai
+check "uses max_completion_tokens" "$(jq 'has("max_completion_tokens")' "$REQ")" "true"
+check "drops plain max_tokens" "$(jq 'has("max_tokens")' "$REQ")" "false"
+
+echo ""
+echo "=== Test: anthropic always sends max_tokens and never response_format ==="
+T_AI_RESPONSE_FORMAT=json_object T_AI_TOKENS_PARAM=max_completion_tokens build_req anthropic
+check "anthropic keeps max_tokens" "$(jq 'has("max_tokens")' "$REQ")" "true"
+check "anthropic ignores response_format" "$(jq 'has("response_format")' "$REQ")" "false"
+
 echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Addresses the **reliability** and **local-model compatibility** findings from the audit. Builds on the merged correctness/marker/parser PRs (#164, #165, #166).

## Reliability (model-call layer)
- Extracted `curl_model` into `scripts/model_call.sh` so its HTTP-status handling is unit-testable (the main driver has no end-to-end harness).
- Dropped `curl -f`: HTTP error bodies are now **preserved and logged** (redacted), so a local endpoint's `context length exceeded` / `model not found` is visible instead of silently discarded.
- Retry loop now **distinguishes failure classes**: parse/validate failures are capped low (deterministic at temp 0.1 — re-sending the same corpus rarely helps) and fall through to the fallback model, while transport/HTTP errors keep the full retry budget and get **exponential backoff** (capped at 120s). Previously every failure type triggered up to 8 identical full-corpus resends at a fixed delay.

## API compatibility (local + cloud)
- `ai_response_format` input: `off` | `json_object` | `json_schema` for OpenAI-compatible endpoints (incl. LiteLLM). `json_schema` enforces the `verdict`/`review_markdown` contract — the highest-leverage reliability fix for smaller local models. Ignored for `anthropic`.
- `ai_temperature` input: empty string omits the field entirely (newer cloud models reject non-default temperature).
- `ai_tokens_param` input: `max_tokens` | `max_completion_tokens` (newer OpenAI reasoning models reject `max_tokens`).
- All three apply to primary + fallback; they're folded into the review **config fingerprint** so changing any forces a fresh review on an unchanged diff.

## Tests
- New `tests/test_model_call.sh` (mock `curl`): exit-code contract (0 / 22 / transport), error-body preservation + logging, and behavioral `build_model_request` checks (temperature omission, json_object/json_schema, max_completion_tokens, anthropic never emitting response_format).
- Wired into CI. Full suite green locally: 399 pytest + all bash suites.
