### PR TITLE
perf: parallelize pipeline I/O, dedup PR fetches, short-circuit precheck

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,9 +84,11 @@ The classification is purely rule-based — no model calls are involved. It uses
 | `context_limit_mode` | Context budget mode: `normal` (140k/70k/220k), `low` (80k/40k/120k), `minimal` (40k/20k/60k) | No | `normal` |
 | `model_context_tokens` | The model's real context window in tokens (e.g. `8192`, `32768`). When set, corpus/diff/file byte budgets are derived from it (reserving `ai_max_tokens` for output) instead of `context_limit_mode`. Recommended for local models. Empty uses `context_limit_mode` | No | `""` |
 | `enrichment_budget_sec` | Maximum seconds to spend on enrichment (linked source fetching, release metadata, ghcr.io lookups). Exceeding the budget stops further enrichment. | No | `60` |
+| `image_digest_budget_sec` | Maximum seconds to spend on image digest provenance lookups (registry tokens, manifests, revision compares). 0 disables the budget. | No | `60` |
 | `evidence_providers_file` | Optional JSON file in the reviewed repo defining evidence provider commands | No | `""` |
 | `evidence_provider_timeout_sec` | Default timeout in seconds for each evidence provider command | No | `30` |
 | `evidence_provider_max_output_bytes` | Max stdout or stderr bytes captured per provider command | No | `20000` |
+| `evidence_provider_parallelism` | Max evidence provider commands run concurrently (set `1` to force serial execution) | No | `4` |
 | `evidence_blocker_enforcement` | Force `request_changes` when any provider reports blocker severity | No | `false` |
 | `evidence_enable_for_forks` | Allow evidence providers on cross-repository PRs | No | `false` |
 | `tool_mode` | Tool harness mode: `off` or `plan_execute_once` | No | `off` |

--- a/action.yml
+++ b/action.yml
@@ -167,6 +167,10 @@ inputs:
     description: Maximum seconds to spend on enrichment (linked source fetching, release metadata, ghcr.io lookups). Exceeding the budget stops further enrichment. Default 60.
     required: false
     default: "60"
+  image_digest_budget_sec:
+    description: Maximum seconds to spend on image digest provenance lookups (registry tokens, manifests, revision compares). 0 disables the budget. Default 60.
+    required: false
+    default: "60"
   evidence_providers_file:
     description: Optional JSON file in the reviewed repository that defines evidence providers to run before review
     required: false
@@ -179,6 +183,10 @@ inputs:
     description: Maximum stdout or stderr bytes captured per evidence provider command
     required: false
     default: "20000"
+  evidence_provider_parallelism:
+    description: Maximum evidence provider commands run concurrently. Set 1 to force serial execution when providers contend on shared files. Default 4.
+    required: false
+    default: "4"
   evidence_blocker_enforcement:
     description: If true, force request_changes when any evidence provider reports blocker severity
     required: false
@@ -424,9 +432,11 @@ runs:
         CONTEXT_LIMIT_MODE: ${{ inputs.context_limit_mode }}
         MODEL_CONTEXT_TOKENS: ${{ inputs.model_context_tokens }}
         ENRICHMENT_BUDGET_SEC: ${{ inputs.enrichment_budget_sec }}
+        IMAGE_DIGEST_BUDGET_SEC: ${{ inputs.image_digest_budget_sec }}
         EVIDENCE_PROVIDERS_FILE: ${{ inputs.evidence_providers_file }}
         EVIDENCE_PROVIDER_TIMEOUT_SEC: ${{ inputs.evidence_provider_timeout_sec }}
         EVIDENCE_PROVIDER_MAX_OUTPUT_BYTES: ${{ inputs.evidence_provider_max_output_bytes }}
+        EVIDENCE_PROVIDER_PARALLELISM: ${{ inputs.evidence_provider_parallelism }}
         EVIDENCE_BLOCKER_ENFORCEMENT: ${{ inputs.evidence_blocker_enforcement }}
         EVIDENCE_ENABLE_FOR_FORKS: ${{ inputs.evidence_enable_for_forks }}
         TOOL_MODE: ${{ inputs.tool_mode }}
@@ -459,7 +469,7 @@ runs:
         GH_TOKEN: ${{ inputs.github_token }}
         REPO: ${{ inputs.repo || github.repository }}
         PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
-        HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        HEAD_SHA: ${{ github.event.pull_request.head.sha || steps.precheck.outputs.head_sha }}
         BROAD_FINGERPRINT: ${{ steps.precheck.outputs.diff_fingerprint }}
         VERDICT: ${{ steps.review.outputs.verdict }}
         REVIEW_MARKDOWN: ${{ steps.review.outputs.review_markdown }}
@@ -484,7 +494,7 @@ runs:
         fi
 
         # Build metadata marker
-        METADATA_MARKER="$(build_metadata_marker "${{ github.event.pull_request.base.sha || '' }}" "${{ steps.precheck.outputs.previous_head_sha || '' }}")"
+        METADATA_MARKER="$(build_metadata_marker "${{ github.event.pull_request.base.sha || steps.precheck.outputs.base_sha }}" "${{ steps.precheck.outputs.previous_head_sha || '' }}")"
         ANALYSIS_SCOPE_SUFFIX=""
         if [ "$EFFECTIVE_SCOPE" = "incremental" ]; then
           ANALYSIS_SCOPE_SUFFIX=" (incremental delta review)"
@@ -521,7 +531,7 @@ runs:
         GH_TOKEN: ${{ inputs.github_token }}
         REPO: ${{ inputs.repo || github.repository }}
         PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
-        HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        HEAD_SHA: ${{ github.event.pull_request.head.sha || steps.precheck.outputs.head_sha }}
         VERDICT: ${{ steps.review.outputs.verdict }}
         REVIEW_MARKDOWN: ${{ steps.review.outputs.review_markdown }}
         ANALYSIS_ENGINE: ${{ steps.review.outputs.analysis_engine }}
@@ -551,7 +561,7 @@ runs:
         fi
 
         # Build metadata marker
-        METADATA_MARKER="$(build_metadata_marker "${{ github.event.pull_request.base.sha || '' }}" "")"
+        METADATA_MARKER="$(build_metadata_marker "${{ github.event.pull_request.base.sha || steps.precheck.outputs.base_sha }}" "")"
         ANALYSIS_SCOPE_SUFFIX=""
         if [ "$EFFECTIVE_SCOPE" = "incremental" ]; then
           ANALYSIS_SCOPE_SUFFIX=" (incremental delta review)"
@@ -592,7 +602,7 @@ runs:
         GH_TOKEN: ${{ inputs.github_token }}
         REPO: ${{ inputs.repo || github.repository }}
         PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
-        HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        HEAD_SHA: ${{ github.event.pull_request.head.sha || steps.precheck.outputs.head_sha }}
         VERDICT: ${{ steps.review.outputs.verdict }}
         REVIEW_MARKDOWN: ${{ steps.review.outputs.review_markdown }}
         ANALYSIS_ENGINE: ${{ steps.review.outputs.analysis_engine }}
@@ -616,8 +626,12 @@ runs:
         CLEANUP_NATIVE_REVIEWS="$(resolve_cleanup_flag "${CLEANUP_PREVIOUS_NATIVE_REVIEWS:-auto}" "review_verdict")"
         cleanup_native_reviews "$CLEANUP_NATIVE_REVIEWS"
 
-        # Determine if the PR is from a fork
-        IS_FORK_PR="$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '((.head.repo.full_name // "") != (.base.repo.full_name // ""))' 2>/dev/null || echo false)"
+        # Determine if the PR is from a fork. The precheck step already fetched
+        # the PR object; only fall back to the API when its output is missing.
+        IS_FORK_PR="${{ steps.precheck.outputs.is_fork_pr }}"
+        if [ -z "$IS_FORK_PR" ]; then
+          IS_FORK_PR="$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '((.head.repo.full_name // "") != (.base.repo.full_name // ""))' 2>/dev/null || echo false)"
+        fi
 
         # Resolve effective scope and review result
         EFFECTIVE_SCOPE="${{ steps.precheck.outputs.effective_review_scope || 'full' }}"
@@ -629,7 +643,7 @@ runs:
         fi
 
         # Build metadata marker with verdict safety for incremental
-        METADATA_MARKER="$(build_metadata_marker "${{ github.event.pull_request.base.sha || '' }}" "$PREVIOUS_HEAD_SHA")"
+        METADATA_MARKER="$(build_metadata_marker "${{ github.event.pull_request.base.sha || steps.precheck.outputs.base_sha }}" "$PREVIOUS_HEAD_SHA")"
         ANALYSIS_SCOPE_SUFFIX=""
         if [ "$EFFECTIVE_SCOPE" = "incremental" ]; then
           ANALYSIS_SCOPE_SUFFIX=" (incremental delta review)"

--- a/scripts/check_review_needed.sh
+++ b/scripts/check_review_needed.sh
@@ -17,9 +17,14 @@ if [[ -z "$REPO" || -z "$PR_NUMBER" ]]; then
 fi
 
 # ── Diff fingerprint (unchanged) ──────────────────────────────────────
-# Tolerate a failing `gh pr diff` (network/auth blip) under `set -o pipefail`
-# so the precheck degrades to a fresh review instead of aborting the action.
-current_fingerprint="$( { gh pr diff "$PR_NUMBER" --repo "$REPO" || true; } | git patch-id --stable | awk 'NR == 1 { print $1 }' || true)"
+# Tolerate a failing `gh pr diff` (network/auth blip) so the precheck degrades
+# to a fresh review instead of aborting the action. The diff is saved to
+# pr.diff so run_review.sh can reuse it instead of fetching it a second time —
+# this also guarantees the reviewed diff is the one that was fingerprinted.
+if ! gh pr diff "$PR_NUMBER" --repo "$REPO" > pr.diff 2>/dev/null; then
+  : > pr.diff
+fi
+current_fingerprint="$(git patch-id --stable < pr.diff | awk 'NR == 1 { print $1 }' || true)"
 if [[ -z "$current_fingerprint" ]]; then
   current_fingerprint="empty-diff"
 fi
