### PR TITLE
fix: wait_for_ci.sh works on Checks-API-only repos and excludes its own run

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -385,6 +385,8 @@ runs:
         GH_TOKEN: ${{ inputs.github_token }}
         REPO: ${{ inputs.repo || github.repository }}
         PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
+        PR_HEAD_SHA: ${{ github.event.pull_request.head.sha || steps.precheck.outputs.head_sha }}
+        CI_STATUS_CHECK: ${{ inputs.ci_status_check }}
         CI_TIMEOUT_SEC: ${{ inputs.ci_timeout_sec }}
         CI_INTERVAL_SEC: ${{ inputs.ci_interval_sec }}
         CI_SKIP_ON_TIMEOUT: ${{ inputs.ci_skip_on_timeout }}

--- a/scripts/wait_for_ci.sh
+++ b/scripts/wait_for_ci.sh
@@ -2,17 +2,30 @@
 set -euo pipefail
 
 # ── wait_for_ci.sh ──────────────────────────────────────────────────────
-# Polls GitHub's commit-status API until all checks are final (success/failure),
-# a skip signal is detected, or the timeout expires.
+# Polls GitHub's Checks API (primary signal) and the legacy commit-status
+# API (supplementary) until every external check is final, a failure is
+# detected, or the timeout expires.
+#
+# Two pitfalls this is built around:
+#   1. Repos that only use GitHub Actions never produce legacy commit
+#      statuses, so the combined-status state stays "pending" forever. The
+#      combined state therefore only counts when total_count > 0.
+#   2. The job running this action is itself a check run and would always be
+#      "in_progress". Every job belonging to the current workflow run is
+#      excluded via GITHUB_RUN_ID (check run detail/html URLs carry
+#      /runs/<run_id>/).
 #
 # Exit codes:
-#   0 – All checks reached a terminal state (success or failure).
+#   0 – All external checks reached a terminal state (success/failure/none).
 #   1 – Timeout reached and ci_skip_on_timeout=true (review may proceed anyway).
-#   2 – Fatal error (no token, repo/PR unresolvable, API unrecoverable).
+#   2 – Fatal error (no token, repo/PR unresolvable) or timeout with
+#       ci_skip_on_timeout=false.
 
 GH_TOKEN="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
 REPO="${REPO:-${GITHUB_REPOSITORY:-}}"
 PR_NUMBER="${PR_NUMBER:-}"
+PR_HEAD_SHA="${PR_HEAD_SHA:-}"
+GITHUB_RUN_ID="${GITHUB_RUN_ID:-}"
 CI_STATUS_CHECK="${CI_STATUS_CHECK:-false}"
 CI_TIMEOUT_SEC="${CI_TIMEOUT_SEC:-300}"
 CI_INTERVAL_SEC="${CI_INTERVAL_SEC:-15}"
@@ -46,15 +59,27 @@ get_head_sha() {
   gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.head.sha' 2>/dev/null
 }
 
+finalize() {
+  local state="$1"
+  echo "ci_status_final=$state" >> "$OUTPUT_FILE"
+  echo "ci_status_skipped=false" >> "$OUTPUT_FILE"
+  exit 0
+}
+
 # ── Main loop ───────────────────────────────────────────────────────────
 
-sha="$(get_head_sha)"
+# The precheck step already fetched the PR object; reuse its head SHA when
+# forwarded instead of re-fetching.
+sha="$PR_HEAD_SHA"
+if [[ -z "$sha" ]]; then
+  sha="$(get_head_sha)"
+fi
 if [[ -z "$sha" ]]; then
   error "Could not resolve head SHA for #$PR_NUMBER"
   exit 2
 fi
 
-log "Polling commit-status for $sha (timeout=${CI_TIMEOUT_SEC}s, interval=${CI_INTERVAL_SEC}s)..."
+log "Polling CI checks for $sha (timeout=${CI_TIMEOUT_SEC}s, interval=${CI_INTERVAL_SEC}s, own run=${GITHUB_RUN_ID:-none})..."
 
 elapsed=0
 while true; do
