### PR TITLE
sec: pass model API keys via 0600 curl --config files instead of argv

### DIFF
--- a/scripts/model_call.sh
+++ b/scripts/model_call.sh
@@ -16,22 +16,26 @@
 # Unlike `curl -f`, the response body is preserved on HTTP errors so a local
 # endpoint's "context length exceeded" / "model not found" message is visible
 # instead of silently discarded and retried.
+# Escape a value for use inside a double-quoted curl-config string.
+curl_config_escape() {
+  printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g'
+}
+
 curl_model() {
   local base_url="$1" api_key="$2" api_format="$3" payload_file="$4" output_file="$5"
   local stream="${6:-false}" request_timeout_sec="${7:-300}" connect_timeout_sec="${8:-30}"
 
   local endpoint
-  local auth_header=()
+  local auth_header=""
   if [[ "$api_format" == "anthropic" ]]; then
     endpoint="$base_url/messages"
-    auth_header=( -H "anthropic-version: ${ANTHROPIC_VERSION:-2023-06-01}" )
     if [[ -n "$api_key" ]]; then
-      auth_header+=( -H "x-api-key: $api_key" )
+      auth_header="x-api-key: $api_key"
     fi
   else
     endpoint="$base_url/chat/completions"
     if [[ -n "$api_key" ]]; then
-      auth_header=( -H "Authorization: Bearer $api_key" )
+      auth_header="Authorization: Bearer $api_key"
     fi
   fi
 
@@ -48,7 +52,19 @@ curl_model() {
     -w '%{http_code}'
   )
 
-  args+=( "${auth_header[@]}" )
+  if [[ "$api_format" == "anthropic" ]]; then
+    args+=( -H "anthropic-version: ${ANTHROPIC_VERSION:-2023-06-01}" )
+  fi
+
+  # The API key goes through a 0600 curl --config file rather than argv, so
+  # it never appears in /proc/<pid>/cmdline or `ps` output on shared runners.
+  local auth_config=""
+  if [[ -n "$auth_header" ]]; then
+    auth_config="$(mktemp)"
+    chmod 600 "$auth_config"
+    printf 'header = "%s"\n' "$(curl_config_escape "$auth_header")" > "$auth_config"
+    args+=( --config "$auth_config" )
+  fi
 
   if [[ "$stream" == "true" ]]; then
     args+=( --no-buffer )
@@ -59,6 +75,10 @@ curl_model() {
 
   local http_code curl_rc=0
   http_code="$(curl "${args[@]}")" || curl_rc=$?
+
+  if [[ -n "$auth_config" ]]; then
+    rm -f "$auth_config"
+  fi
 
   if [[ "$curl_rc" -ne 0 ]]; then
     echo "  curl transport error (exit ${curl_rc}) calling model endpoint" >&2

--- a/scripts/run_tool_harness.py
+++ b/scripts/run_tool_harness.py
@@ -216,10 +216,21 @@ def run_chat_completion(
     ]
     if api_format == "anthropic":
         curl_args.extend(["-H", f"anthropic-version: {os.getenv('ANTHROPIC_VERSION', '2023-06-01')}"])
-        if api_key:
-            curl_args.extend(["-H", f"x-api-key: {api_key}"])
-    elif api_key:
-        curl_args.extend(["-H", f"Authorization: Bearer {api_key}"])
+
+    # The API key goes through a 0600 curl --config file rather than argv, so
+    # it never appears in /proc/<pid>/cmdline or `ps` output on shared runners.
+    auth_config_path = None
+    if api_key:
+        if api_format == "anthropic":
+            auth_header = f"x-api-key: {api_key}"
+        else:
+            auth_header = f"Authorization: Bearer {api_key}"
+        escaped = auth_header.replace("\\", "\\\\").replace('"', '\\"')
+        fd, auth_config_path = tempfile.mkstemp()
+        with os.fdopen(fd, "w", encoding="utf-8") as auth_file:
+            auth_file.write(f'header = "{escaped}"\n')
+        os.chmod(auth_config_path, 0o600)
+        curl_args.extend(["--config", auth_config_path])
 
     with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as payload_file:
         json.dump(payload, payload_file)
@@ -228,10 +239,13 @@ def run_chat_completion(
     try:
         completed = safe_run(curl_args + ["--data", f"@{payload_path}"], timeout_sec + 5)
     finally:
-        try:
-            os.unlink(payload_path)
-        except OSError:
-            pass
+        for cleanup_path in (payload_path, auth_config_path):
+            if cleanup_path is None:
+                continue
+            try:
+                os.unlink(cleanup_path)
+            except OSError:
+                pass
 
     if isinstance(completed, dict) and completed.get("timeout"):
         raise RuntimeError("planner model request timed out")

--- a/tests/test_api_key_argv.py
+++ b/tests/test_api_key_argv.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Tests that run_tool_harness.run_chat_completion keeps the API key out of
+curl argv, passing it via a 0600 --config file that is removed afterwards."""
+
+import json
+import os
+import stat
+import sys
+import types
+from pathlib import Path
+from unittest import mock
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+import pytest
+
+import run_tool_harness as rth
+
+
+OPENAI_RESPONSE = json.dumps({"choices": [{"message": {"content": "planned"}}]})
+
+
+class _Capture:
+    def __init__(self):
+        self.argv = None
+        self.config_path = None
+        self.config_content = None
+        self.config_mode = None
+
+    def fake_safe_run(self, args, timeout_sec):
+        self.argv = list(args)
+        if "--config" in args:
+            self.config_path = args[args.index("--config") + 1]
+            self.config_content = Path(self.config_path).read_text()
+            self.config_mode = stat.S_IMODE(os.stat(self.config_path).st_mode)
+        return types.SimpleNamespace(returncode=0, stdout=OPENAI_RESPONSE, stderr="")
+
+
+def _call(api_format="openai", api_key="sk-secret-789"):
+    cap = _Capture()
+    with mock.patch.object(rth, "safe_run", cap.fake_safe_run):
+        result = rth.run_chat_completion(
+            base_url="http://localhost:11434/v1",
+            api_format=api_format,
+            model="m",
+            api_key=api_key,
+            system_prompt="sys",
+            user_prompt="user",
+            timeout_sec=5,
+            max_tokens=100,
+        )
+    return cap, result
+
+
+class TestApiKeyOutOfArgv:
+    def test_key_not_in_argv(self):
+        cap, result = _call()
+        assert result == "planned"
+        assert not any("sk-secret-789" in arg for arg in cap.argv)
+
+    def test_config_file_carries_bearer_header(self):
+        cap, _ = _call()
+        assert cap.config_path is not None
+        assert 'header = "Authorization: Bearer sk-secret-789"' in cap.config_content
+
+    def test_anthropic_uses_x_api_key_header(self):
+        cap, _ = _call(api_format="anthropic")
+        assert 'header = "x-api-key: sk-secret-789"' in cap.config_content
+        # The non-secret version header stays in argv.
+        assert any("anthropic-version" in arg for arg in cap.argv)
+        assert not any("sk-secret-789" in arg for arg in cap.argv)
+
+    def test_config_file_is_0600(self):
+        cap, _ = _call()
+        assert cap.config_mode == 0o600
+
+    def test_config_file_removed_after_call(self):
+        cap, _ = _call()
+        assert not Path(cap.config_path).exists()
+
+    def test_no_config_without_key(self):
+        cap, _ = _call(api_key="")
+        assert "--config" not in cap.argv
+
+    def test_quotes_in_key_are_escaped(self):
+        cap, _ = _call(api_key='odd"key')
+        assert 'odd\\"key' in cap.config_content
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_model_call.sh
+++ b/tests/test_model_call.sh
@@ -45,7 +45,10 @@ done
 if [ -n "$cfg" ] && [ -n "${MOCK_CONFIG_COPY:-}" ]; then
   cp "$cfg" "$MOCK_CONFIG_COPY"
   printf '%s' "$cfg" > "${MOCK_CONFIG_COPY}.path"
-  { stat -f %Lp "$cfg" 2>/dev/null || stat -c %a "$cfg" 2>/dev/null; } > "${MOCK_CONFIG_COPY}.perms"
+  # GNU stat first: BSD's -f flag is valid-but-different on GNU (filesystem
+  # status), so probing -f first captured garbage on Linux. -c fails cleanly
+  # on BSD/macOS, making it the safe first probe.
+  { stat -c %a "$cfg" 2>/dev/null || stat -f %Lp "$cfg" 2>/dev/null; } > "${MOCK_CONFIG_COPY}.perms"
 fi
 case "${MOCK_CURL_MODE:-ok}" in
   ok)

--- a/tests/test_model_call.sh
+++ b/tests/test_model_call.sh
@@ -31,12 +31,22 @@ mkdir -p "$TMPDIR/bin"
 # prints an HTTP status to stdout (as -w '%{http_code}' would), or fails.
 cat > "$TMPDIR/bin/curl" <<'MOCK'
 #!/usr/bin/env bash
+if [ -n "${MOCK_ARGV_LOG:-}" ]; then
+  printf '%s\n' "$@" > "$MOCK_ARGV_LOG"
+fi
 out=""
+cfg=""
 prev=""
 for a in "$@"; do
   if [ "$prev" = "-o" ]; then out="$a"; fi
+  if [ "$prev" = "--config" ]; then cfg="$a"; fi
   prev="$a"
 done
+if [ -n "$cfg" ] && [ -n "${MOCK_CONFIG_COPY:-}" ]; then
+  cp "$cfg" "$MOCK_CONFIG_COPY"
+  printf '%s' "$cfg" > "${MOCK_CONFIG_COPY}.path"
+  { stat -f %Lp "$cfg" 2>/dev/null || stat -c %a "$cfg" 2>/dev/null; } > "${MOCK_CONFIG_COPY}.perms"
+fi
 case "${MOCK_CURL_MODE:-ok}" in
   ok)
     [ -n "$out" ] && printf '{"choices":[{"message":{"content":"hi"}}]}' > "$out"
@@ -89,6 +99,50 @@ LOG="$(PATH="$TMPDIR/bin:$PATH" MOCK_CURL_MODE=http_error \
   curl_model "http://x/v1" "" "openai" "$PAYLOAD" "$OUT" "false" "5" "2" 2>&1 >/dev/null || true)"
 check "HTTP error is logged to stderr" \
   "$(printf '%s' "$LOG" | grep -q 'HTTP 400' && echo yes || echo no)" "yes"
+
+echo ""
+echo "=== Test: API key stays out of curl argv (0600 --config file) ==="
+OUT="$TMPDIR/auth.json"
+ARGV_LOG="$TMPDIR/argv.log"
+CONFIG_COPY="$TMPDIR/config.copy"
+rm -f "$ARGV_LOG" "$CONFIG_COPY" "$CONFIG_COPY.path" "$CONFIG_COPY.perms"
+(
+  PATH="$TMPDIR/bin:$PATH" MOCK_CURL_MODE=ok \
+  MOCK_ARGV_LOG="$ARGV_LOG" MOCK_CONFIG_COPY="$CONFIG_COPY" \
+    curl_model "http://x/v1" "sk-supersecret123" "openai" "$PAYLOAD" "$OUT" "false" "5" "2" >/dev/null 2>&1
+)
+check "api key absent from curl argv" \
+  "$(grep -c 'sk-supersecret123' "$ARGV_LOG" || true)" "0"
+check "--config flag passed" "$(grep -cx -- '--config' "$ARGV_LOG")" "1"
+check "config file carries the bearer header" \
+  "$(grep -c 'header = "Authorization: Bearer sk-supersecret123"' "$CONFIG_COPY")" "1"
+check "config file is 0600" "$(cat "$CONFIG_COPY.perms")" "600"
+check "config file removed after the call" \
+  "$(test -e "$(cat "$CONFIG_COPY.path")" && echo present || echo gone)" "gone"
+
+echo ""
+echo "=== Test: anthropic API key via config; version header stays in argv ==="
+rm -f "$ARGV_LOG" "$CONFIG_COPY" "$CONFIG_COPY.path" "$CONFIG_COPY.perms"
+(
+  PATH="$TMPDIR/bin:$PATH" MOCK_CURL_MODE=ok \
+  MOCK_ARGV_LOG="$ARGV_LOG" MOCK_CONFIG_COPY="$CONFIG_COPY" \
+    curl_model "http://x/v1" "sk-ant-secret456" "anthropic" "$PAYLOAD" "$OUT" "false" "5" "2" >/dev/null 2>&1
+)
+check "anthropic key absent from curl argv" \
+  "$(grep -c 'sk-ant-secret456' "$ARGV_LOG" || true)" "0"
+check "config file carries the x-api-key header" \
+  "$(grep -c 'header = "x-api-key: sk-ant-secret456"' "$CONFIG_COPY")" "1"
+check "anthropic-version stays in argv (not secret)" \
+  "$(grep -c 'anthropic-version' "$ARGV_LOG")" "1"
+
+echo ""
+echo "=== Test: empty API key produces no --config ==="
+rm -f "$ARGV_LOG" "$CONFIG_COPY"
+(
+  PATH="$TMPDIR/bin:$PATH" MOCK_CURL_MODE=ok MOCK_ARGV_LOG="$ARGV_LOG" \
+    curl_model "http://x/v1" "" "openai" "$PAYLOAD" "$OUT" "false" "5" "2" >/dev/null 2>&1
+)
+check "no --config without an api key" "$(grep -cx -- '--config' "$ARGV_LOG" || true)" "0"
 
 echo ""
 echo "=== build_model_request: payload shaping ==="


### PR DESCRIPTION
## Summary

LOW-severity hardening from the audit: API keys were passed to curl as `-H "Authorization: Bearer <key>"` argv entries, which are world-readable via `/proc/<pid>/cmdline` / `ps` for the duration of the request on shared runners.

Both curl call sites now write the auth header to a `0600` temp file and pass it with `curl --config`:

- `scripts/model_call.sh` `curl_model` — primary/fallback review calls. The config file is created only when a key is set (local models typically have none), and removed immediately after the call on both success and error paths. The non-secret `anthropic-version` header stays in argv.
- `scripts/run_tool_harness.py` `run_chat_completion` — tool-planning calls. Same pattern via `tempfile.mkstemp` (0600 by default, chmod'd explicitly) with cleanup in `finally`.

Header values are escaped for curl-config double-quoted strings (backslash, double quote), so unusual key material cannot break out of the `header = "..."` directive.

Note `curl -q` (used everywhere here to skip `.curlrc`) does not disable explicit `--config` files.

## Tests

- `tests/test_model_call.sh`: mock curl now captures argv and the `--config` file; new cases assert the key is absent from argv, the config carries the right header (`Authorization: Bearer` / `x-api-key`), the file is mode 600, it is removed after the call, and no `--config` is passed without a key. (39 checks total.)
- `tests/test_api_key_argv.py` (new): same assertions for `run_chat_completion`, plus quote-escaping.
- Full suite green: 424 pytest + bash suites.
