### PR TITLE
perf: trim low-value bytes from the review corpus and planner context

### DIFF
--- a/scripts/image_digest_analysis.py
+++ b/scripts/image_digest_analysis.py
@@ -523,14 +523,13 @@ def main():
                         f"  - `{short(changed_file.get('filename'))}` status={short(changed_file.get('status'))} changes={short(changed_file.get('changes'))}"
                     )
 
-            lines.append("- Old digest metadata:")
-            lines.append("```json")
-            lines.append(json.dumps(old_meta, indent=2))
-            lines.append("```")
-            lines.append("- New digest metadata:")
-            lines.append("```json")
-            lines.append(json.dumps(new_meta, indent=2))
-            lines.append("```")
+            # The bullets above already carry every field the reviewer needs;
+            # the full metadata JSON dumps doubled this section's size for no
+            # added signal. Keep only fetch errors, which the bullets omit.
+            if old_meta.get("error"):
+                lines.append(f"- Old digest metadata error: `{short(old_meta['error'])}`")
+            if new_meta.get("error"):
+                lines.append(f"- New digest metadata error: `{short(new_meta['error'])}`")
             lines.append("")
 
     out_path.write_text("\n".join(lines) + "\n", encoding="utf-8")

--- a/scripts/run_evidence_providers.py
+++ b/scripts/run_evidence_providers.py
@@ -214,6 +214,22 @@ def run_provider(
     return entry
 
 
+def head_tail_cap(text: str, max_bytes: int) -> str:
+    """Cap text at max_bytes keeping the head and the tail.
+
+    Command failures usually print the interesting part (the error) at the
+    end of the output, which a plain head-cap discarded.
+    """
+    raw = text.encode("utf-8", errors="replace")
+    if len(raw) <= max_bytes:
+        return text
+    head_bytes = max_bytes * 6 // 10
+    tail_bytes = max_bytes - head_bytes
+    head = raw[:head_bytes].decode("utf-8", errors="ignore")
+    tail = raw[len(raw) - tail_bytes :].decode("utf-8", errors="ignore")
+    return head + "\n…[middle truncated]…\n" + tail
+
+
 def write_outputs(summary: dict, markdown: str) -> None:
     Path("evidence-providers.json").write_text(
         json.dumps(summary, indent=2, ensure_ascii=False) + "\n",
@@ -292,6 +308,28 @@ def main() -> int:
             summary["has_blocker"] = True
         summary["providers"].append(entry)
 
+    # Markdown embeds are head+tail capped, per stream and in aggregate, so
+    # one chatty provider cannot crowd everything else out of the corpus.
+    # evidence-providers.json keeps the full (per-provider capped) output.
+    md_stdout_cap = env_int("EVIDENCE_MARKDOWN_STDOUT_BYTES", 4000)
+    md_stderr_cap = env_int("EVIDENCE_MARKDOWN_STDERR_BYTES", 2000)
+    md_budget = env_int("EVIDENCE_MARKDOWN_AGGREGATE_BYTES", 24000)
+
+    def emit_stream(label: str, text: str, per_cap: int) -> None:
+        nonlocal md_budget
+        if md_budget < 256:
+            md_lines.append(
+                f"- {label}: (omitted — aggregate evidence output cap reached; "
+                "full output in evidence-providers.json)"
+            )
+            return
+        block = head_tail_cap(text, min(per_cap, md_budget))
+        md_budget -= len(block.encode("utf-8", errors="replace"))
+        md_lines.append(f"- {label}:")
+        md_lines.append("```text")
+        md_lines.append(block)
+        md_lines.append("```")
+
     if not summary["providers"]:
         md_lines.append("No providers were configured in the config file.")
     else:
@@ -313,17 +351,11 @@ def main() -> int:
 
             stdout_text = provider.get("stdout", "").strip()
             if stdout_text and not findings:
-                md_lines.append("- stdout:")
-                md_lines.append("```text")
-                md_lines.append(stdout_text)
-                md_lines.append("```")
+                emit_stream("stdout", stdout_text, md_stdout_cap)
 
             stderr_text = provider.get("stderr", "").strip()
             if stderr_text:
-                md_lines.append("- stderr:")
-                md_lines.append("```text")
-                md_lines.append(stderr_text)
-                md_lines.append("```")
+                emit_stream("stderr", stderr_text, md_stderr_cap)
 
             md_lines.append("")
 

--- a/scripts/run_review.sh
+++ b/scripts/run_review.sh
@@ -500,6 +500,14 @@ url_host_allowed() {
   return 1
 }
 
+# Reduce a fetched linked-source body to corpus-worthy text: HTML pages are
+# stripped to visible text, non-HTML passes through, output capped on a clean
+# boundary. Raw HTML heads were mostly <head> boilerplate that burned corpus
+# budget without giving the model anything to read.
+strip_source_to_text() {
+  python3 "$SCRIPT_DIR/strip_source_text.py" "$1" "$2" "$3"
+}
+
 section_timer_start "enrichment"
 log "Gathering linked sources..."
 : > linked-sources.md
@@ -523,7 +531,10 @@ if [ -s urls.txt ]; then
     [ "$i" -gt 25 ] && break
     normalized_url="$(printf '%s' "$url" | sed -E 's#^https?://redirect.github.com/#https://github.com/#')"
     rm -f "source.$i.raw"
-    if url_host_allowed "$normalized_url"; then
+    host=$(printf '%s' "$normalized_url" | sed -E 's#^https?://([^/]+).*#\1#' | tr '[:upper:]' '[:lower:]')
+    # github.com bodies are JS-app shells; phase 2's gh api branches capture
+    # the structured data instead, so don't spend a fetch on them at all.
+    if [ "$host" != "github.com" ] && url_host_allowed "$normalized_url"; then
       {
         echo "url = $normalized_url"
         echo "output = source.$i.raw"
@@ -558,8 +569,14 @@ if [ -s urls.txt ]; then
     host=$(printf '%s' "$normalized_url" | sed -E 's#^https?://([^/]+).*#\1#' | tr '[:upper:]' '[:lower:]')
 
     if url_host_allowed "$normalized_url"; then
-      if [ -s "source.$i.raw" ]; then
-        head -c 5000 "source.$i.raw" | tr $'\0' ' ' > source.tmp
+      if [ "$host" = "github.com" ]; then
+        # Raw github.com pages are JS-app HTML shells with none of the actual
+        # content; the gh api branches below capture the release/compare data
+        # in structured form instead. Skipping the fetch saves both time and
+        # ~5KB of corpus boilerplate per URL.
+        echo "(Raw HTML fetch skipped for github.com — structured release/compare metadata is captured below when available)" >> linked-sources.md
+      elif [ -s "source.$i.raw" ]; then
+        strip_source_to_text "source.$i.raw" source.tmp 4000
         if [ -s source.tmp ]; then
           echo '```text' >> linked-sources.md
           cat source.tmp >> linked-sources.md

--- a/scripts/run_tool_harness.py
+++ b/scripts/run_tool_harness.py
@@ -466,6 +466,63 @@ def run_command(command, workspace_root, request_timeout=30):
         }
 
 
+def build_planning_context(max_bytes, corpus_path=None):
+    """Build a compact, high-signal context for tool planning.
+
+    Head-truncating the full review corpus filled the planner's budget with
+    standards/manifest boilerplate and often cut the diff off entirely. The
+    planner needs: what kind of PR this is, which files changed, the version
+    hints, the standards requirements (its contract says they are mandatory),
+    and the head of the diff. Falls back to the corpus head when the piece
+    files are unavailable (e.g. standalone invocation).
+
+    Returns (text, truncated).
+    """
+    pieces = [
+        ("PR Classification", "classification.json", 4000, "json"),
+        ("Changed Files", "pr-files.truncated.json", 6000, "json"),
+        ("Version Hints from Diff", "version-hints.truncated.txt", 2500, "text"),
+        ("Repository Standards and Conventions", "standards-context.capped.md", 6000, None),
+    ]
+
+    sections = []
+    any_clipped = False
+
+    def add_section(title, path, cap, fence):
+        nonlocal any_clipped
+        p = Path(path)
+        if not p.exists():
+            return
+        body = p.read_text(encoding="utf-8", errors="replace").strip()
+        if not body:
+            return
+        raw = body.encode("utf-8")
+        if len(raw) > cap:
+            body = raw[:cap].decode("utf-8", errors="ignore") + "\n[truncated]"
+            any_clipped = True
+        if fence:
+            sections.append(f"# {title}\n```{fence}\n{body}\n```")
+        else:
+            sections.append(f"# {title}\n{body}")
+
+    for title, path, cap, fence in pieces:
+        add_section(title, path, cap, fence)
+
+    if sections:
+        # Whatever budget remains goes to the head of the diff.
+        used = sum(len(s.encode("utf-8")) for s in sections)
+        diff_cap = max(2000, max_bytes - used - 200)
+        add_section("PR Diff (head)", "pr.diff.truncated", diff_cap, "diff")
+        text, clipped = truncate_text("\n\n".join(sections), max_bytes)
+        return text, clipped or any_clipped
+
+    if corpus_path is not None and Path(corpus_path).exists():
+        corpus_text = Path(corpus_path).read_text(encoding="utf-8", errors="replace")
+        return truncate_text(corpus_text, max_bytes)
+
+    return "", False
+
+
 def normalize_tool_request(raw_req):
     """Return (tool_name, args) tolerating common planner output mistakes.
 
@@ -761,9 +818,11 @@ def main():
             write_outputs(result, "Tool harness could not run: missing REPO, AI_BASE_URL, or AI_MODEL.")
             return 0
 
-        # Read and prepare corpus
-        corpus_text = corpus_path.read_text(encoding="utf-8", errors="replace")
-        corpus_text, corpus_truncated = truncate_text(corpus_text, planning_max_context)
+        # Build the planning context from the high-signal pieces (falls back
+        # to the corpus head when they are unavailable).
+        corpus_text, corpus_truncated = build_planning_context(
+            planning_max_context, corpus_path
+        )
 
         current_repo_norm = normalize_repo_name(repo)
         allowed_gh_api_repos = set()

--- a/scripts/strip_source_text.py
+++ b/scripts/strip_source_text.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Reduce a fetched linked-source body to corpus-worthy text.
+
+HTML pages are stripped to visible text (script/style/head dropped, tags
+removed, entities unescaped, whitespace collapsed); non-HTML content passes
+through unchanged. Output is capped at MAX bytes on a clean UTF-8 boundary.
+
+Usage: strip_source_text.py SRC DST MAX_BYTES
+"""
+
+import html
+import re
+import sys
+
+
+def looks_like_html(text: str) -> bool:
+    head = text[:512].lstrip().lower()
+    return (
+        head.startswith("<!doctype")
+        or head.startswith("<html")
+        or head.startswith("<")
+        or "<body" in head
+    )
+
+
+def strip_html(text: str) -> str:
+    text = re.sub(r"(?is)<(script|style|noscript|svg|head)\b.*?</\1>", " ", text)
+    text = re.sub(r"(?s)<[^>]+>", " ", text)
+    text = html.unescape(text)
+    text = re.sub(r"[ \t]+", " ", text)
+    text = re.sub(r"\n\s*\n+", "\n", text)
+    return text.strip()
+
+
+def reduce_source(data: bytes, max_bytes: int) -> str:
+    text = data.replace(b"\x00", b" ").decode("utf-8", errors="ignore")
+    if looks_like_html(text):
+        text = strip_html(text)
+    clipped = text.encode("utf-8")[:max_bytes].decode("utf-8", errors="ignore")
+    if len(clipped) < len(text):
+        clipped += "\n…[source truncated]"
+    return clipped
+
+
+def main(argv) -> int:
+    src, dst, max_b = argv[1], argv[2], int(argv[3])
+    try:
+        data = open(src, "rb").read()
+    except OSError:
+        data = b""
+    open(dst, "w", encoding="utf-8").write(reduce_source(data, max_b))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/tests/test_context_budget.sh
+++ b/tests/test_context_budget.sh
@@ -78,5 +78,17 @@ check "output is valid UTF-8" \
   "$(python3 -c 'open("'"$TMP"'/utfdst",encoding="utf-8").read(); print("ok")')" "ok"
 
 echo ""
+echo "=== Test: enrichment context trims are wired into run_review.sh ==="
+RUN_REVIEW="$(cat "$ROOT_DIR/scripts/run_review.sh")"
+check "github.com raw HTML fetch is skipped" \
+  "$(grep -c 'Raw HTML fetch skipped for github.com' "$ROOT_DIR/scripts/run_review.sh")" "1"
+check "non-github sources go through strip_source_to_text" \
+  "$(grep -c 'strip_source_to_text "source.$i.raw"' "$ROOT_DIR/scripts/run_review.sh")" "1"
+check "github.com is excluded from the parallel prefetch" \
+  "$(grep -c '"\$host" != "github.com"' "$ROOT_DIR/scripts/run_review.sh")" "1"
+check "strip helper delegates to strip_source_text.py" \
+  "$(grep -c 'strip_source_text.py' "$ROOT_DIR/scripts/run_review.sh")" "1"
+
+echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="
 [ "$FAIL" -eq 0 ]

--- a/tests/test_evidence_providers.py
+++ b/tests/test_evidence_providers.py
@@ -642,5 +642,91 @@ class TestParallelExecution:
         assert data["has_blocker"] is True
 
 
+# ── Markdown output caps (head+tail per stream, aggregate across providers) ──
+
+from run_evidence_providers import head_tail_cap  # noqa: E402
+
+
+class TestHeadTailCap:
+    def test_under_cap_unchanged(self):
+        assert head_tail_cap("short", 100) == "short"
+
+    def test_over_cap_keeps_head_and_tail(self):
+        text = "HEAD-" + ("x" * 5000) + "-TAIL"
+        out = head_tail_cap(text, 400)
+        assert out.startswith("HEAD-")
+        assert out.endswith("-TAIL")
+        assert "…[middle truncated]…" in out
+        assert len(out.encode("utf-8")) < 500
+
+    def test_multibyte_boundaries_survive(self):
+        text = "é" * 4000
+        out = head_tail_cap(text, 300)
+        out.encode("utf-8").decode("utf-8")  # must be valid UTF-8
+
+
+def _run_caps(config_data, tmp_path: Path, env_overrides: dict):
+    config_file = tmp_path / "providers.json"
+    config_file.write_text(json.dumps(config_data, indent=2), encoding="utf-8")
+    env = os.environ.copy()
+    env["EVIDENCE_PROVIDERS_FILE"] = str(config_file)
+    env.update(env_overrides)
+    return subprocess.run(
+        [sys.executable, str(EVIDENCE_SCRIPT)],
+        cwd=str(tmp_path),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+class TestMarkdownCaps:
+    def test_stdout_is_head_tail_capped_in_markdown(self, tmp_path: Path):
+        config = {
+            "providers": [
+                {"id": "chatty", "command": "python3 -c \"print('START'); print('x' * 9000); print('THE-ERROR-AT-END')\""}
+            ]
+        }
+        result = _run_caps(config, tmp_path, {"EVIDENCE_MARKDOWN_STDOUT_BYTES": "1000"})
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        md = (tmp_path / "evidence-providers.md").read_text()
+        assert "START" in md
+        assert "THE-ERROR-AT-END" in md          # tail survives
+        assert "…[middle truncated]…" in md
+        # JSON summary keeps the full (per-provider capped) stdout.
+        data = _load_json_output(tmp_path)
+        assert len(data["providers"][0]["stdout"]) > 9000
+
+    def test_aggregate_cap_stops_further_embeds(self, tmp_path: Path):
+        providers = [
+            {"id": f"p{i}", "command": "python3 -c \"print('y' * 3000)\""}
+            for i in range(4)
+        ]
+        result = _run_caps(
+            {"providers": providers},
+            tmp_path,
+            {
+                "EVIDENCE_MARKDOWN_STDOUT_BYTES": "3000",
+                "EVIDENCE_MARKDOWN_AGGREGATE_BYTES": "5000",
+            },
+        )
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        md = (tmp_path / "evidence-providers.md").read_text()
+        assert "aggregate evidence output cap reached" in md
+        # Every provider still has its header even when its output is omitted.
+        for i in range(4):
+            assert f"## p{i}" in md
+
+    def test_small_outputs_unaffected(self, tmp_path: Path):
+        config = {"providers": [{"id": "tiny", "command": "echo hello"}]}
+        result = _run_caps(config, tmp_path, {})
+        assert result.returncode == 0
+        md = (tmp_path / "evidence-providers.md").read_text()
+        assert "hello" in md
+        assert "truncated" not in md
+        assert "cap reached" not in md
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/test_strip_source_text.py
+++ b/tests/test_strip_source_text.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Tests for scripts/strip_source_text.py — HTML reduction and capping for
+linked-source enrichment."""
+
+import sys
+from pathlib import Path
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+import pytest
+
+from strip_source_text import looks_like_html, reduce_source, main
+
+
+HTML_PAGE = b"""<!DOCTYPE html>
+<html><head><title>Release v1.2.3</title>
+<style>body { color: red; }</style>
+<script>var tracking = "noise";</script>
+</head>
+<body>
+<h1>Release v1.2.3</h1>
+<p>Fixed a &amp; bug in the &lt;parser&gt;.</p>
+<script>more("noise");</script>
+</body></html>
+"""
+
+
+class TestReduceSource:
+    def test_html_tags_and_scripts_removed(self):
+        out = reduce_source(HTML_PAGE, 100000)
+        assert "Release v1.2.3" in out
+        assert "Fixed a & bug in the <parser>." in out
+        assert "tracking" not in out
+        assert "color: red" not in out
+        assert "<p>" not in out
+
+    def test_non_html_passes_through(self):
+        text = b"## Changelog\n\n- fixed thing\n- added thing\n"
+        out = reduce_source(text, 100000)
+        assert out == text.decode()
+
+    def test_cap_appends_marker(self):
+        text = b"plain text " * 1000
+        out = reduce_source(text, 100)
+        assert out.endswith("…[source truncated]")
+        assert len(out.encode("utf-8")) < 200
+
+    def test_cap_does_not_split_multibyte(self):
+        text = ("héllo wörld ☃ " * 100).encode("utf-8")
+        out = reduce_source(text, 101)
+        out.encode("utf-8").decode("utf-8")  # must be valid UTF-8
+
+    def test_nul_bytes_replaced(self):
+        out = reduce_source(b"abc\x00def", 100)
+        assert "\x00" not in out
+        assert "abc" in out and "def" in out
+
+
+class TestLooksLikeHtml:
+    def test_doctype(self):
+        assert looks_like_html("<!DOCTYPE html><html>")
+
+    def test_leading_whitespace(self):
+        assert looks_like_html("\n  <html lang='en'>")
+
+    def test_markdown_is_not_html(self):
+        assert not looks_like_html("# Title\n\nSome *markdown* here")
+
+    def test_json_is_not_html(self):
+        assert not looks_like_html('{"key": "value"}')
+
+
+class TestMain:
+    def test_writes_reduced_output(self, tmp_path):
+        src = tmp_path / "src.html"
+        dst = tmp_path / "dst.txt"
+        src.write_bytes(HTML_PAGE)
+        assert main(["prog", str(src), str(dst), "100000"]) == 0
+        out = dst.read_text()
+        assert "Release v1.2.3" in out
+        assert "tracking" not in out
+
+    def test_missing_source_writes_empty(self, tmp_path):
+        dst = tmp_path / "dst.txt"
+        assert main(["prog", str(tmp_path / "nope"), str(dst), "100"]) == 0
+        assert dst.read_text() == ""
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_tool_planning_context.py
+++ b/tests/test_tool_planning_context.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Tests for run_tool_harness.build_planning_context — the dedicated planning
+context replacing the head-truncated corpus."""
+
+import sys
+from pathlib import Path
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+import pytest
+
+from run_tool_harness import build_planning_context
+
+
+def _write_pieces(tmp_path, diff_lines=20):
+    (tmp_path / "classification.json").write_text(
+        '{"pr_kind": "dependency-update", "risk_flags": ["auth_changes"], "must_check": []}'
+    )
+    (tmp_path / "pr-files.truncated.json").write_text(
+        '[{"filename": "charts/app/values.yaml", "status": "modified"}]'
+    )
+    (tmp_path / "version-hints.truncated.txt").write_text(
+        "+  tag: v1.2.3\n-  tag: v1.2.2\n"
+    )
+    (tmp_path / "standards-context.capped.md").write_text(
+        "# Repository Standards and Conventions\nAlways verify upstream release notes.\n"
+    )
+    diff = "\n".join(f"+line {i}" for i in range(diff_lines))
+    (tmp_path / "pr.diff.truncated").write_text(f"diff --git a/x b/x\n{diff}\n")
+
+
+class TestBuildPlanningContext:
+    def test_pieces_assembled_in_priority_order(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _write_pieces(tmp_path)
+        text, truncated = build_planning_context(50000)
+        assert truncated is False
+        order = [
+            text.index("# PR Classification"),
+            text.index("# Changed Files"),
+            text.index("# Version Hints from Diff"),
+            text.index("# Repository Standards and Conventions"),
+            text.index("# PR Diff (head)"),
+        ]
+        assert order == sorted(order)
+        assert "dependency-update" in text
+        assert "values.yaml" in text
+        assert "v1.2.3" in text
+        assert "upstream release notes" in text
+        assert "diff --git" in text
+
+    def test_diff_gets_remaining_budget(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _write_pieces(tmp_path, diff_lines=10000)
+        text, truncated = build_planning_context(20000)
+        assert truncated is True
+        assert len(text.encode("utf-8")) <= 20100
+        # High-signal pieces survive; the diff is what gets clipped.
+        assert "# PR Classification" in text
+        assert "# PR Diff (head)" in text
+
+    def test_standards_included_for_planner_contract(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _write_pieces(tmp_path)
+        text, _ = build_planning_context(50000)
+        # The planning prompt instructs the model to honor this section.
+        assert "# Repository Standards and Conventions" in text
+
+    def test_falls_back_to_corpus_head_without_pieces(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        corpus = tmp_path / "review-corpus.truncated.md"
+        corpus.write_text("# Corpus head\nsome corpus content\n")
+        text, truncated = build_planning_context(50000, corpus)
+        assert "Corpus head" in text
+        assert truncated is False
+
+    def test_empty_when_nothing_available(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        text, truncated = build_planning_context(50000, tmp_path / "missing.md")
+        assert text == ""
+        assert truncated is False
+
+    def test_oversized_piece_is_clipped_and_flagged(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _write_pieces(tmp_path)
+        (tmp_path / "classification.json").write_text(
+            '{"pr_kind": "' + "x" * 10000 + '"}'
+        )
+        text, truncated = build_planning_context(50000)
+        assert truncated is True
+        assert "[truncated]" in text
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Context-efficiency pass (audit theme C2): every byte sent to the model should carry signal, which matters most for local models with 8–32k windows.

### Linked-source enrichment (`run_review.sh`)
- **github.com raw-HTML fetches are skipped** — the page is a JS-app shell with none of the content, and the `gh api` release/compare branches already capture the same information in structured form. Saves a network round-trip and ~5KB of boilerplate per URL.
- **Other hosts' bodies are reduced to visible text** via a new [strip_source_text.py](scripts/strip_source_text.py): script/style/head blocks dropped, tags stripped, entities unescaped, whitespace collapsed, capped at 4000 bytes on a clean UTF-8 boundary. Non-HTML (markdown/JSON changelogs) passes through unchanged.

### Image digest provenance (`image_digest_analysis.py`)
- The full `old_meta`/`new_meta` JSON dumps are dropped — the bullets directly above them already carry every field (digests, revisions, created, source, compare summary). A compact error bullet is kept when a metadata fetch failed, since that was the only signal unique to the dumps.

### Evidence providers (`run_evidence_providers.py`)
- Markdown embeds of stdout/stderr are now **head+tail capped** (per-stream 4000/2000 bytes, env-overridable via `EVIDENCE_MARKDOWN_{STDOUT,STDERR,AGGREGATE}_BYTES`) with a **24KB aggregate cap** across all providers. Head+tail matters because command failures print the error at the end, which the old head-only cap discarded. `evidence-providers.json` keeps the full per-provider-capped output for debugging.

### Tool planning context (`run_tool_harness.py`)
- Planning previously head-truncated the full corpus to `tool_planning_max_context_bytes` — and the corpus head is standards + manifests + PR metadata, so the planner frequently never saw the diff. It now gets a **dedicated context**: classification, changed files, version hints, the capped standards section (the planner contract treats standards as mandatory for upstream-verification planning), and the head of the diff with all remaining budget. Falls back to the corpus head for standalone invocations.

## Tests
- `tests/test_strip_source_text.py` (new): HTML reduction, passthrough, caps, multibyte safety, NUL handling.
- `tests/test_tool_planning_context.py` (new): piece priority order, diff-gets-remaining-budget, standards inclusion, corpus fallback, oversize clipping.
- `tests/test_evidence_providers.py`: head+tail cap unit tests; integration tests proving the tail (error) survives, the aggregate cap kicks in, and small outputs are untouched.
- `tests/test_context_budget.sh`: wiring assertions for the enrichment trims.
- Full suite green: 440 pytest + all bash suites.