@@ -222,6 +227,25 @@ if [[ "$SKIP_IF_DIFF_UNCHANGED" == "true" && -n "$last_broad_fingerprint" && "$l
   skip_reason="diff-unchanged"
 fi
 
+# ── Short-circuit when no review will run ─────────────────────────────
+# Scope resolution below costs a PR-object fetch plus (potentially) a compare
+# API call — all of it feeds steps that are gated on should_review=true, so
+# skip it entirely when the review is being skipped.
+if [[ "$should_review" == "false" ]]; then
+  {
+    echo "effective_review_scope=full"
+    echo "previous_head_sha="
+    echo "baseline_clean=false"
+    echo "head_sha="
+    echo "base_sha="
+    echo "is_fork_pr="
+    echo "diff_fingerprint=$broad_fingerprint"
+    echo "should_review=$should_review"
+    echo "skip_reason=$skip_reason"
+  } >> "$OUTPUT_FILE"
+  exit 0
+fi
+
 # ── Review scope resolution ───────────────────────────────────────────
 # Global variables for review scope resolution
 EFFECTIVE_SCOPE=""
@@ -355,14 +379,16 @@ if [[ -n "$last_comment_body" ]]; then
   extract_review_metadata "$last_comment_body"
 fi
 
-# Get current PR head/base SHAs. pr.json is not created until run_review.sh
-# runs (a later step), so reading it here always yielded an empty head SHA and
-# the force-push ancestor guard below never ran. Fetch both from the API in a
-# single call instead.
-pr_head_base_json="$(gh api "repos/$REPO/pulls/$PR_NUMBER" 2>/dev/null || true)"
-[[ -n "$pr_head_base_json" ]] || pr_head_base_json='{}'
-CURRENT_HEAD_SHA="$(printf '%s' "$pr_head_base_json" | jq -r '.head.sha // ""' 2>/dev/null || echo "")"
-CURRENT_BASE_SHA="$(printf '%s' "$pr_head_base_json" | jq -r '.base.sha // ""' 2>/dev/null || echo "")"
+# Get the current PR object once. This is the single PR-object fetch point for
+# the whole action: the head/base SHAs drive scope resolution here, and the
+# object is saved to pr-object.json so run_review.sh (and the publish steps,
+# via the is_fork_pr output) do not have to fetch it again.
+if ! gh api "repos/$REPO/pulls/$PR_NUMBER" > pr-object.json 2>/dev/null; then
+  echo '{}' > pr-object.json
+fi
+CURRENT_HEAD_SHA="$(jq -r '.head.sha // ""' pr-object.json 2>/dev/null || echo "")"
+CURRENT_BASE_SHA="$(jq -r '.base.sha // ""' pr-object.json 2>/dev/null || echo "")"
+IS_FORK_PR="$(jq -r '((.head.repo.full_name // "") != (.base.repo.full_name // ""))' pr-object.json 2>/dev/null || echo "")"
 
 # Resolve effective review scope
 resolve_review_scope "$REVIEW_SCOPE" "$LAST_HEAD_SHA" "$LAST_BASE_SHA" \
@@ -372,6 +398,12 @@ resolve_review_scope "$REVIEW_SCOPE" "$LAST_HEAD_SHA" "$LAST_BASE_SHA" \
 echo "effective_review_scope=$EFFECTIVE_SCOPE" >> "$OUTPUT_FILE"
 echo "previous_head_sha=$PREVIOUS_HEAD_SHA" >> "$OUTPUT_FILE"
 echo "baseline_clean=$BASELINE_CLEAN" >> "$OUTPUT_FILE"
+
+# Forward the PR facts fetched above so later steps can reuse them instead of
+# re-fetching the PR object.
+echo "head_sha=$CURRENT_HEAD_SHA" >> "$OUTPUT_FILE"
+echo "base_sha=$CURRENT_BASE_SHA" >> "$OUTPUT_FILE"
+echo "is_fork_pr=$IS_FORK_PR" >> "$OUTPUT_FILE"
 
 echo "diff_fingerprint=$broad_fingerprint" >> "$OUTPUT_FILE"
 echo "should_review=$should_review" >> "$OUTPUT_FILE"

--- a/scripts/image_digest_analysis.py
+++ b/scripts/image_digest_analysis.py
@@ -1,10 +1,30 @@
 import json
+import os
 import re
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from urllib import parse
 import subprocess
 import sys
 from typing import Optional
+
+
+def time_budget_deadline():
+    """Return a monotonic deadline from IMAGE_DIGEST_BUDGET_SEC (0 disables)."""
+    raw = os.getenv("IMAGE_DIGEST_BUDGET_SEC", "60").strip()
+    try:
+        budget = int(raw)
+    except ValueError:
+        budget = 60
+    if budget <= 0:
+        return None
+    return time.monotonic() + budget
+
+
+def deadline_exceeded(deadline):
+    return deadline is not None and time.monotonic() >= deadline
 
 
 def http_json(url, headers=None):
@@ -56,7 +76,23 @@ def registry_targets(repo: str):
     raise ValueError(f"unsupported registry for repo {repo}")
 
 
-def fetch_digest_metadata(repo: str, digest: str):
+# Anonymous pull tokens are scoped per repository, so one token serves every
+# digest/manifest/blob request for that repository. Cache them per token URL.
+_TOKEN_CACHE: dict = {}
+_TOKEN_LOCK = threading.Lock()
+
+
+def get_registry_token(token_url: str):
+    with _TOKEN_LOCK:
+        if token_url in _TOKEN_CACHE:
+            return _TOKEN_CACHE[token_url]
+    token = http_json(token_url).get("token")
+    with _TOKEN_LOCK:
+        _TOKEN_CACHE[token_url] = token
+    return token
+
+
+def fetch_digest_metadata(repo: str, digest: str, deadline=None):
     result = {
         "repository": repo,
         "digest": digest,
@@ -71,8 +107,10 @@ def fetch_digest_metadata(repo: str, digest: str):
         "indexManifests": None,
     }
     try:
+        if deadline_exceeded(deadline):
+            raise RuntimeError("image digest time budget exceeded")
         repo_path, token_url, base_url = registry_targets(repo)
-        token = http_json(token_url).get("token")
+        token = get_registry_token(token_url)
         if not token:
             raise RuntimeError("registry token unavailable")
 
@@ -104,6 +142,8 @@ def fetch_digest_metadata(repo: str, digest: str):
         config_digest = (manifest.get("config") or {}).get("digest")
         result["configDigest"] = config_digest
         if config_digest:
+            if deadline_exceeded(deadline):
+                raise RuntimeError("image digest time budget exceeded")
             config = http_json(
                 f"{base_url}/v2/{repo_path}/blobs/{config_digest}",
                 headers={"Authorization": f"Bearer {token}"},
@@ -155,7 +195,10 @@ def guess_repo_from_image(image_repo: str):
 
 
 def fetch_github_compare(
-    repo: Optional[str], old_rev: Optional[str], new_rev: Optional[str]
+    repo: Optional[str],
+    old_rev: Optional[str],
+    new_rev: Optional[str],
+    deadline=None,
 ):
     result = {
         "repo": repo,
@@ -176,6 +219,9 @@ def fetch_github_compare(
         return result
     if not old_rev or not new_rev:
         result["error"] = "revision labels missing"
+        return result
+    if deadline_exceeded(deadline):
+        result["error"] = "image digest time budget exceeded"
         return result
     try:
         data = http_json(
@@ -210,6 +256,56 @@ def fetch_github_compare(
     except Exception as exc:
         result["error"] = str(exc)
     return result
+
+
+def resolve_compare_repo(old_meta: dict, new_meta: dict, image_repo: str):
+    """Pick the GitHub repo to compare revisions against.
+
+    Returns (compare_repo, compare_repo_source, mismatch) where mismatch is
+    an (old_repo, new_repo) tuple when the OCI source labels disagree.
+    """
+    old_repo = github_repo_from_source(old_meta.get("source"))
+    new_repo = github_repo_from_source(new_meta.get("source"))
+    compare_repo = None
+    compare_repo_source = ""
+    mismatch = None
+    if old_repo and new_repo and old_repo == new_repo:
+        compare_repo = old_repo
+        compare_repo_source = "oci-source-label"
+    elif old_repo and not new_repo:
+        compare_repo = old_repo
+        compare_repo_source = "oci-source-label-old"
+    elif new_repo and not old_repo:
+        compare_repo = new_repo
+        compare_repo_source = "oci-source-label-new"
+    elif old_repo and new_repo and old_repo != new_repo:
+        mismatch = (old_repo, new_repo)
+    if not compare_repo:
+        guessed = guess_repo_from_image(image_repo)
+        if guessed:
+            compare_repo = guessed
+            compare_repo_source = "image-repo-heuristic"
+    return compare_repo, compare_repo_source, mismatch
+
+
+def fetch_all_metadata(changes, deadline=None, max_workers=8):
+    """Fetch digest metadata for every unique (repository, digest) in parallel."""
+    pairs = sorted(
+        {(change["repository"], change["old_digest"]) for change in changes}
+        | {(change["repository"], change["new_digest"]) for change in changes}
+    )
+    if not pairs:
+        return {}
+    if len(pairs) == 1:
+        repo, digest = pairs[0]
+        return {pairs[0]: fetch_digest_metadata(repo, digest, deadline)}
+    with ThreadPoolExecutor(max_workers=min(max_workers, len(pairs))) as executor:
+        metas = list(
+            executor.map(
+                lambda pair: fetch_digest_metadata(pair[0], pair[1], deadline), pairs
+            )
+        )
+    return dict(zip(pairs, metas))
 
 
 def short(value):
@@ -314,12 +410,51 @@ def main():
     if not changes:
         lines.append("No image digest changes detected in PR diff.")
     else:
+        deadline = time_budget_deadline()
+
+        # Wave 1: digest metadata for all unique (repo, digest) pairs in
+        # parallel (registry tokens are cached per repo inside).
+        metas = fetch_all_metadata(changes, deadline)
+
+        # Wave 2: revision compares in parallel, deduplicated by
+        # (repo, old_rev, new_rev).
+        prepared = []
+        compare_keys = set()
+        for change in changes:
+            old_meta = metas[(change["repository"], change["old_digest"])]
+            new_meta = metas[(change["repository"], change["new_digest"])]
+            compare_repo, compare_repo_source, mismatch = resolve_compare_repo(
+                old_meta, new_meta, change["repository"]
+            )
+            key = (compare_repo, old_meta.get("revision"), new_meta.get("revision"))
+            compare_keys.add(key)
+            prepared.append(
+                (change, old_meta, new_meta, compare_repo, compare_repo_source, mismatch, key)
+            )
+
+        compare_keys = sorted(compare_keys, key=lambda k: tuple(str(p) for p in k))
+        with ThreadPoolExecutor(max_workers=min(8, len(compare_keys))) as executor:
+            compares = dict(
+                zip(
+                    compare_keys,
+                    executor.map(
+                        lambda key: fetch_github_compare(key[0], key[1], key[2], deadline),
+                        compare_keys,
+                    ),
+                )
+            )
+
         lines.append("# Image Digest Provenance Analysis")
         lines.append("")
-        for idx, change in enumerate(changes, start=1):
-            old_meta = fetch_digest_metadata(change["repository"], change["old_digest"])
-            new_meta = fetch_digest_metadata(change["repository"], change["new_digest"])
-
+        for idx, (
+            change,
+            old_meta,
+            new_meta,
+            compare_repo,
+            compare_repo_source,
+            mismatch,
+            compare_key,
+        ) in enumerate(prepared, start=1):
             lines.append(f"## Image {idx}: {change['repository']}")
             lines.append(f"- File: `{change['file']}`")
             lines.append(f"- Tag/variant: `{change['tag']}`")
@@ -348,30 +483,14 @@ def main():
                     "- Revision changed: **unknown** (missing OCI revision labels)"
                 )
 
-            old_repo = github_repo_from_source(old_meta.get("source"))
-            new_repo = github_repo_from_source(new_meta.get("source"))
-            compare_repo = None
-            compare_repo_source = ""
-            if old_repo and new_repo and old_repo == new_repo:
-                compare_repo = old_repo
-                compare_repo_source = "oci-source-label"
-            elif old_repo and not new_repo:
-                compare_repo = old_repo
-                compare_repo_source = "oci-source-label-old"
-            elif new_repo and not old_repo:
-                compare_repo = new_repo
-                compare_repo_source = "oci-source-label-new"
-            elif old_repo and new_repo and old_repo != new_repo:
+            if mismatch:
                 lines.append(
-                    f"- Root repo mismatch between old/new labels: `{old_repo}` vs `{new_repo}`"
+                    f"- Root repo mismatch between old/new labels: `{mismatch[0]}` vs `{mismatch[1]}`"
                 )
-            if not compare_repo:
-                guessed = guess_repo_from_image(change["repository"])
-                if guessed:
-                    compare_repo = guessed
-                    compare_repo_source = "image-repo-heuristic"
 
-            compare = fetch_github_compare(compare_repo, old_rev, new_rev)
+            # Compare results are shared between changes with the same key, so
+            # copy before stamping the per-change repo source.
+            compare = dict(compares[compare_key])
             compare["repo_source"] = compare_repo_source or None
 
             lines.append(

--- a/scripts/publish_helpers.sh
+++ b/scripts/publish_helpers.sh
@@ -50,12 +50,23 @@ cleanup_native_reviews() {
   echo "Cleaning up previous managed native reviews for #$PR_NUMBER"
   CURRENT_ACTOR="$(gh api user --jq .login 2>/dev/null || echo "")"
   if [ -n "$CURRENT_ACTOR" ]; then
-    PREV_REVIEWS="$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" --paginate --jq '.[] | select(.user.login == "'"$CURRENT_ACTOR"'" and (.body | contains("<!-- ai-pr-reviewer -->"))) | .id' 2>/dev/null || echo "")"
+    # Managed bodies start with the configured marker (or, for reviews created
+    # by older action versions, the bare/JSON "<!-- ai-pr-reviewer" prefix).
+    # Matching both fixes cleanup misses when comment_marker is customized or
+    # when v1.1.x-era reviews carried only the JSON metadata marker (#162).
+    # The list query carries id and state together so no per-review GET is
+    # needed afterwards.
+    PREV_REVIEWS="$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" --paginate 2>/dev/null \
+      | jq -r --arg actor "$CURRENT_ACTOR" \
+          --arg marker "${COMMENT_MARKER:-<!-- ai-pr-reviewer -->}" \
+          '.[] | select(.user.login == $actor
+                and (((.body // "") | contains($marker))
+                     or ((.body // "") | startswith("<!-- ai-pr-reviewer"))))
+              | "\(.id)\t\(.state // "")"' 2>/dev/null || echo "")"
     if [ -n "$PREV_REVIEWS" ]; then
-      while IFS= read -r REVIEW_ID; do
+      while IFS=$'\t' read -r REVIEW_ID REVIEW_STATE; do
         if [ -z "$REVIEW_ID" ]; then continue; fi
         # Dismiss approval/request-changes reviews to stop stale verdicts from counting
-        REVIEW_STATE="$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews/$REVIEW_ID" --jq '.state // ""' 2>/dev/null || echo "")"
         if [ "$REVIEW_STATE" = "APPROVED" ] || [ "$REVIEW_STATE" = "CHANGES_REQUESTED" ]; then
           if gh api "repos/$REPO/pulls/$PR_NUMBER/reviews/$REVIEW_ID/dismissals" --method PUT -f message="Superseded by a newer automated review for this pull request." --jq '.id' >/dev/null 2>&1; then
             echo "  Dismissed outdated managed review #$REVIEW_ID ($REVIEW_STATE)"

--- a/scripts/run_evidence_providers.py
+++ b/scripts/run_evidence_providers.py
@@ -7,6 +7,7 @@ import shlex
 import subprocess
 import sys
 import time
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 # Ensure the scripts directory is on sys.path so we can import shared helpers.
@@ -95,6 +96,124 @@ def parse_findings(payload: object) -> tuple[str, list[dict[str, str]]]:
     return highest, findings[:40]
 
 
+def run_provider(
+    index: int, provider: object, default_timeout: int, default_max_output: int
+) -> dict:
+    """Execute a single evidence provider and return its result entry."""
+    entry = {
+        "id": f"provider-{index}",
+        "status": "invalid",
+        "command": "",
+        "duration_sec": 0.0,
+        "exit_code": None,
+        "provider_severity": "info",
+        "findings": [],
+        "stdout": "",
+        "stderr": "",
+        "stdout_truncated": False,
+        "stderr_truncated": False,
+    }
+
+    if isinstance(provider, dict) and provider.get("id"):
+        entry["id"] = str(provider["id"])
+
+    timeout = default_timeout
+    max_output = default_max_output
+    command = None
+
+    if isinstance(provider, dict):
+        command = provider.get("command")
+        if provider.get("timeout_sec") is not None:
+            try:
+                timeout = max(1, int(provider["timeout_sec"]))
+            except (TypeError, ValueError):
+                timeout = default_timeout
+        if provider.get("max_output_bytes") is not None:
+            try:
+                max_output = max(256, int(provider["max_output_bytes"]))
+            except (TypeError, ValueError):
+                max_output = default_max_output
+
+    if not command:
+        entry["status"] = "invalid"
+        entry["stderr"] = "Missing required field: command"
+        return entry
+
+    start = time.monotonic()
+    try:
+        if isinstance(command, list):
+            args = [str(part) for part in command]
+            entry["command"] = " ".join(shlex.quote(part) for part in args)
+            completed = subprocess.run(
+                args,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                timeout=timeout,
+                check=False,
+            )
+        else:
+            command_text = str(command)
+            entry["command"] = command_text
+            completed = subprocess.run(
+                ["bash", "-lc", command_text],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                timeout=timeout,
+                check=False,
+            )
+
+        entry["duration_sec"] = round(time.monotonic() - start, 3)
+        entry["exit_code"] = completed.returncode
+        entry["status"] = "ok" if completed.returncode == 0 else "error"
+
+        # --- Secret redaction on stdout/stderr before capturing output ---
+        stdout_text = completed.stdout.decode("utf-8", errors="replace") if completed.stdout else ""
+        stderr_text = completed.stderr.decode("utf-8", errors="replace") if completed.stderr else ""
+        entry["stdout"], entry["stdout_truncated"] = mask_and_truncate(
+            stdout_text, max_output
+        )
+        entry["stderr"], entry["stderr_truncated"] = mask_and_truncate(
+            stderr_text, max_output
+        )
+    except subprocess.TimeoutExpired as exc:
+        entry["duration_sec"] = round(time.monotonic() - start, 3)
+        entry["status"] = "timeout"
+        entry["exit_code"] = None
+        stdout_raw = exc.stdout if isinstance(exc.stdout, bytes) else b""
+        stderr_raw = exc.stderr if isinstance(exc.stderr, bytes) else b""
+
+        # Redact before storing in the summary JSON and markdown.
+        entry["stdout"], entry["stdout_truncated"] = mask_and_truncate(
+            stdout_raw.decode("utf-8", errors="replace") if stdout_raw else "",
+            max_output,
+        )
+        entry["stderr"], entry["stderr_truncated"] = mask_and_truncate(
+            stderr_raw.decode("utf-8", errors="replace") if stderr_raw else "",
+            max_output,
+        )
+
+    # Also redact the stored stdout before JSON-parse attempt so that
+    # any secrets leaking into the parsed output are already gone.
+    entry["stdout"] = mask_secrets(entry["stdout"])
+
+    parsed = None
+    if entry["stdout"].strip():
+        try:
+            parsed = json.loads(entry["stdout"])
+        except json.JSONDecodeError:
+            parsed = None
+
+    if parsed is not None:
+        entry["output_format"] = "json"
+        severity, findings = parse_findings(parsed)
+        entry["provider_severity"] = severity
+        entry["findings"] = findings
+    else:
+        entry["output_format"] = "text"
+
+    return entry
+
+
 def write_outputs(summary: dict, markdown: str) -> None:
     Path("evidence-providers.json").write_text(
         json.dumps(summary, indent=2, ensure_ascii=False) + "\n",
@@ -151,122 +270,26 @@ def main() -> int:
 
     md_lines = ["Evidence providers executed before final review synthesis.", ""]
 
-    for index, provider in enumerate(providers[:25], start=1):
-        entry = {
-            "id": f"provider-{index}",
-            "status": "invalid",
-            "command": "",
-            "duration_sec": 0.0,
-            "exit_code": None,
-            "provider_severity": "info",
-            "findings": [],
-            "stdout": "",
-            "stderr": "",
-            "stdout_truncated": False,
-            "stderr_truncated": False,
-        }
+    # Providers are independent commands, so run them concurrently. Results
+    # keep config order regardless of completion order. Set
+    # EVIDENCE_PROVIDER_PARALLELISM=1 for providers that must run serially
+    # (e.g. they contend on the same working-tree files).
+    parallelism = env_int("EVIDENCE_PROVIDER_PARALLELISM", 4)
+    indexed = list(enumerate(providers[:25], start=1))
 
-        if isinstance(provider, dict) and provider.get("id"):
-            entry["id"] = str(provider["id"])
+    def _run(item: tuple) -> dict:
+        index, provider = item
+        return run_provider(index, provider, default_timeout, default_max_output)
 
-        timeout = default_timeout
-        max_output = default_max_output
-        command = None
+    if len(indexed) <= 1 or parallelism <= 1:
+        entries = [_run(item) for item in indexed]
+    else:
+        with ThreadPoolExecutor(max_workers=min(parallelism, len(indexed))) as executor:
+            entries = list(executor.map(_run, indexed))
 
-        if isinstance(provider, dict):
-            command = provider.get("command")
-            if provider.get("timeout_sec") is not None:
-                try:
-                    timeout = max(1, int(provider["timeout_sec"]))
-                except (TypeError, ValueError):
-                    timeout = default_timeout
-            if provider.get("max_output_bytes") is not None:
-                try:
-                    max_output = max(256, int(provider["max_output_bytes"]))
-                except (TypeError, ValueError):
-                    max_output = default_max_output
-
-        if not command:
-            entry["status"] = "invalid"
-            entry["stderr"] = "Missing required field: command"
-            summary["providers"].append(entry)
-            continue
-
-        start = time.monotonic()
-        try:
-            if isinstance(command, list):
-                args = [str(part) for part in command]
-                entry["command"] = " ".join(shlex.quote(part) for part in args)
-                completed = subprocess.run(
-                    args,
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.PIPE,
-                    timeout=timeout,
-                    check=False,
-                )
-            else:
-                command_text = str(command)
-                entry["command"] = command_text
-                completed = subprocess.run(
-                    ["bash", "-lc", command_text],
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.PIPE,
-                    timeout=timeout,
-                    check=False,
-                )
-
-            entry["duration_sec"] = round(time.monotonic() - start, 3)
-            entry["exit_code"] = completed.returncode
-            entry["status"] = "ok" if completed.returncode == 0 else "error"
-
-            # --- Secret redaction on stdout/stderr before capturing output ---
-            stdout_text = completed.stdout.decode("utf-8", errors="replace") if completed.stdout else ""
-            stderr_text = completed.stderr.decode("utf-8", errors="replace") if completed.stderr else ""
-            entry["stdout"], entry["stdout_truncated"] = mask_and_truncate(
-                stdout_text, max_output
-            )
-            entry["stderr"], entry["stderr_truncated"] = mask_and_truncate(
-                stderr_text, max_output
-            )
-        except subprocess.TimeoutExpired as exc:
-            entry["duration_sec"] = round(time.monotonic() - start, 3)
-            entry["status"] = "timeout"
-            entry["exit_code"] = None
-            stdout_raw = exc.stdout if isinstance(exc.stdout, bytes) else b""
-            stderr_raw = exc.stderr if isinstance(exc.stderr, bytes) else b""
-
-            # Redact before storing in the summary JSON and markdown.
-            entry["stdout"], entry["stdout_truncated"] = mask_and_truncate(
-                stdout_raw.decode("utf-8", errors="replace") if stdout_raw else "",
-                max_output,
-            )
-            entry["stderr"], entry["stderr_truncated"] = mask_and_truncate(
-                stderr_raw.decode("utf-8", errors="replace") if stderr_raw else "",
-                max_output,
-            )
-
-        # Also redact the stored stdout before JSON-parse attempt so that
-        # any secrets leaking into the parsed output are already gone.
-        entry["stdout"] = mask_secrets(entry["stdout"])
-
-        parsed = None
-        if entry["stdout"].strip():
-            try:
-                parsed = json.loads(entry["stdout"])
-            except json.JSONDecodeError:
-                parsed = None
-
-        if parsed is not None:
-            entry["output_format"] = "json"
-            severity, findings = parse_findings(parsed)
-            entry["provider_severity"] = severity
-            entry["findings"] = findings
-        else:
-            entry["output_format"] = "text"
-
+    for entry in entries:
         if entry["provider_severity"] == "blocker":
             summary["has_blocker"] = True
-
         summary["providers"].append(entry)
 
     if not summary["providers"]:

--- a/scripts/run_review.sh
+++ b/scripts/run_review.sh
@@ -353,22 +353,42 @@ apply_all_enforcement(
 section_timer_start "pr-context"
 log "Collecting PR context for #$PR_NUMBER in $REPO..."
 
-gh pr view "$PR_NUMBER" --repo "$REPO" \
-  --json number,title,body,headRefOid,baseRefName,headRefName,author,changedFiles,additions,deletions,files,url > pr.json
+# check_review_needed.sh (the precheck step) already fetched the PR object and
+# the full diff. Reuse them when present so the PR object and diff are each
+# fetched exactly once per run; fall back to fetching for standalone use
+# (smoke test, manual invocation).
+if [[ -s pr-object.json && "$(jq -r '.number // empty' pr-object.json 2>/dev/null)" == "$PR_NUMBER" ]]; then
+  log "Reusing PR object fetched by precheck"
+else
+  gh api "repos/$REPO/pulls/$PR_NUMBER" > pr-object.json
+fi
+jq '{number, title, body, headRefOid: .head.sha, baseRefName: .base.ref, headRefName: .head.ref, author: {login: (.user.login // "")}, changedFiles: .changed_files, additions, deletions, url: .html_url}' \
+  pr-object.json > pr.json
 
-IS_FORK_PR="$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '((.head.repo.full_name // "") != (.base.repo.full_name // ""))' 2>/dev/null || echo false)"
+IS_FORK_PR="$(jq -r '((.head.repo.full_name // "") != (.base.repo.full_name // ""))' pr-object.json 2>/dev/null || echo false)"
 if [[ "$IS_FORK_PR" == "true" ]]; then
   log "Detected cross-repository pull request"
 fi
 
-gh pr diff "$PR_NUMBER" --repo "$REPO" > pr.diff
+if [[ -s pr.diff ]]; then
+  log "Reusing PR diff fetched by precheck"
+else
+  gh pr diff "$PR_NUMBER" --repo "$REPO" > pr.diff
+fi
 truncate_clean pr.diff pr.diff.truncated "$MAX_DIFF" '…[diff truncated to fit context budget]'
 
-gh api "repos/$REPO/pulls/$PR_NUMBER/files" --paginate > pr-files.raw.json
+# One bounded page instead of --paginate: 100 files is far beyond what the
+# MAX_FILES byte budget keeps anyway, and unbounded pagination on huge PRs
+# both burned API quota and produced concatenated JSON documents.
+gh api "repos/$REPO/pulls/$PR_NUMBER/files?per_page=100" > pr-files.raw.json
 # Note: 'patch' is intentionally dropped — the per-file patches duplicate the
 # raw diff that is already embedded in the corpus, and the classifier does not
 # read them. Keeping them here doubled the diff bytes sent to the model.
-jq '[.[] | {filename,status,additions,deletions,changes,previous_filename}]' pr-files.raw.json > pr-files.json
+TOTAL_CHANGED_FILES="$(jq -r '.changedFiles // 0' pr.json 2>/dev/null || echo 0)"
+jq --argjson total "${TOTAL_CHANGED_FILES:-0}" \
+  '[.[] | {filename,status,additions,deletions,changes,previous_filename}]
+   + (if $total > 100 then [{note: "file list truncated to first 100 of \($total) changed files"}] else [] end)' \
+  pr-files.raw.json > pr-files.json
 truncate_clean pr-files.json pr-files.truncated.json "$MAX_FILES" '…[file list truncated]'
 
 jq -r '.body // ""' pr.json > pr-body.txt
@@ -465,6 +485,21 @@ else
 fi
 section_timer_end
 
+# Returns 0 when the URL's host is in ALLOWED_SOURCE_HOSTS.
+url_host_allowed() {
+  local host raw_host candidate
+  host=$(printf '%s' "$1" | sed -E 's#^https?://([^/]+).*#\1#' | tr '[:upper:]' '[:lower:]')
+  IFS=',' read -ra _allowed_hosts <<< "$ALLOWED_SOURCE_HOSTS"
+  for raw_host in "${_allowed_hosts[@]}"; do
+    candidate=$(printf '%s' "$raw_host" | xargs | tr '[:upper:]' '[:lower:]')
+    [ -n "$candidate" ] || continue
+    if [ "$host" = "$candidate" ]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
 section_timer_start "enrichment"
 log "Gathering linked sources..."
 : > linked-sources.md
@@ -473,6 +508,30 @@ if [ -s urls.txt ]; then
   TARGET_VERSION="$(jq -r '.title' pr.json | sed -n 's/.*→ *v\?\([0-9][0-9.]*\).*/\1/p' | head -n1)"
   if [ -z "$TARGET_VERSION" ]; then
     TARGET_VERSION="$(grep -Eo 'v?[0-9]+\.[0-9]+\.[0-9]+' version-hints.truncated.txt 2>/dev/null | sed 's/^v//' | tail -n1 || true)"
+  fi
+
+  # Phase 1: fetch every allowlisted URL body in one parallel curl run instead
+  # of serially (25 URLs x 25s worst-case each). parallel-max covers the full
+  # URL cap so wall-clock is bounded by the single slowest transfer. URLs are
+  # space-free by construction (extracted with a space-excluding grep), so the
+  # unquoted curl-config value cannot smuggle extra directives.
+  : > curl-parallel.cfg
+  i=0
+  while IFS= read -r url; do
+    [ -z "$url" ] && continue
+    i=$((i + 1))
+    [ "$i" -gt 25 ] && break
+    normalized_url="$(printf '%s' "$url" | sed -E 's#^https?://redirect.github.com/#https://github.com/#')"
+    rm -f "source.$i.raw"
+    if url_host_allowed "$normalized_url"; then
+      {
+        echo "url = $normalized_url"
+        echo "output = source.$i.raw"
+      } >> curl-parallel.cfg
+    fi
+  done < urls.txt
+  if [ -s curl-parallel.cfg ]; then
+    curl -q -fsSL --parallel --parallel-max 25 --max-time 25 --config curl-parallel.cfg 2>/dev/null || true
   fi
 
   : > seen-repos.txt
@@ -497,20 +556,10 @@ if [ -s urls.txt ]; then
     } >> linked-sources.md
 
     host=$(printf '%s' "$normalized_url" | sed -E 's#^https?://([^/]+).*#\1#' | tr '[:upper:]' '[:lower:]')
-    allowed=0
-    IFS=',' read -ra allowed_hosts <<< "$ALLOWED_SOURCE_HOSTS"
-    for raw_host in "${allowed_hosts[@]}"; do
-      candidate=$(printf '%s' "$raw_host" | xargs | tr '[:upper:]' '[:lower:]')
-      [ -n "$candidate" ] || continue
-      if [ "$host" = "$candidate" ]; then
-        allowed=1
-        break
-      fi
-    done
 
-    if [ "$allowed" -eq 1 ]; then
-      if curl -fsSL -L --max-time 25 "$normalized_url" -o source.raw 2>/dev/null; then
-        head -c 5000 source.raw | tr $'\0' ' ' > source.tmp
+    if url_host_allowed "$normalized_url"; then
+      if [ -s "source.$i.raw" ]; then
+        head -c 5000 "source.$i.raw" | tr $'\0' ' ' > source.tmp
         if [ -s source.tmp ]; then
           echo '```text' >> linked-sources.md
           cat source.tmp >> linked-sources.md

--- a/scripts/run_tool_harness.py
+++ b/scripts/run_tool_harness.py
@@ -10,6 +10,7 @@ import tempfile
 import urllib.error
 import urllib.parse
 import urllib.request
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 # Ensure the scripts directory is on sys.path so we can import shared helpers.
@@ -585,6 +586,45 @@ def execute_tool_request(
     return tool_result
 
 
+def execute_tool_requests(
+    normalized_requests,
+    workspace_root,
+    allowed_gh_repos,
+    current_repo,
+    allowed_hosts,
+    max_response_bytes,
+    request_timeout,
+):
+    """Execute normalized (tool_name, args) requests concurrently.
+
+    Tools are read-only, so they are safe to run in parallel; results are
+    returned in request order so the markdown/JSON output stays deterministic.
+    """
+    if not normalized_requests:
+        return []
+
+    def _run(pair):
+        tool_name, args = pair
+        return execute_tool_request(
+            tool_name,
+            args,
+            workspace_root,
+            allowed_gh_repos,
+            current_repo,
+            allowed_hosts,
+            max_response_bytes,
+            request_timeout,
+        )
+
+    if len(normalized_requests) == 1:
+        return [_run(normalized_requests[0])]
+
+    with ThreadPoolExecutor(
+        max_workers=min(4, len(normalized_requests))
+    ) as executor:
+        return list(executor.map(_run, normalized_requests))
+
+
 def tool_result_md_lines(index, tool_name, args, tool_result):
     """Generate markdown lines for a single tool result.
 
@@ -853,22 +893,23 @@ def main():
             md_lines.append(f"**Planning warning:** {result['planning_warning']}")
         md_lines.append("")
 
-        for i, raw_req in enumerate(requests_list[:max_requests]):
-            if not isinstance(raw_req, dict):
-                continue
-            tool_name, args = normalize_tool_request(raw_req)
-
-            tool_result = execute_tool_request(
-                tool_name,
-                args,
-                workspace_root,
-                allowed_gh_repos,
-                current_repo,
-                allowed_hosts,
-                max_response_bytes,
-                request_timeout,
-            )
-
+        normalized = [
+            normalize_tool_request(raw_req)
+            for raw_req in requests_list[:max_requests]
+            if isinstance(raw_req, dict)
+        ]
+        tool_results = execute_tool_requests(
+            normalized,
+            workspace_root,
+            allowed_gh_repos,
+            current_repo,
+            allowed_hosts,
+            max_response_bytes,
+            request_timeout,
+        )
+        for i, ((tool_name, args), tool_result) in enumerate(
+            zip(normalized, tool_results)
+        ):
             if tool_result["status"] == "ok":
                 result["executed_request_count"] += 1
 
@@ -919,20 +960,17 @@ def main():
     md_lines.append(f"**Planned requests:** {result['planned_request_count']}")
     md_lines.append("")
 
-    for i, call in enumerate(tool_calls[:max_requests]):
-        tool_name, args = normalize_tool_request(call)
-
-        tool_result = execute_tool_request(
-            tool_name,
-            args,
-            workspace_root,
-            allowed_gh_repos,
-            current_repo,
-            allowed_hosts,
-            max_response_bytes,
-            request_timeout,
-        )
-
+    normalized = [normalize_tool_request(call) for call in tool_calls[:max_requests]]
+    tool_results = execute_tool_requests(
+        normalized,
+        workspace_root,
+        allowed_gh_repos,
+        current_repo,
+        allowed_hosts,
+        max_response_bytes,
+        request_timeout,
+    )
+    for i, ((tool_name, args), tool_result) in enumerate(zip(normalized, tool_results)):
         if tool_result["status"] == "ok":
             result["executed_request_count"] += 1
 

--- a/tests/test_check_review_needed.sh
+++ b/tests/test_check_review_needed.sh
@@ -42,6 +42,7 @@ index 123..456 644
 
 cat > "$TMPDIR/bin/gh" <<'SHELLEOF'
 #!/usr/bin/env bash
+echo "$*" >> /tmp/testfp_gh_calls.log
 case "$1" in
   "pr")
     case "$2" in
@@ -53,6 +54,8 @@ case "$1" in
       [ -f /tmp/testfp_reviews.json ] && cat /tmp/testfp_reviews.json
     elif echo "$*" | grep -q 'comments'; then
       cat /tmp/testfp_comments.json
+    elif echo "$*" | grep -q 'pulls/42'; then
+      [ -f /tmp/testfp_pr_object.json ] && cat /tmp/testfp_pr_object.json
     fi
     ;;
 esac
@@ -60,10 +63,24 @@ exit 0
 SHELLEOF
 chmod +x "$TMPDIR/bin/gh"
 
+cat > /tmp/testfp_pr_object.json <<'JSONEOF'
+{
+  "number": 42,
+  "head": {"sha": "aaaa111122223333aaaa111122223333aaaa1111", "ref": "feature", "repo": {"full_name": "test/repo"}},
+  "base": {"sha": "bbbb111122223333bbbb111122223333bbbb1111", "ref": "main", "repo": {"full_name": "test/repo"}}
+}
+JSONEOF
+
+# The precheck writes pr.diff / pr-object.json into its CWD; run it in a
+# scratch workdir so test runs do not litter the repository root.
+WORKDIR="$TMPDIR/work"
+
 run_precheck() {
   local output_file="$TMPDIR/out_$RANDOM$RANDOM"
   printf '%s' "$FIXED_DIFF" > /tmp/testfp_diff
+  rm -rf "$WORKDIR" && mkdir -p "$WORKDIR"
   (
+    cd "$WORKDIR" || exit 1
     PATH="$TMPDIR/bin:$PATH" \
     REPO="test/repo" \
     PR_NUMBER=42 \
@@ -127,7 +144,9 @@ set_empty_comments() {
 run_precheck_empty_diff() {
   local output_file="$TMPDIR/out_$RANDOM$RANDOM"
   printf '' > /tmp/testfp_diff
+  rm -rf "$WORKDIR" && mkdir -p "$WORKDIR"
   (
+    cd "$WORKDIR" || exit 1
     PATH="$TMPDIR/bin:$PATH" \
     REPO="test/repo" \
     PR_NUMBER=42 \
@@ -259,6 +278,40 @@ set_comments "<!-- ai-pr-reviewer -->
 APPROVE"
 RESULT="$(PUBLISH_MODE=review_verdict run_precheck)"
 check "should_review=true when only an issue comment matches (review_verdict)" "$(echo "$RESULT" | grep '^should_review=' | head -1 | cut -d= -f2)" "true"
+
+# ── Test 13: skip path short-circuits the PR-object fetch ─────────────
+echo ""
+echo "=== Test 13: should_review=false short-circuits scope resolution ==="
+rm -f /tmp/testfp_reviews.json
+set_empty_comments
+OUTPUT_FP_SC="$(run_precheck)"
+BROAD_FP_SC="$(echo "$OUTPUT_FP_SC" | grep '^diff_fingerprint=' | head -1 | cut -d= -f2)"
+set_comments "<!-- ai-pr-reviewer -->
+<!-- ai-pr-review-fingerprint:${BROAD_FP_SC} -->
+APPROVE"
+: > /tmp/testfp_gh_calls.log
+RESULT="$(run_precheck)"
+check "should_review=false on matching fingerprint" "$(echo "$RESULT" | grep '^should_review=' | head -1 | cut -d= -f2)" "false"
+PULLS_FETCHES="$(grep -c 'api repos/test/repo/pulls/42$' /tmp/testfp_gh_calls.log || true)"
+check "PR object is not fetched when skipping" "$PULLS_FETCHES" "0"
+check "skip path still emits scope output" "$(echo "$RESULT" | grep -c '^effective_review_scope=')" "1"
+
+# ── Test 14: review path emits PR facts and reusable files ───────────
+echo ""
+echo "=== Test 14: review path forwards head/base SHA, fork flag, and files ==="
+set_empty_comments
+: > /tmp/testfp_gh_calls.log
+RESULT="$(run_precheck)"
+check "should_review=true" "$(echo "$RESULT" | grep '^should_review=' | head -1 | cut -d= -f2)" "true"
+check "head_sha output forwarded" "$(echo "$RESULT" | grep '^head_sha=' | head -1 | cut -d= -f2)" "aaaa111122223333aaaa111122223333aaaa1111"
+check "base_sha output forwarded" "$(echo "$RESULT" | grep '^base_sha=' | head -1 | cut -d= -f2)" "bbbb111122223333bbbb111122223333bbbb1111"
+check "is_fork_pr output forwarded" "$(echo "$RESULT" | grep '^is_fork_pr=' | head -1 | cut -d= -f2)" "false"
+check "pr.diff saved for reuse by run_review" "$(test -s "$WORKDIR/pr.diff" && echo yes || echo no)" "yes"
+check "pr-object.json saved for reuse by run_review" "$(test -s "$WORKDIR/pr-object.json" && echo yes || echo no)" "yes"
+PULLS_FETCHES="$(grep -c 'api repos/test/repo/pulls/42$' /tmp/testfp_gh_calls.log || true)"
+check "PR object fetched exactly once" "$PULLS_FETCHES" "1"
+DIFF_FETCHES="$(grep -c '^pr diff' /tmp/testfp_gh_calls.log || true)"
+check "diff fetched exactly once" "$DIFF_FETCHES" "1"
 
 echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="

--- a/tests/test_cleanup_previous_native_reviews.sh
+++ b/tests/test_cleanup_previous_native_reviews.sh
@@ -237,6 +237,64 @@ check_exists "README warns about permission requirements" \
   "$(grep -ci 'permission\|warn' "$README_MD" || echo 0)"
 
 echo ""
+echo "=== Functional: cleanup_native_reviews matching + single list query ==="
+
+CLEANUP_TMP="$(mktemp -d)"
+trap 'rm -rf "$CLEANUP_TMP"' EXIT
+mkdir -p "$CLEANUP_TMP/bin"
+CALL_LOG="$CLEANUP_TMP/gh-calls.log"
+: > "$CALL_LOG"
+
+# Review fixtures: 11 carries a custom marker, 22 carries only the legacy
+# v1.1.x JSON metadata marker, 33 is a human review, 44 is unmanaged bot output.
+cat > "$CLEANUP_TMP/reviews.json" <<'JSONEOF'
+[
+  {"id": 11, "state": "APPROVED", "user": {"login": "test-bot"},
+   "body": "<!-- my-marker -->\n<!-- ai-pr-review-sha:abc -->\nold review"},
+  {"id": 22, "state": "CHANGES_REQUESTED", "user": {"login": "test-bot"},
+   "body": "<!-- ai-pr-reviewer:{\"version\":1,\"head_sha\":\"abc\"} -->\nlegacy review"},
+  {"id": 33, "state": "APPROVED", "user": {"login": "human"},
+   "body": "<!-- my-marker -->\nhuman pasted the marker"},
+  {"id": 44, "state": "COMMENTED", "user": {"login": "test-bot"},
+   "body": "unrelated bot output"}
+]
+JSONEOF
+
+cat > "$CLEANUP_TMP/bin/gh" <<SHELLEOF
+#!/usr/bin/env bash
+echo "\$*" >> "$CALL_LOG"
+if [ "\$1" = "api" ] && [ "\$2" = "user" ]; then echo "test-bot"; exit 0; fi
+case "\$*" in
+  *"/reviews --paginate"*) cat "$CLEANUP_TMP/reviews.json" ;;
+  *dismissals*) echo '{"id": 1}' ;;
+  *"--method PATCH"*) echo '{}' ;;
+esac
+exit 0
+SHELLEOF
+chmod +x "$CLEANUP_TMP/bin/gh"
+
+CLEANUP_OUTPUT="$(
+  PATH="$CLEANUP_TMP/bin:$PATH" \
+  GH_TOKEN=test REPO="test/repo" PR_NUMBER=9 COMMENT_MARKER="<!-- my-marker -->" \
+  bash -c 'source "'"$HELPER_SCRIPT"'"; cleanup_native_reviews true' 2>&1
+)"
+
+check_contains "custom-marker review is dismissed" \
+  "$CLEANUP_OUTPUT" "Dismissed outdated managed review #11 (APPROVED)"
+check_contains "legacy JSON-marker review is dismissed" \
+  "$CLEANUP_OUTPUT" "Dismissed outdated managed review #22 (CHANGES_REQUESTED)"
+check_not_contains "human review with pasted marker is untouched" \
+  "$CLEANUP_OUTPUT" "#33"
+check_not_contains "unmanaged bot review is untouched" \
+  "$CLEANUP_OUTPUT" "#44"
+
+# State must come from the list query — no per-review GETs.
+PER_REVIEW_GETS="$(grep -E 'reviews/[0-9]+' "$CALL_LOG" | grep -vc -- '--method' || true)"
+check "review state read from list query (no per-review GET)" "$PER_REVIEW_GETS" "0"
+LIST_QUERIES="$(grep -c '/reviews --paginate' "$CALL_LOG" || true)"
+check "exactly one review list query" "$LIST_QUERIES" "1"
+
+echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="
 
 if [[ "$FAIL" -gt 0 ]]; then

--- a/tests/test_evidence_providers.py
+++ b/tests/test_evidence_providers.py
@@ -59,11 +59,15 @@ sys.stderr.write("token=ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij\\n")
 """
 
 
-def _run_with_config(config_data, tmp_path: Path) -> subprocess.CompletedProcess:
+def _run_with_config(
+    config_data, tmp_path: Path, extra_env=None
+) -> subprocess.CompletedProcess:
     config_file = tmp_path / "providers.json"
     config_file.write_text(json.dumps(config_data, indent=2), encoding="utf-8")
     env = os.environ.copy()
     env["EVIDENCE_PROVIDERS_FILE"] = str(config_file)
+    if extra_env:
+        env.update(extra_env)
     result = subprocess.run(
         [sys.executable, str(EVIDENCE_SCRIPT)],
         cwd=str(tmp_path),
@@ -555,6 +559,87 @@ class TestForkEnablement:
         assert self._should_skip("false", "false") is False
         assert self._should_skip("false", "true") is False
         assert self._should_skip("false", "") is False
+
+
+# ── Parallel execution ─────────────────────────────────────────────
+
+_TIMESTAMP_HELPER = """\
+import sys, time
+start = time.time()
+time.sleep(0.8)
+end = time.time()
+open(sys.argv[1], "w").write(f"{start} {end}")
+print("done")
+"""
+
+
+def _interval(tmp_path: Path, name: str):
+    start, end = (tmp_path / name).read_text().split()
+    return float(start), float(end)
+
+
+class TestParallelExecution:
+    def test_results_keep_config_order(self, tmp_path: Path):
+        config = {
+            "providers": [
+                {"id": "slow", "command": "sleep 0.5; echo slow-out"},
+                {"id": "fast", "command": "echo fast-out"},
+            ]
+        }
+        result = _run_with_config(config, tmp_path)
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        data = _load_json_output(tmp_path)
+        assert [p["id"] for p in data["providers"]] == ["slow", "fast"]
+        assert data["providers"][0]["stdout"].strip() == "slow-out"
+        assert data["providers"][1]["stdout"].strip() == "fast-out"
+
+    def test_providers_run_concurrently_by_default(self, tmp_path: Path):
+        helper = tmp_path / "stamp.py"
+        helper.write_text(_TIMESTAMP_HELPER)
+        config = {
+            "providers": [
+                {"id": "a", "command": f"{sys.executable} {helper} {tmp_path}/a.ts"},
+                {"id": "b", "command": f"{sys.executable} {helper} {tmp_path}/b.ts"},
+            ]
+        }
+        result = _run_with_config(config, tmp_path)
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        a_start, a_end = _interval(tmp_path, "a.ts")
+        b_start, b_end = _interval(tmp_path, "b.ts")
+        # Execution windows must overlap when run in parallel.
+        assert a_start < b_end and b_start < a_end
+
+    def test_parallelism_one_forces_serial(self, tmp_path: Path):
+        helper = tmp_path / "stamp.py"
+        helper.write_text(_TIMESTAMP_HELPER)
+        config = {
+            "providers": [
+                {"id": "a", "command": f"{sys.executable} {helper} {tmp_path}/a.ts"},
+                {"id": "b", "command": f"{sys.executable} {helper} {tmp_path}/b.ts"},
+            ]
+        }
+        result = _run_with_config(
+            config, tmp_path, extra_env={"EVIDENCE_PROVIDER_PARALLELISM": "1"}
+        )
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        a_start, a_end = _interval(tmp_path, "a.ts")
+        b_start, b_end = _interval(tmp_path, "b.ts")
+        # Serial execution: one window fully precedes the other.
+        assert a_end <= b_start or b_end <= a_start
+
+    def test_blocker_flag_still_aggregates(self, tmp_path: Path):
+        helper = tmp_path / "blocker.py"
+        helper.write_text(HELPER_BLOCKER)
+        config = {
+            "providers": [
+                {"id": "clean", "command": "echo ok"},
+                {"id": "blocker", "command": f"{sys.executable} {helper}"},
+            ]
+        }
+        result = _run_with_config(config, tmp_path)
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        data = _load_json_output(tmp_path)
+        assert data["has_blocker"] is True
 
 
 if __name__ == "__main__":

--- a/tests/test_image_digest_analysis.py
+++ b/tests/test_image_digest_analysis.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""Tests for scripts/image_digest_analysis.py — token caching, time budget,
+parallel metadata fetching, and compare-repo resolution."""
+
+import sys
+import time
+from pathlib import Path
+from unittest import mock
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+import pytest
+
+import image_digest_analysis as ida
+
+
+DIGEST_A = "sha256:" + "a" * 64
+DIGEST_B = "sha256:" + "b" * 64
+
+
+@pytest.fixture(autouse=True)
+def _clear_token_cache():
+    ida._TOKEN_CACHE.clear()
+    yield
+    ida._TOKEN_CACHE.clear()
+
+
+# ── Registry token caching ─────────────────────────────────────────
+
+
+class TestTokenCache:
+    def test_token_fetched_once_per_repo(self):
+        calls = []
+
+        def fake_http_json(url, headers=None):
+            calls.append(url)
+            if "token" in url:
+                return {"token": "tok-123"}
+            return {"mediaType": "application/vnd.oci.image.manifest.v1+json"}
+
+        with mock.patch.object(ida, "http_json", fake_http_json):
+            ida.fetch_digest_metadata("ghcr.io/acme/app", DIGEST_A)
+            ida.fetch_digest_metadata("ghcr.io/acme/app", DIGEST_B)
+
+        token_calls = [c for c in calls if "token" in c]
+        assert len(token_calls) == 1
+
+    def test_distinct_repos_get_distinct_tokens(self):
+        calls = []
+
+        def fake_http_json(url, headers=None):
+            calls.append(url)
+            if "token" in url:
+                return {"token": "tok"}
+            return {"mediaType": "application/vnd.oci.image.manifest.v1+json"}
+
+        with mock.patch.object(ida, "http_json", fake_http_json):
+            ida.fetch_digest_metadata("ghcr.io/acme/app", DIGEST_A)
+            ida.fetch_digest_metadata("ghcr.io/acme/other", DIGEST_A)
+
+        token_calls = [c for c in calls if "token" in c]
+        assert len(token_calls) == 2
+
+
+# ── Time budget ────────────────────────────────────────────────────
+
+
+class TestTimeBudget:
+    def test_expired_deadline_short_circuits_metadata(self):
+        def fail_http_json(url, headers=None):
+            raise AssertionError("network should not be touched after deadline")
+
+        with mock.patch.object(ida, "http_json", fail_http_json):
+            result = ida.fetch_digest_metadata(
+                "ghcr.io/acme/app", DIGEST_A, deadline=time.monotonic() - 1
+            )
+        assert "time budget exceeded" in (result["error"] or "")
+
+    def test_expired_deadline_short_circuits_compare(self):
+        def fail_http_json(url, headers=None):
+            raise AssertionError("network should not be touched after deadline")
+
+        with mock.patch.object(ida, "http_json", fail_http_json):
+            result = ida.fetch_github_compare(
+                "acme/app", "rev1", "rev2", deadline=time.monotonic() - 1
+            )
+        assert "time budget exceeded" in (result["error"] or "")
+
+    def test_budget_env_zero_disables(self, monkeypatch):
+        monkeypatch.setenv("IMAGE_DIGEST_BUDGET_SEC", "0")
+        assert ida.time_budget_deadline() is None
+
+    def test_budget_env_invalid_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv("IMAGE_DIGEST_BUDGET_SEC", "nope")
+        deadline = ida.time_budget_deadline()
+        assert deadline is not None
+        assert deadline - time.monotonic() <= 60.5
+
+    def test_budget_env_default(self, monkeypatch):
+        monkeypatch.delenv("IMAGE_DIGEST_BUDGET_SEC", raising=False)
+        assert ida.time_budget_deadline() is not None
+
+
+# ── Parallel metadata fetch ────────────────────────────────────────
+
+
+class TestFetchAllMetadata:
+    def _changes(self):
+        return [
+            {
+                "file": "a.yaml",
+                "repository": "ghcr.io/acme/app",
+                "tag": "v1",
+                "old_digest": DIGEST_A,
+                "new_digest": DIGEST_B,
+            }
+        ]
+
+    def test_returns_entry_per_unique_pair(self):
+        fetched = []
+
+        def fake_fetch(repo, digest, deadline=None):
+            fetched.append((repo, digest))
+            return {"repository": repo, "digest": digest, "revision": None, "error": None}
+
+        with mock.patch.object(ida, "fetch_digest_metadata", fake_fetch):
+            metas = ida.fetch_all_metadata(self._changes())
+
+        assert set(metas) == {
+            ("ghcr.io/acme/app", DIGEST_A),
+            ("ghcr.io/acme/app", DIGEST_B),
+        }
+        assert sorted(fetched) == sorted(set(fetched))
+
+    def test_duplicate_digests_fetched_once(self):
+        changes = self._changes() + [
+            {
+                "file": "b.yaml",
+                "repository": "ghcr.io/acme/app",
+                "tag": "v1",
+                "old_digest": DIGEST_A,
+                "new_digest": DIGEST_B,
+            }
+        ]
+        count = {"n": 0}
+
+        def fake_fetch(repo, digest, deadline=None):
+            count["n"] += 1
+            return {"repository": repo, "digest": digest, "error": None}
+
+        with mock.patch.object(ida, "fetch_digest_metadata", fake_fetch):
+            metas = ida.fetch_all_metadata(changes)
+
+        assert count["n"] == 2
+        assert len(metas) == 2
+
+    def test_empty_changes(self):
+        assert ida.fetch_all_metadata([]) == {}
+
+
+# ── Compare-repo resolution ────────────────────────────────────────
+
+
+class TestResolveCompareRepo:
+    def test_matching_labels(self):
+        old = {"source": "https://github.com/acme/app"}
+        new = {"source": "https://github.com/acme/app"}
+        repo, source, mismatch = ida.resolve_compare_repo(old, new, "ghcr.io/acme/app")
+        assert repo == "acme/app"
+        assert source == "oci-source-label"
+        assert mismatch is None
+
+    def test_old_label_only(self):
+        old = {"source": "https://github.com/acme/app"}
+        repo, source, mismatch = ida.resolve_compare_repo(old, {}, "ghcr.io/acme/app")
+        assert repo == "acme/app"
+        assert source == "oci-source-label-old"
+
+    def test_new_label_only(self):
+        new = {"source": "https://github.com/acme/app"}
+        repo, source, mismatch = ida.resolve_compare_repo({}, new, "ghcr.io/acme/app")
+        assert repo == "acme/app"
+        assert source == "oci-source-label-new"
+
+    def test_mismatched_labels_fall_back_to_heuristic(self):
+        old = {"source": "https://github.com/acme/app"}
+        new = {"source": "https://github.com/other/thing"}
+        repo, source, mismatch = ida.resolve_compare_repo(old, new, "ghcr.io/acme/app")
+        assert mismatch == ("acme/app", "other/thing")
+        assert repo == "acme/app"
+        assert source == "image-repo-heuristic"
+
+    def test_no_labels_uses_image_heuristic(self):
+        repo, source, mismatch = ida.resolve_compare_repo({}, {}, "ghcr.io/acme/app")
+        assert repo == "acme/app"
+        assert source == "image-repo-heuristic"
+        assert mismatch is None
+
+
+# ── End-to-end main() with mocked network ──────────────────────────
+
+
+class TestMainOutput:
+    DIFF = (
+        "diff --git a/apps/app/helmrelease.yaml b/apps/app/helmrelease.yaml\n"
+        "   repository: ghcr.io/acme/app\n"
+        f"-  tag: v1.0.0@{DIGEST_A}\n"
+        f"+  tag: v1.0.0@{DIGEST_B}\n"
+    )
+
+    def test_markdown_written_with_provenance(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "pr.diff.truncated").write_text(self.DIFF)
+
+        def fake_fetch(repo, digest, deadline=None):
+            rev = "oldrev" if digest == DIGEST_A else "newrev"
+            return {
+                "repository": repo,
+                "digest": digest,
+                "mediaType": None,
+                "configDigest": None,
+                "created": "2026-01-01",
+                "revision": rev,
+                "source": "https://github.com/acme/app",
+                "version": None,
+                "refName": None,
+                "error": None,
+                "indexManifests": None,
+            }
+
+        def fake_compare(repo, old_rev, new_rev, deadline=None):
+            return {
+                "repo": repo,
+                "old_revision": old_rev,
+                "new_revision": new_rev,
+                "status": "ahead",
+                "ahead_by": 2,
+                "behind_by": 0,
+                "total_commits": 2,
+                "html_url": f"https://github.com/{repo}/compare/{old_rev}...{new_rev}",
+                "commits": [{"sha": "abc123", "message": "fix thing"}],
+                "files": [],
+                "error": None,
+                "repo_source": None,
+            }
+
+        with mock.patch.object(ida, "fetch_digest_metadata", fake_fetch), \
+                mock.patch.object(ida, "fetch_github_compare", fake_compare):
+            ida.main()
+
+        out = (tmp_path / "image-digest-context.md").read_text()
+        assert "Image 1: ghcr.io/acme/app" in out
+        assert "Revision changed: **yes**" in out
+        assert "acme/app/compare/oldrev...newrev" in out
+
+    def test_no_changes(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "pr.diff.truncated").write_text("diff --git a/x b/x\n+nothing\n")
+        ida.main()
+        out = (tmp_path / "image-digest-context.md").read_text()
+        assert "No image digest changes detected" in out
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_review_scope.sh
+++ b/tests/test_review_scope.sh
@@ -126,7 +126,11 @@ chmod +x "$TMPDIR/bin/git"
 run_precheck() {
   local output_file="$TMPDIR/out_$RANDOM$RANDOM"
   printf '%s' "$FIXED_DIFF" > /tmp/testfp_diff
+  # The precheck writes pr.diff / pr-object.json into its CWD; run it in a
+  # scratch workdir so test runs do not litter the repository root.
+  rm -rf "$TMPDIR/work" && mkdir -p "$TMPDIR/work"
   (
+    cd "$TMPDIR/work" || exit 1
     export PATH="$TMPDIR/bin:$PATH"
     export PR_HEAD_SHA="$PR_HEAD_SHA"
     export PR_BASE_SHA="$PR_BASE_SHA"
@@ -177,9 +181,6 @@ set_pr_data() {
   if [ -n "$PR_BASE_SHA" ]; then
     echo "$PR_BASE_SHA" >> "$SHA_TRACK_FILE"
   fi
-  cat > pr.json <<JSONEOF
-{"number":42,"title":"Test PR","headRefOid":"${PR_HEAD_SHA}","baseRefName":"main","headRefName":"feature","author":{"login":"test"},"changedFiles":1,"additions":1,"deletions":0,"files":[],"url":"https://github.com/test/repo/pull/42"}
-JSONEOF
 }
 
 # ── Test 1: review_scope=full always does full review ─────────────────

--- a/tests/test_tool_parallel_execution.py
+++ b/tests/test_tool_parallel_execution.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Tests for run_tool_harness.execute_tool_requests — parallel execution must
+preserve request order and per-request error isolation."""
+
+import sys
+import threading
+import time
+from pathlib import Path
+from unittest import mock
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+import pytest
+
+import run_tool_harness as rth
+
+
+def _call(requests, fake_execute):
+    with mock.patch.object(rth, "execute_tool_request", fake_execute):
+        return rth.execute_tool_requests(
+            requests,
+            workspace_root="/tmp",
+            allowed_gh_repos=set(),
+            current_repo="acme/app",
+            allowed_hosts=["github.com"],
+            max_response_bytes=1000,
+            request_timeout=5,
+        )
+
+
+class TestExecuteToolRequests:
+    def test_results_preserve_request_order(self):
+        # The first request is the slowest; results must still come back in
+        # request order, not completion order.
+        def fake_execute(tool_name, args, *rest):
+            if tool_name == "slow":
+                time.sleep(0.3)
+            return {"tool": tool_name, "status": "ok", "result": {}}
+
+        requests = [("slow", {}), ("fast1", {}), ("fast2", {})]
+        results = _call(requests, fake_execute)
+        assert [r["tool"] for r in results] == ["slow", "fast1", "fast2"]
+
+    def test_requests_run_concurrently(self):
+        barrier = threading.Barrier(2, timeout=5)
+
+        def fake_execute(tool_name, args, *rest):
+            # Both requests must be in flight at once to pass the barrier.
+            barrier.wait()
+            return {"tool": tool_name, "status": "ok", "result": {}}
+
+        results = _call([("a", {}), ("b", {})], fake_execute)
+        assert len(results) == 2
+
+    def test_single_request_runs_inline(self):
+        seen_threads = []
+
+        def fake_execute(tool_name, args, *rest):
+            seen_threads.append(threading.current_thread().name)
+            return {"tool": tool_name, "status": "ok", "result": {}}
+
+        results = _call([("only", {})], fake_execute)
+        assert len(results) == 1
+        assert seen_threads == [threading.main_thread().name]
+
+    def test_empty_requests(self):
+        assert _call([], lambda *a: None) == []
+
+    def test_real_executor_errors_stay_per_request(self):
+        # Unknown tool produces an error result without breaking the others.
+        results = rth.execute_tool_requests(
+            [("nonsense_tool", {}), ("git_grep", {"pattern": ""})],
+            workspace_root="/tmp",
+            allowed_gh_repos=set(),
+            current_repo="acme/app",
+            allowed_hosts=[],
+            max_response_bytes=1000,
+            request_timeout=5,
+        )
+        assert results[0]["status"] == "error"
+        assert "Unknown tool" in results[0]["result"]["error"]
+        assert results[1]["status"] == "error"
+        assert "pattern" in results[1]["result"]["error"]
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Speed/efficiency pass over the review pipeline. No behavioral change to review content; the same data is collected with far fewer round-trips and more concurrency.

### Deduplicated PR fetches (single fetch point)
- `check_review_needed.sh` is now the **single fetch point** for the PR object and full diff. It saves `pr-object.json` + `pr.diff` to the workspace for `run_review.sh` to reuse (with standalone fallback for the smoke test), and forwards `head_sha` / `base_sha` / `is_fork_pr` as step outputs.
- `run_review.sh` derives `pr.json` from the saved REST object instead of a second `gh pr view`, and reuses the precheck's diff — this also guarantees the reviewed diff is exactly the one that was fingerprinted.
- The `review_verdict` publish step reuses the precheck's `is_fork_pr` output instead of re-fetching; `HEAD_SHA`/base-SHA in publish steps fall back to precheck outputs when the event payload lacks them (manual `pr_number` dispatch).

### Precheck short-circuit
- When `should_review=false`, the precheck now emits outputs and exits before fetching the PR object or resolving review scope (which could cost a compare API call) — that work only feeds steps gated on `should_review=true`.

### Parallelized I/O
- **Enrichment URL loop** (`run_review.sh`): all allowlisted URL bodies are fetched in one `curl --parallel` invocation (wall-clock bounded by the slowest single transfer instead of the sum), then the markdown assembly reads the prefetched bodies in the original order.
- **`image_digest_analysis.py`**: registry tokens are cached per repository (one token call instead of one per digest), digest metadata and revision compares run in parallel waves with dedup, and everything is bounded by a new `image_digest_budget_sec` input (default 60, `0` disables).
- **`run_evidence_providers.py`**: providers run concurrently via `ThreadPoolExecutor` (new `evidence_provider_parallelism` input, default 4; set `1` for serial). Results keep config order.
- **`run_tool_harness.py`**: planned tool requests execute concurrently (they are read-only) with deterministic result ordering in both planning paths.

### Bounded pagination
- `pulls/N/files` uses a single `per_page=100` fetch instead of `--paginate` (which also produced concatenated JSON documents on multi-page PRs); a truncation note is added when the PR has >100 changed files. The byte budget (`MAX_FILES`) capped the list far below that anyway.

### Cleanup reads state from the list query (fixes #162)
- `cleanup_native_reviews` now takes review id+state from the list response (no per-review GET), and matches the configured `comment_marker` **or** the legacy `<!-- ai-pr-reviewer` prefix — so customized markers and v1.1.x-era JSON-only bodies are cleaned up correctly.

## Tests
- `tests/test_check_review_needed.sh`: +2 scenarios (skip path makes no PR-object fetch; review path forwards SHAs/fork flag and saves reusable files, each fetched exactly once).
- `tests/test_cleanup_previous_native_reviews.sh`: new functional stub-`gh` test (custom marker matched, legacy JSON marker matched, human/unmanaged reviews untouched, zero per-review GETs).
- `tests/test_image_digest_analysis.py` (new): token cache, time budget short-circuits, parallel fetch dedup, compare-repo resolution, end-to-end `main()` with mocked network.
- `tests/test_tool_parallel_execution.py` (new): order preservation, concurrency, single-request inline path, per-request error isolation.
- `tests/test_evidence_providers.py`: order preservation, concurrency overlap, `EVIDENCE_PROVIDER_PARALLELISM=1` serializes, blocker aggregation.
- Full suite green: 443 pytest + all bash suites.

Fixes #162
