### PR TITLE
Observability (step summary) + graceful degradation (on_model_failure)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,7 @@ jobs:
         run: ruby -e 'require "yaml"; YAML.load_file("examples/workflow-self-hosted.yml"); YAML.load_file("examples/workflow-cloud.yml")'
 
       - name: Check shell scripts
-        run: bash -n scripts/check_review_needed.sh && bash -n scripts/run_review.sh && bash -n scripts/model_call.sh && bash -n tests/smoke_test.sh && bash -n tests/test_check_review_needed.sh && bash -n tests/test_approval_guardrails.sh && bash -n tests/test_tool_harness_enforcement.sh && bash -n tests/test_cleanup_previous_native_reviews.sh && bash -n tests/test_model_call.sh && bash -n tests/test_context_budget.sh
+        run: bash -n scripts/check_review_needed.sh && bash -n scripts/run_review.sh && bash -n tests/test_model_failure.sh && bash -n tests/test_step_summary.sh && bash -n scripts/model_call.sh && bash -n tests/smoke_test.sh && bash -n tests/test_check_review_needed.sh && bash -n tests/test_approval_guardrails.sh && bash -n tests/test_tool_harness_enforcement.sh && bash -n tests/test_cleanup_previous_native_reviews.sh && bash -n tests/test_model_call.sh && bash -n tests/test_context_budget.sh
 
       - name: Check Python scripts
         run: python3 -m py_compile scripts/image_digest_analysis.py scripts/run_evidence_providers.py scripts/run_tool_harness.py tests/mock_openai_server.py tests/test_model_parsing.py tests/test_redact.py tests/test_strip_metadata_markers.py tests/test_evidence_providers.py
@@ -52,6 +52,9 @@ jobs:
 
       - name: Run tool harness enforcement tests
         run: bash tests/test_tool_harness_enforcement.sh
+
+      - name: Run model-failure + step-summary tests
+        run: bash tests/test_model_failure.sh && bash tests/test_step_summary.sh
 
       - name: Run native review cleanup + marker emission tests
         run: bash tests/test_cleanup_previous_native_reviews.sh

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ The classification is purely rule-based — no model calls are involved. It uses
 | `ai_fallback_model` | Optional fallback model name | No | `""` |
 | `ai_fallback_api_key` | Optional API key for the fallback AI endpoint | No | `""` |
 | `ai_primary_retries` | Number of retries for the primary model | No | `8` |
+| `on_model_failure` | Behavior when primary **and** fallback models fail: `fail` (fail the step) or `notice` (post a visible `request_changes` notice explaining the review could not run — never auto-approves) | No | `fail` |
 | `ai_primary_retry_delay_sec` | Delay between retries in seconds | No | `15` |
 | `allowed_source_hosts` | Comma-separated allowlist for linked URL fetching | No | `github.com,api.github.com,gitlab.com,registry.terraform.io,artifacthub.io` |
 | `system_prompt` | Optional system prompt override | No | bundled prompt |

--- a/action.yml
+++ b/action.yml
@@ -79,6 +79,14 @@ inputs:
     description: Delay between primary retries in seconds
     required: false
     default: "15"
+  on_model_failure:
+    description: >-
+      Behavior when both primary and fallback models fail to return a usable review.
+      'fail' (default) fails the action step. 'notice' instead posts a visible
+      request_changes notice explaining the review could not run (never auto-approves),
+      so reviewers see an explanation instead of only a red check.
+    required: false
+    default: "fail"
   ai_stream:
     description: If true, use streaming responses to avoid timeouts behind proxies with short read timeouts (e.g. Cloudflare 100s edge timer)
     required: false
@@ -405,6 +413,7 @@ runs:
         AI_FALLBACK_API_KEY: ${{ inputs.ai_fallback_api_key }}
         AI_PRIMARY_RETRIES: ${{ inputs.ai_primary_retries }}
         AI_PRIMARY_RETRY_DELAY_SEC: ${{ inputs.ai_primary_retry_delay_sec }}
+        ON_MODEL_FAILURE: ${{ inputs.on_model_failure }}
         AI_STREAM: ${{ inputs.ai_stream }}
         AI_FALLBACK_STREAM: ${{ inputs.ai_fallback_stream }}
         ALLOWED_SOURCE_HOSTS: ${{ inputs.allowed_source_hosts }}

--- a/scripts/run_review.sh
+++ b/scripts/run_review.sh
@@ -98,6 +98,7 @@ AI_CONNECT_TIMEOUT_SEC="${AI_CONNECT_TIMEOUT_SEC:-30}"
 AI_FALLBACK_REQUEST_TIMEOUT_SEC="${AI_FALLBACK_REQUEST_TIMEOUT_SEC:-${AI_REQUEST_TIMEOUT_SEC}}"
 AI_FALLBACK_CONNECT_TIMEOUT_SEC="${AI_FALLBACK_CONNECT_TIMEOUT_SEC:-${AI_CONNECT_TIMEOUT_SEC}}"
 OUTPUT_FILE="${GITHUB_OUTPUT:-/dev/null}"