@@ -71,54 +96,68 @@ while true; do
     fi
   fi
 
-  response="$(gh api "repos/$REPO/commits/$sha/status" 2>/dev/null || true)"
+  check_runs_response="$(gh api "repos/$REPO/commits/$sha/check-runs?per_page=100" 2>/dev/null || echo "")"
+  combined_response="$(gh api "repos/$REPO/commits/$sha/status" 2>/dev/null || echo "")"
 
-  if [[ -z "$response" ]]; then
+  if [[ -z "$check_runs_response" && -z "$combined_response" ]]; then
     log "API returned empty; retrying in ${CI_INTERVAL_SEC}s..."
     sleep "$CI_INTERVAL_SEC"
     elapsed=$((elapsed + CI_INTERVAL_SEC))
     continue
   fi
+  [[ -n "$check_runs_response" ]] || check_runs_response='{}'
+  [[ -n "$combined_response" ]] || combined_response='{}'
 
-  # Determine overall state: pending | success | failure | error | neutral
-  overall="$(printf '%s' "$response" | jq -r '.state // "unknown"' 2>/dev/null || echo "unknown")"
+  # Summarize external check runs, excluding every job of our own workflow
+  # run. Conclusions that mean "CI did not pass or did not run" (failure,
+  # timed_out, cancelled, action_required) all count as failed.
+  summary="$(printf '%s' "$check_runs_response" | jq -c --arg run "$GITHUB_RUN_ID" '
+    ([.check_runs[]?
+      | select(
+          $run == ""
+          or ((((.details_url // "") | test("/runs/" + $run + "(/|$)"))
+               or ((.html_url // "") | test("/runs/" + $run + "(/|$)"))) | not)
+        )]) as $ext
+    | {
+        total: ($ext | length),
+        pending: ([$ext[] | select(.status != "completed")] | length),
+        failed: ([$ext[] | select(.status == "completed"
+                  and ((.conclusion // "") as $c
+                       | ($c == "failure" or $c == "timed_out"
+                          or $c == "cancelled" or $c == "action_required")))] | length)
+      }' 2>/dev/null || echo '{"total":0,"pending":0,"failed":0}')"
+  total_checks="$(printf '%s' "$summary" | jq -r '.total' 2>/dev/null || echo 0)"
+  pending_checks="$(printf '%s' "$summary" | jq -r '.pending' 2>/dev/null || echo 0)"
+  failed_checks="$(printf '%s' "$summary" | jq -r '.failed' 2>/dev/null || echo 0)"
 
-  # Check for any non-completed checks in the check-runs API as well (the combined
-  # status API sometimes lags behind). GitHub Checks API statuses are:
-  # queued, in_progress, completed, requested, waiting, stale.
-  # We count all runs where status != "completed" (i.e., still running or queued).
-  pending_checks=0
-  check_runs_response=""
-  if [[ "$overall" != "failure" && "$overall" != "success" ]]; then
-    # Fetch check-runs once and reuse for both pending and failed counts
-    check_runs_response="$(gh api "repos/$REPO/commits/$sha/check-runs?per_page=100" 2>/dev/null || echo "{}")"
-    pending_checks="$(printf '%s' "$check_runs_response" | jq '[.check_runs[] | select(.status != "completed")] | length' 2>/dev/null || echo 0)"
+  combined_state="$(printf '%s' "$combined_response" | jq -r '.state // "pending"' 2>/dev/null || echo "pending")"
+  combined_total="$(printf '%s' "$combined_response" | jq -r '.total_count // 0' 2>/dev/null || echo 0)"
+
+  # Failure is terminal as soon as either signal reports it.
+  if [[ "$failed_checks" -gt 0 ]]; then
+    log "Detected $failed_checks failed check run(s) — treating as failure"
+    finalize "failure"
+  fi
+  if [[ "$combined_total" -gt 0 && ( "$combined_state" == "failure" || "$combined_state" == "error" ) ]]; then
+    log "Combined commit status reports $combined_state"
+    finalize "failure"
   fi
 
-  if [[ "$overall" == "success" || "$overall" == "failure" ]]; then
-    # Terminal state reached (even a single failure counts as terminal).
-    log "CI checks finalized: $overall"
-    echo "ci_status_final=$overall" >> "$OUTPUT_FILE"
-    echo "ci_status_skipped=false" >> "$OUTPUT_FILE"
-    exit 0
-  fi
-
-  # Detect failed check runs even when the combined status API hasn't caught up yet.
-  # This handles repos that rely primarily on GitHub Checks (not legacy statuses).
-  if [[ -n "$check_runs_response" ]]; then
-    failed_checks="$(printf '%s' "$check_runs_response" | jq '[.check_runs[] | select(.status == "completed" and .conclusion == "failure")] | length' 2>/dev/null || echo 0)"
-    if [[ "$failed_checks" -gt 0 ]]; then
-      log "Detected $failed_checks failed check run(s) before combined status updated — treating as failure"
-      echo "ci_status_final=failure" >> "$OUTPUT_FILE"
-      echo "ci_status_skipped=false" >> "$OUTPUT_FILE"
-      exit 0
+  if [[ "$pending_checks" -eq 0 ]] && \
+     { [[ "$combined_total" -eq 0 ]] || [[ "$combined_state" == "success" ]]; }; then
+    if [[ "$total_checks" -gt 0 || "$combined_total" -gt 0 ]]; then
+      log "CI checks finalized: success (${total_checks} external check run(s), ${combined_total} legacy status(es))"
+      finalize "success"
     fi
-  fi
-
-  if [[ "$pending_checks" -gt 0 ]]; then
-    log "Overall=$overall, $pending_checks check(s) not yet completed — waiting ${CI_INTERVAL_SEC}s..."
+    # No external CI exists at all. Give late-registering checks one grace
+    # window, then proceed instead of burning the full timeout.
+    if [[ "$elapsed" -ge $(( CI_INTERVAL_SEC * 2 )) ]]; then
+      log "No external CI checks found after ${elapsed}s — proceeding without CI gating"
+      finalize "none"
+    fi
+    log "No external CI checks registered yet — waiting ${CI_INTERVAL_SEC}s..."
   else
-    log "Overall=$overall — waiting ${CI_INTERVAL_SEC}s..."
+    log "Pending: ${pending_checks}/${total_checks} external check(s), combined=${combined_state} — waiting ${CI_INTERVAL_SEC}s..."
   fi
 
   sleep "$CI_INTERVAL_SEC"

--- a/tests/test_ci_status_check.sh
+++ b/tests/test_ci_status_check.sh
@@ -161,10 +161,113 @@ check_contains "stores check-runs response for reuse" \
 # ── Test 14: Failed check-run detection before combined status update ──
 echo ""
 echo "=== Test: failed check-run early detection ==="
-check_contains "detects failed check runs before combined status catches up" \
-  "$wait_content" '.conclusion == "failure"'
+check_contains "treats failure conclusions as failed" \
+  "$wait_content" '"failure"'
+check_contains "treats timed_out conclusions as failed" \
+  "$wait_content" '"timed_out"'
 check_contains "logs when failed check runs detected early" \
   "$wait_content" 'failed check run'
+
+# ── Test 15: own-run exclusion and step env wiring ──
+echo ""
+echo "=== Test: own workflow run excluded; step env wiring ==="
+check_contains "script excludes the action's own run via GITHUB_RUN_ID" \
+  "$wait_content" 'GITHUB_RUN_ID'
+check_contains "action.yml passes CI_STATUS_CHECK to the step (script guard)" \
+  "$ci_step_section" "CI_STATUS_CHECK:"
+check_contains "action.yml forwards PR_HEAD_SHA to avoid a re-fetch" \
+  "$ci_step_section" "PR_HEAD_SHA:"
+
+# ── Functional tests with a stubbed gh ──────────────────────────────────
+echo ""
+echo "=== Functional: wait_for_ci.sh against stubbed APIs ==="
+
+CI_TMP="$(mktemp -d)"
+trap 'rm -rf "$CI_TMP"' EXIT
+mkdir -p "$CI_TMP/bin"
+
+cat > "$CI_TMP/bin/gh" <<SHELLEOF
+#!/usr/bin/env bash
+case "\$*" in
+  *check-runs*) cat "$CI_TMP/check-runs.json" ;;
+  *commits*status*) cat "$CI_TMP/combined.json" ;;
+  *pulls*) echo "deadbeef" ;;
+esac
+exit 0
+SHELLEOF
+chmod +x "$CI_TMP/bin/gh"
+
+run_wait() {
+  local output_file="$CI_TMP/out_$RANDOM$RANDOM"
+  local rc=0
+  (
+    PATH="$CI_TMP/bin:$PATH" \
+    GH_TOKEN=test REPO="test/repo" PR_NUMBER=7 \
+    PR_HEAD_SHA="deadbeef" \
+    GITHUB_RUN_ID="999" \
+    CI_STATUS_CHECK=true \
+    CI_TIMEOUT_SEC="${CI_TIMEOUT_SEC_OVERRIDE:-6}" \
+    CI_INTERVAL_SEC=1 \
+    CI_SKIP_ON_TIMEOUT="${CI_SKIP_ON_TIMEOUT_OVERRIDE:-true}" \
+    GITHUB_OUTPUT="$output_file" \
+    bash "$WAIT_SCRIPT" >/dev/null 2>&1
+  ) || rc=$?
+  echo "rc=$rc"
+  cat "$output_file" 2>/dev/null || true
+}
+
+own_run='{"id": 1, "name": "ai-review", "status": "in_progress", "conclusion": null, "details_url": "https://github.com/test/repo/actions/runs/999/job/1", "html_url": "https://github.com/test/repo/actions/runs/999/job/1"}'
+ext_success='{"id": 2, "name": "build", "status": "completed", "conclusion": "success", "details_url": "https://github.com/test/repo/actions/runs/555/job/2", "html_url": "https://github.com/test/repo/actions/runs/555/job/2"}'
+ext_failure='{"id": 3, "name": "test", "status": "completed", "conclusion": "failure", "details_url": "https://github.com/test/repo/actions/runs/556/job/3", "html_url": "https://github.com/test/repo/actions/runs/556/job/3"}'
+ext_pending='{"id": 4, "name": "lint", "status": "in_progress", "conclusion": null, "details_url": "https://github.com/test/repo/actions/runs/557/job/4", "html_url": "https://github.com/test/repo/actions/runs/557/job/4"}'
+
+echo ""
+echo "--- Checks-only repo: external success despite pending combined status ---"
+echo "{\"check_runs\": [$own_run, $ext_success], \"total_count\": 2}" > "$CI_TMP/check-runs.json"
+echo '{"state": "pending", "total_count": 0}' > "$CI_TMP/combined.json"
+RESULT="$(run_wait)"
+check "exit 0 on checks-only success" "$(echo "$RESULT" | grep '^rc=')" "rc=0"
+check_contains "final state is success" "$RESULT" "ci_status_final=success"
+
+echo ""
+echo "--- Own run is the only check: concludes none instead of hanging ---"
+echo "{\"check_runs\": [$own_run], \"total_count\": 1}" > "$CI_TMP/check-runs.json"
+echo '{"state": "pending", "total_count": 0}' > "$CI_TMP/combined.json"
+RESULT="$(run_wait)"
+check "exit 0 when only own run exists" "$(echo "$RESULT" | grep '^rc=')" "rc=0"
+check_contains "final state is none" "$RESULT" "ci_status_final=none"
+
+echo ""
+echo "--- External check failure is terminal ---"
+echo "{\"check_runs\": [$own_run, $ext_failure], \"total_count\": 2}" > "$CI_TMP/check-runs.json"
+echo '{"state": "pending", "total_count": 0}' > "$CI_TMP/combined.json"
+RESULT="$(run_wait)"
+check "exit 0 on failure detection" "$(echo "$RESULT" | grep '^rc=')" "rc=0"
+check_contains "final state is failure" "$RESULT" "ci_status_final=failure"
+
+echo ""
+echo "--- Pending external check leads to timeout + skip ---"
+echo "{\"check_runs\": [$own_run, $ext_pending], \"total_count\": 2}" > "$CI_TMP/check-runs.json"
+echo '{"state": "pending", "total_count": 0}' > "$CI_TMP/combined.json"
+RESULT="$(CI_TIMEOUT_SEC_OVERRIDE=3 run_wait)"
+check "exit 1 on timeout with skip=true" "$(echo "$RESULT" | grep '^rc=')" "rc=1"
+check_contains "skipped output written" "$RESULT" "ci_status_skipped=true"
+
+echo ""
+echo "--- Legacy statuses: combined failure is terminal ---"
+echo '{"check_runs": [], "total_count": 0}' > "$CI_TMP/check-runs.json"
+echo '{"state": "failure", "total_count": 2}' > "$CI_TMP/combined.json"
+RESULT="$(run_wait)"
+check "exit 0 on combined failure" "$(echo "$RESULT" | grep '^rc=')" "rc=0"
+check_contains "final state is failure (combined)" "$RESULT" "ci_status_final=failure"
+
+echo ""
+echo "--- Legacy statuses: combined success is terminal ---"
+echo '{"check_runs": [], "total_count": 0}' > "$CI_TMP/check-runs.json"
+echo '{"state": "success", "total_count": 2}' > "$CI_TMP/combined.json"
+RESULT="$(run_wait)"
+check "exit 0 on combined success" "$(echo "$RESULT" | grep '^rc=')" "rc=0"
+check_contains "final state is success (combined)" "$RESULT" "ci_status_final=success"
 
 echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="


### PR DESCRIPTION
## Problem

`ci_status_check=true` could never produce a useful result:

1. **The step never passed `CI_STATUS_CHECK` to the script.** The step-level `if:` gate ran the script, but the script's own guard (`CI_STATUS_CHECK != "true"` → exit 0) saw the unset default — so the wait was a silent no-op in the composite action.
2. **Checks-API-only repos never reach a terminal combined status.** With zero legacy commit statuses, `commits/<sha>/status` reports `"pending"` forever, and the old success condition (`overall == success`) could never fire — every run burned the full timeout.
3. **The action counted its own run as pending.** The job running this action is itself an in-progress check run, so `pending_checks` was always ≥ 1.

## Fix

- The **Checks API is now the primary signal**; the combined status only counts when `total_count > 0`.
- Every job of the current workflow run is **excluded via `GITHUB_RUN_ID`** (check-run `details_url`/`html_url` carry `/runs/<run_id>/`).
- `CI_STATUS_CHECK` is passed into the step env so the script guard works as designed.
- Failure detection now covers `timed_out` / `cancelled` / `action_required` conclusions and the combined `error` state (previously only `failure`).
- A repo with **no external CI at all** concludes `ci_status_final=none` after one grace window (2× poll interval) instead of hanging until timeout.
- The head SHA forwarded by the event payload (or the precheck step, once #175 lands) is reused instead of re-fetching the PR object. Falls back to the API when absent, so the script still works standalone.

Exit-code contract unchanged: `0` terminal, `1` timeout+skip, `2` fatal/timeout+no-skip.

## Tests

`tests/test_ci_status_check.sh` gains functional stub-`gh` scenarios: checks-only success despite pending combined status, own-run-only concluding `none`, external check failure, pending check → timeout+skip, and legacy combined success/failure. Static assertions updated for the new conclusion handling and env wiring. Full suite green (417 pytest + bash suites).

Addresses findings 1–2 of the audit issue #110.
