### PR TITLE
Security: neutralize @-mentions in posted reviews; redact.py 3.9 compat

### DIFF
--- a/scripts/redact.py
+++ b/scripts/redact.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 """Shared secret-redaction helpers for tool harness and evidence providers."""
 
+from __future__ import annotations
+
 import re
 
 

--- a/scripts/sanitize_review_markdown.py
+++ b/scripts/sanitize_review_markdown.py
@@ -63,6 +63,14 @@ _RE_BARE_REF = re.compile(
     r"(?<!\w)#(\d+)(?!\w)"
 )
 
+# @-mentions: @user and @org/team. The model can echo these from PR content
+# (incl. prompt-injected text); posted verbatim they ping people and create
+# notification noise / a social-engineering vector. Word-boundary lookbehind
+# avoids matching email local parts (foo@bar) and existing code spans.
+_RE_MENTION = re.compile(
+    r"(?<![\w/`@])@([A-Za-z0-9][A-Za-z0-9-]{0,38}(?:/[A-Za-z0-9._-]+)?)"
+)
+
 
 def sanitize_pr_url(match: re.Match) -> str:
     """Convert GitHub PR URL to inert text."""
@@ -105,6 +113,15 @@ def sanitize_bare_ref(match: re.Match) -> str:
     return f"PR {num}"
 
 
+def sanitize_mention(match: re.Match) -> str:
+    """Neutralize an @-mention by inserting a zero-width space after the @.
+
+    Renders identically to a human but is not treated as a mention by GitHub,
+    so it does not notify the named user/team.
+    """
+    return "@\u200b" + match.group(1)
+
+
 def sanitize_markdown(text: str) -> str:
     """Return *text* with upstream references neutralized.
 
@@ -130,6 +147,9 @@ def sanitize_markdown(text: str) -> str:
 
     # 3. Sanitize bare references (#123)
     text = _RE_BARE_REF.sub(sanitize_bare_ref, text)
+
+    # 4. Neutralize @-mentions so posted output never pings users/teams
+    text = _RE_MENTION.sub(sanitize_mention, text)
 
     return text
 

--- a/tests/test_sanitize_review_markdown.py
+++ b/tests/test_sanitize_review_markdown.py
@@ -245,3 +245,27 @@ class TestEdgeCases:
         text = "(see #552 for details)"
         result = sanitize_markdown(text)
         assert "PR 552" in result
+
+
+class TestSanitizeMention:
+    """@-mentions must be neutralized so posted output never notifies users/teams."""
+
+    def test_user_mention_neutralized(self):
+        result = sanitize_markdown("Thanks @octocat for the fix")
+        assert "@​octocat" in result      # zero-width space inserted
+        assert "@octocat" not in result          # raw (linkable) form gone
+
+    def test_team_mention_neutralized(self):
+        result = sanitize_markdown("cc @acme/platform-team")
+        assert "@​acme/platform-team" in result
+        assert "@acme/platform-team" not in result
+
+    def test_email_local_part_not_touched(self):
+        # foo@bar.com is not a mention — the @ is preceded by a word char.
+        result = sanitize_markdown("contact foo@bar.com")
+        assert "foo@bar.com" in result
+
+    def test_already_escaped_at_not_double_escaped(self):
+        # An @@ sequence (e.g. literal) must not be turned into a mention.
+        result = sanitize_markdown("see user@@host")
+        assert "​" not in result


### PR DESCRIPTION
Two remaining security/robustness findings. (The `eval` metadata-injection and `GITHUB_OUTPUT` heredoc findings were already addressed on main; verdict normalization / finish_reason / SSE-error surfacing also already landed.)

## Changes
- **@-mention neutralization** (`scripts/sanitize_review_markdown.py`): the existing sanitizer handled PR/issue/commit URLs and `#123` refs but not `@user` / `@org/team`. The model can echo mentions from PR content (including prompt-injected text); posted verbatim via `gh pr comment`/`gh pr review`, they notify those users/teams — notification noise and a social-engineering vector. Now neutralized with a zero-width space after the `@` (renders identically, doesn't notify). Email local parts (`foo@bar`) and `@@` sequences are left alone.
- **`redact.py` Python 3.9 compat**: added `from __future__ import annotations` so the `str | None` annotations don't crash the tool harness / evidence providers on a 3.9 self-hosted runner.

## Tests
- +4 mention cases in `tests/test_sanitize_review_markdown.py` (user mention, team mention, email untouched, `@@` untouched). Full suite 403 green.

## Still remaining (next PR)
Observability (`GITHUB_STEP_SUMMARY` with tokens/truncation/attempts), graceful-degradation notice on total model failure, pipeline parallelism, and the API-key-in-`curl`-argv hardening (LOW).