+ON_MODEL_FAILURE="${ON_MODEL_FAILURE:-fail}"
 REVIEW_SCOPE="${REVIEW_SCOPE:-auto}"
 EFFECTIVE_SCOPE="${EFFECTIVE_SCOPE:-full}"
 PREVIOUS_HEAD_SHA="${PREVIOUS_HEAD_SHA:-}"
@@ -1033,15 +1034,44 @@ while [ "$ATTEMPT" -le "$AI_PRIMARY_RETRIES" ]; do
   fi
 done
 
+# On total model failure, either fail the step (default, preserves prior
+# behaviour) or — when on_model_failure=notice — emit a request_changes notice so
+# the publish step posts a visible explanation instead of leaving a red check
+# with nothing on the PR. request_changes is the safe default (never auto-approves).
+handle_model_failure() {
+  local reason="$1"
+  error "$reason"
+  if [[ "$(printf '%s' "$ON_MODEL_FAILURE" | tr '[:upper:]' '[:lower:]')" != "notice" ]]; then
+    exit 1
+  fi
+  log "on_model_failure=notice: emitting a request_changes notice instead of failing the check"
+  ANALYSIS_ENGINE="(model unavailable)"
+  REASON="$reason" python3 - > ai-output.json <<'PY'
+import json, os
+reason = os.environ.get("REASON", "model unavailable")
+md = (
+    "## AI review could not run\n\n"
+    "The configured model endpoint(s) did not return a usable review for this run "
+    f"(reason: {reason}).\n\n"
+    "This is an automated notice, not a substantive review. Re-run the workflow "
+    "once the endpoint is reachable; see the action logs for the underlying error.\n"
+)
+print(json.dumps({"verdict": "request_changes", "review_markdown": md}))
+PY
+}
+
 if [ "$PRIMARY_OK" -eq 1 ]; then
   ANALYSIS_ENGINE="$AI_MODEL@$AI_BASE_URL ($AI_API_FORMAT)"
   echo "Primary model succeeded"
 else
+  TRY_FALLBACK=1
   if [[ -z "$AI_FALLBACK_BASE_URL" || -z "$AI_FALLBACK_MODEL" ]]; then
-    error "Primary model unavailable and no fallback model configured"
-    exit 1
+    # In notice mode handle_model_failure returns; otherwise it exits.
+    handle_model_failure "Primary model unavailable and no fallback model configured"
+    TRY_FALLBACK=0
   fi
 
+  if [ "$TRY_FALLBACK" -eq 1 ]; then
   echo "Primary model unavailable after retries; trying fallback: $AI_FALLBACK_MODEL @ $AI_FALLBACK_BASE_URL ($AI_FALLBACK_API_FORMAT)" >&2
   head -c 120000 review-corpus.md > review-corpus.fallback.truncated.md
 
@@ -1065,8 +1095,8 @@ else
     ANALYSIS_ENGINE="$AI_FALLBACK_MODEL@$AI_FALLBACK_BASE_URL ($AI_FALLBACK_API_FORMAT)"
     echo "Fallback model succeeded" >&2
   else
-    error "Fallback model failed"
-    exit 1
+    handle_model_failure "Fallback model failed"
+  fi
   fi
 fi
 
@@ -1105,5 +1135,53 @@ echo "effective_review_scope=$EFFECTIVE_SCOPE" >> "$OUTPUT_FILE"
 if [[ -n "$PREVIOUS_HEAD_SHA" ]]; then
   echo "previous_head_sha=$PREVIOUS_HEAD_SHA" >> "$OUTPUT_FILE"
 fi
+
+# Observability: a step-summary table so a user debugging a slow/odd review can
+# see the engine, verdict, token usage, truncation, and the active budget
+# without digging through raw logs.
+write_step_summary() {
+  [[ -n "${GITHUB_STEP_SUMMARY:-}" ]] || return 0
+
+  local verdict diff_bytes corpus_bytes prompt_tok comp_tok usage_file
+  verdict="$(jq -r '.verdict // "unknown"' ai-output.json 2>/dev/null || echo unknown)"
+  diff_bytes="$( [ -f pr.diff ] && wc -c < pr.diff | tr -d ' ' || echo 0 )"
+  corpus_bytes="$( [ -f review-corpus.md ] && wc -c < review-corpus.md | tr -d ' ' || echo 0 )"
+
+  usage_file=""
+  [ -f ai-response.primary.json ] && usage_file="ai-response.primary.json"
+  [[ "$ANALYSIS_ENGINE" == *fallback* || "$ANALYSIS_ENGINE" == "$AI_FALLBACK_MODEL"* ]] && [ -f ai-response.fallback.json ] && usage_file="ai-response.fallback.json"
+  prompt_tok="-"; comp_tok="-"
+  if [ -n "$usage_file" ]; then
+    prompt_tok="$(jq -r '.usage.prompt_tokens // "-"' "$usage_file" 2>/dev/null || echo -)"
+    comp_tok="$(jq -r '.usage.completion_tokens // "-"' "$usage_file" 2>/dev/null || echo -)"
+  fi
+
+  local diff_trunc="no" corpus_trunc="no"
+  [ "$diff_bytes" -gt "$MAX_DIFF" ] 2>/dev/null && diff_trunc="yes (cap ${MAX_DIFF})"
+  [ "$corpus_bytes" -gt "$MAX_CORPUS" ] 2>/dev/null && corpus_trunc="yes (cap ${MAX_CORPUS})"
+
+  local budget_desc
+  if [[ "${MODEL_CONTEXT_TOKENS:-}" =~ ^[0-9]+$ ]]; then
+    budget_desc="model_context_tokens=${MODEL_CONTEXT_TOKENS}"
+  else
+    budget_desc="context_limit_mode=${CONTEXT_LIMIT_MODE:-normal}"
+  fi
+
+  {
+    echo "### AI PR Review"
+    echo ""
+    echo "| Field | Value |"
+    echo "| --- | --- |"
+    echo "| Engine | ${ANALYSIS_ENGINE} |"
+    echo "| Verdict | ${verdict} |"
+    echo "| Scope | ${EFFECTIVE_SCOPE} |"
+    echo "| Budget | ${budget_desc} |"
+    echo "| Diff bytes | ${diff_bytes} (truncated: ${diff_trunc}) |"
+    echo "| Corpus bytes | ${corpus_bytes} (truncated: ${corpus_trunc}) |"
+    echo "| Prompt tokens | ${prompt_tok} |"
+    echo "| Completion tokens | ${comp_tok} |"
+  } >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || true
+}
+write_step_summary
 
 log "Done."

--- a/tests/test_model_failure.sh
+++ b/tests/test_model_failure.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# Tests for handle_model_failure() in run_review.sh: fail mode exits non-zero;
+# notice mode writes a request_changes notice and returns 0 so publishing can
+# post a visible explanation. Extracted and driven in isolation.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+PASS=0
+FAIL=0
+check() {
+  local desc="$1" result="$2" expected="$3"
+  if [[ "$result" == "$expected" ]]; then
+    echo "  PASS: $desc"; PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc (got '$result', expected '$expected')"; FAIL=$((FAIL + 1))
+  fi
+}
+
+FUNC="$(mktemp)"
+TMP="$(mktemp -d)"
+trap 'rm -f "$FUNC"; rm -rf "$TMP"' EXIT
+
+python3 - "$ROOT_DIR/scripts/run_review.sh" "$FUNC" <<'PY'
+import re, sys
+src = open(sys.argv[1]).read()
+m = re.search(r"^handle_model_failure\(\) \{\n(.*?)\n\}", src, re.S | re.M)
+if not m:
+    sys.exit("could not extract handle_model_failure")
+open(sys.argv[2], "w").write("handle_model_failure() {\n%s\n}\n" % m.group(1))
+PY
+
+log() { :; }
+error() { :; }
+# shellcheck source=/dev/null
+source "$FUNC"
+
+cd "$TMP"
+
+echo "=== Test: fail mode exits non-zero ==="
+rc=0
+( ON_MODEL_FAILURE="fail" ANALYSIS_ENGINE="x" handle_model_failure 'boom' ) >/dev/null 2>&1 || rc=$?
+check "fail mode returns non-zero" "$rc" "1"
+
+echo ""
+echo "=== Test: notice mode returns 0 and writes a request_changes notice ==="
+rc=0
+( ON_MODEL_FAILURE="notice" ANALYSIS_ENGINE="x" handle_model_failure "endpoint down" ) >/dev/null 2>&1 || rc=$?
+check "notice mode returns 0" "$rc" "0"
+check "notice ai-output.json verdict is request_changes" \
+  "$(jq -r '.verdict' ai-output.json 2>/dev/null)" "request_changes"
+check "notice markdown explains the failure" \
+  "$(jq -r '.review_markdown' ai-output.json 2>/dev/null | grep -qi 'could not run' && echo yes || echo no)" "yes"
+check "notice markdown mentions the reason" \
+  "$(jq -r '.review_markdown' ai-output.json 2>/dev/null | grep -qi 'endpoint down' && echo yes || echo no)" "yes"
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ]

--- a/tests/test_step_summary.sh
+++ b/tests/test_step_summary.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# Tests for write_step_summary() in run_review.sh: emits a markdown table to
+# GITHUB_STEP_SUMMARY with verdict, budget, and truncation flags; no-ops when
+# GITHUB_STEP_SUMMARY is unset.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+PASS=0
+FAIL=0
+check() {
+  local desc="$1" result="$2" expected="$3"
+  if [[ "$result" == "$expected" ]]; then
+    echo "  PASS: $desc"; PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc (got '$result', expected '$expected')"; FAIL=$((FAIL + 1))
+  fi
+}
+
+FUNC="$(mktemp)"
+TMP="$(mktemp -d)"
+trap 'rm -f "$FUNC"; rm -rf "$TMP"' EXIT
+
+python3 - "$ROOT_DIR/scripts/run_review.sh" "$FUNC" <<'PY'
+import re, sys
+src = open(sys.argv[1]).read()
+m = re.search(r"^write_step_summary\(\) \{\n(.*?)\n\}", src, re.S | re.M)
+if not m:
+    sys.exit("could not extract write_step_summary")
+open(sys.argv[2], "w").write("write_step_summary() {\n%s\n}\n" % m.group(1))
+PY
+
+log() { :; }
+# shellcheck source=/dev/null
+source "$FUNC"
+
+cd "$TMP"
+echo '{"verdict":"request_changes","review_markdown":"x"}' > ai-output.json
+# 100-byte diff with a small cap → should report truncation
+printf 'd%.0s' $(seq 1 100) > pr.diff
+printf 'c%.0s' $(seq 1 50) > review-corpus.md
+MAX_DIFF=10; MAX_CORPUS=1000
+ANALYSIS_ENGINE="qwen@local (openai)"; EFFECTIVE_SCOPE="full"
+CONTEXT_LIMIT_MODE="normal"; MODEL_CONTEXT_TOKENS=""; AI_FALLBACK_MODEL=""
+
+echo "=== Test: no-op when GITHUB_STEP_SUMMARY unset ==="
+unset GITHUB_STEP_SUMMARY
+rc=0; write_step_summary || rc=$?
+check "returns 0 with no summary target" "$rc" "0"
+
+echo ""
+echo "=== Test: writes a table with verdict + truncation flag ==="
+export GITHUB_STEP_SUMMARY="$TMP/summary.md"
+: > "$GITHUB_STEP_SUMMARY"
+write_step_summary
+check "summary mentions verdict" \
+  "$(grep -c 'request_changes' "$GITHUB_STEP_SUMMARY")" "1"
+check "summary flags diff truncation" \
+  "$(grep -qi 'Diff bytes' "$GITHUB_STEP_SUMMARY" && grep -qi 'truncated: yes' "$GITHUB_STEP_SUMMARY" && echo yes || echo no)" "yes"
+check "summary shows the budget mode" \
+  "$(grep -qi 'context_limit_mode=normal' "$GITHUB_STEP_SUMMARY" && echo yes || echo no)" "yes"
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Two MEDIUM reliability/well-roundedness findings, both aimed at running against local models.

## Graceful degradation — `on_model_failure` input (`fail` | `notice`, default `fail`)
Today, when primary **and** fallback both fail, `run_review.sh` exits 1 → the action step goes red and **nothing is posted to the PR**, so reviewers just see a failed check. In `notice` mode the failure paths route through `handle_model_failure()`, which writes a `request_changes` notice (safe — never auto-approves, important for your `allow_approve` repos) explaining the review couldn't run, and exits 0 so the publish step posts it. Default `fail` preserves current behavior.

## Observability — `GITHUB_STEP_SUMMARY`
`run_review.sh` now appends a summary table: engine, verdict, scope, **active budget** (`model_context_tokens` or `context_limit_mode`), **diff/corpus bytes with truncation flags**, and **prompt/completion tokens** (from the reassembled `usage`). Makes a slow or surprising review debuggable without digging through raw logs — the missing feedback loop when tuning a local model's context size. No-ops when `GITHUB_STEP_SUMMARY` is unset (local runs).

## Tests
- `tests/test_model_failure.sh` (fail exits non-zero; notice returns 0 + writes the request_changes notice with the reason).
- `tests/test_step_summary.sh` (table contents, truncation flag, unset no-op).
- Wired into CI. 413 pytest + all bash suites green.

## Remaining after this
Pipeline parallelism (enrichment/digest/providers), `wait_for_ci` checks-only fix, structured `findings[]` + verdict policy + inline comments (larger, design-bearing), C2 context trims, API-key-in-argv (LOW), docs.
