### PR TITLE
feat: opt-in native line-anchored inline comments from structured findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ The classification is purely rule-based — no model calls are involved. It uses
 | `ai_primary_retries` | Number of retries for the primary model | No | `8` |
 | `on_model_failure` | Behavior when primary **and** fallback models fail: `fail` (fail the step) or `notice` (post a visible `request_changes` notice explaining the review could not run — never auto-approves) | No | `fail` |
 | `verdict_policy` | How the final verdict is decided: `model` (the model's own verdict) or `findings_severity_gated` (derived from structured findings: `request_changes` iff any blocker finding; falls back to the model verdict when no findings). Enforcement settings still apply afterwards | No | `model` |
+| `inline_findings` | Attach diff-anchorable structured findings as native line-anchored review comments in `review_comment`/`review_verdict` modes. Ignored for `comment` mode | No | `false` |
+| `inline_findings_max` | Maximum inline review comments per review when `inline_findings=true` | No | `20` |
 | `ai_primary_retry_delay_sec` | Delay between retries in seconds | No | `15` |
 | `allowed_source_hosts` | Comma-separated allowlist for linked URL fetching | No | `github.com,api.github.com,gitlab.com,registry.terraform.io,artifacthub.io` |
 | `system_prompt` | Optional system prompt override | No | bundled prompt |
@@ -558,6 +560,27 @@ With `verdict_policy: findings_severity_gated`, the verdict is derived determini
     ai_model: qwen3-32b
     ai_response_format: json_schema   # schema includes the findings array
     verdict_policy: findings_severity_gated
+```
+
+### Inline review comments from findings
+
+With `inline_findings: "true"` and a native publish mode, findings that carry a `file` + `line` anchoring to the PR diff are attached as **line-anchored review comments**:
+
+- `publish_mode: review_verdict` — the approve/request_changes review itself carries the inline comments (`comments[]` on the reviews API). If GitHub rejects the payload (e.g. an anchor raced a new push), the action falls back to the plain review, so publishing never fails because of inline findings.
+- `publish_mode: review_comment` — the sticky summary comment is published as usual, plus a separate native `COMMENT` review carrying the inline comments. That review includes the managed marker, so the next run's cleanup marks it superseded.
+- `publish_mode: comment` — ignored.
+
+Anchors are validated against the diff before submission (GitHub only accepts comments on lines present in the diff); findings without a valid anchor stay in the review body. Comment bodies are secret-masked and @-mention-neutralized like all published output, and capped by `inline_findings_max` (default 20).
+
+```yaml
+- uses: misospace/pr-reviewer-action@v1
+  with:
+    github_token: ${{ secrets.GITHUB_TOKEN }}
+    ai_base_url: http://llama-server.internal:8080/v1
+    ai_model: qwen3-32b
+    publish_mode: review_verdict
+    verdict_policy: findings_severity_gated
+    inline_findings: "true"
 ```
 
 ### Token-saving with incremental reviews

--- a/action.yml
+++ b/action.yml
@@ -97,6 +97,18 @@ inputs:
       tool failure) still apply afterwards and can force request_changes.
     required: false
     default: "model"
+  inline_findings:
+    description: >-
+      If true, structured findings that anchor to a line in the PR diff are attached as
+      native line-anchored review comments when publishing with publish_mode=review_comment
+      or review_verdict. Findings that cannot be anchored stay in the review body only.
+      Default false — no inline comments. Ignored for publish_mode=comment.
+    required: false
+    default: "false"
+  inline_findings_max:
+    description: Maximum inline review comments attached per review when inline_findings=true.
+    required: false
+    default: "20"
   ai_stream:
     description: If true, use streaming responses to avoid timeouts behind proxies with short read timeouts (e.g. Cloudflare 100s edge timer)
     required: false
@@ -553,6 +565,9 @@ runs:
         HEAD_SHA: ${{ github.event.pull_request.head.sha || steps.precheck.outputs.head_sha }}
         VERDICT: ${{ steps.review.outputs.verdict }}
         REVIEW_MARKDOWN: ${{ steps.review.outputs.review_markdown }}
+        FINDINGS: ${{ steps.review.outputs.findings }}
+        INLINE_FINDINGS: ${{ inputs.inline_findings }}
+        INLINE_FINDINGS_MAX: ${{ inputs.inline_findings_max }}
         ANALYSIS_ENGINE: ${{ steps.review.outputs.analysis_engine }}
         COMMENT_MARKER: ${{ inputs.comment_marker }}
         BROAD_FINGERPRINT: ${{ steps.precheck.outputs.diff_fingerprint }}
@@ -614,6 +629,31 @@ runs:
         # Use gh pr comment instead for visibility, with --edit-last/--create-if-none for sticky behavior.
         gh pr comment "$PR_NUMBER" --repo "$REPO" --edit-last --create-if-none --body-file "$BODY_FILE"
 
+        # Optionally attach line-anchored inline comments from the structured
+        # findings as a separate native COMMENT review. It carries the managed
+        # marker so the next run's cleanup marks it superseded. Best-effort:
+        # the summary comment above is already published.
+        if [ "$(printf '%s' "${INLINE_FINDINGS:-false}" | tr '[:upper:]' '[:lower:]')" = "true" ] && [ -n "${FINDINGS:-}" ]; then
+          printf '%s' "$FINDINGS" > findings.json
+          COMMENTS_JSON="[]"
+          if INLINE_FINDINGS_MAX="${INLINE_FINDINGS_MAX:-20}" python3 "${GITHUB_ACTION_PATH}/scripts/build_review_comments.py" findings.json pr.diff review-comments.json; then
+            COMMENTS_JSON="$(cat review-comments.json)"
+          fi
+          if [ -n "$COMMENTS_JSON" ] && [ "$COMMENTS_JSON" != "[]" ]; then
+            {
+              echo "$COMMENT_MARKER"
+              echo "_Inline findings from the automated review (summary in the sticky comment)._"
+            } > inline-findings-body.md
+            jq -n --rawfile body inline-findings-body.md --argjson comments "$COMMENTS_JSON" \
+              '{body: $body, event: "COMMENT", comments: $comments}' > review-request.json
+            if gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" --method POST --input review-request.json >/dev/null 2>&1; then
+              echo "Attached $(printf '%s' "$COMMENTS_JSON" | jq 'length') inline finding comment(s)"
+            else
+              echo "WARN: inline findings review submission failed; summary comment was still published" >&2
+            fi
+          fi
+        fi
+
     - name: Publish review verdict (native PR review)
       if: inputs.publish_mode == 'review_verdict' && steps.precheck.outputs.should_review == 'true'
       shell: bash
@@ -624,6 +664,9 @@ runs:
         HEAD_SHA: ${{ github.event.pull_request.head.sha || steps.precheck.outputs.head_sha }}
         VERDICT: ${{ steps.review.outputs.verdict }}
         REVIEW_MARKDOWN: ${{ steps.review.outputs.review_markdown }}
+        FINDINGS: ${{ steps.review.outputs.findings }}
+        INLINE_FINDINGS: ${{ inputs.inline_findings }}
+        INLINE_FINDINGS_MAX: ${{ inputs.inline_findings_max }}
         ANALYSIS_ENGINE: ${{ steps.review.outputs.analysis_engine }}
         ALLOW_APPROVE: ${{ inputs.allow_approve }}
         APPROVE_FORKS: ${{ inputs.approve_forks }}
@@ -713,9 +756,41 @@ runs:
           cat review-verdict-markdown.raw.md
         } > "$BODY_FILE"
 
+        # Build line-anchored inline comments from the structured findings
+        # when enabled. Anchors are validated against pr.diff (written by the
+        # review step); non-anchorable findings stay in the body only.
+        COMMENTS_JSON="[]"
+        if [ "$(printf '%s' "${INLINE_FINDINGS:-false}" | tr '[:upper:]' '[:lower:]')" = "true" ] && [ -n "${FINDINGS:-}" ]; then
+          printf '%s' "$FINDINGS" > findings.json
+          if INLINE_FINDINGS_MAX="${INLINE_FINDINGS_MAX:-20}" python3 "${GITHUB_ACTION_PATH}/scripts/build_review_comments.py" findings.json pr.diff review-comments.json; then
+            COMMENTS_JSON="$(cat review-comments.json)"
+          fi
+        fi
+
+        # Submit the native review, attaching inline comments when present.
+        # If GitHub rejects the comments payload (e.g. an anchor raced a new
+        # push), fall back to the plain review so publishing never breaks
+        # because of inline findings.
+        submit_native_review() {
+          local event="$1" body_file="$2"
+          if [ -n "$COMMENTS_JSON" ] && [ "$COMMENTS_JSON" != "[]" ]; then
+            jq -n --rawfile body "$body_file" --arg event "$event" --argjson comments "$COMMENTS_JSON" \
+              '{body: $body, event: $event, comments: $comments}' > review-request.json
+            if gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" --method POST --input review-request.json >/dev/null 2>&1; then
+              echo "Submitted native review ($event) with $(printf '%s' "$COMMENTS_JSON" | jq 'length') inline comment(s)"
+              return 0
+            fi
+            echo "WARN: inline-comment review submission failed; falling back to plain review" >&2
+          fi
+          case "$event" in
+            APPROVE) gh pr review "$PR_NUMBER" --repo "$REPO" --approve --body-file "$body_file" ;;
+            *) gh pr review "$PR_NUMBER" --repo "$REPO" --request-changes --body-file "$body_file" ;;
+          esac
+        }
+
         if [ "$CAN_APPROVE" = true ]; then
           echo "Submitting native approval for #$PR_NUMBER"
-          if ! gh pr review "$PR_NUMBER" --repo "$REPO" --approve --body-file "$BODY_FILE" 2>&1; then
+          if ! submit_native_review APPROVE "$BODY_FILE" 2>&1; then
             echo "ERROR: Native approval failed for #$PR_NUMBER." >&2
             echo "This may be caused by the 'Allow GitHub Actions to create and approve pull requests' setting being disabled." >&2
             echo "Enable this setting at: Repository Settings → Actions → General → Allow GitHub Actions to create and approve pull requests" >&2
@@ -727,7 +802,7 @@ runs:
           echo "Blocking native approval for #$PR_NUMBER (allow_approve=${ALLOW_APPROVE_BOOL}, approve_forks=${APPROVE_FORKS_BOOL}, is_fork=${IS_FORK_PR})"
 
           if [ "$VERDICT" = "request_changes" ]; then
-            gh pr review "$PR_NUMBER" --repo "$REPO" --request-changes --body-file "$BODY_FILE"
+            submit_native_review REQUEST_CHANGES "$BODY_FILE"
           else
             # Model approved but guardrails blocked it
             {
@@ -735,6 +810,6 @@ runs:
               echo "> **Approval blocked by policy**: This workflow requires \`allow_approve: true\` to submit native approvals. Set that input to enable automatic approval."
             } >> "$BODY_FILE"
 
-            gh pr review "$PR_NUMBER" --repo "$REPO" --request-changes --body-file "$BODY_FILE"
+            submit_native_review REQUEST_CHANGES "$BODY_FILE"
           fi
         fi

--- a/scripts/build_review_comments.py
+++ b/scripts/build_review_comments.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Turn structured findings into native PR review comments[] entries.
+
+Reads a findings JSON array and the PR's unified diff, keeps only findings
+that anchor to a commentable line (a new-side line present in a diff hunk —
+GitHub rejects review comments outside the diff), and emits the comments[]
+payload for POST /repos/{owner}/{repo}/pulls/{n}/reviews.
+
+Usage: build_review_comments.py FINDINGS_JSON_FILE DIFF_FILE OUTPUT_FILE
+
+Environment:
+  INLINE_FINDINGS_MAX  maximum comments to emit (default 20)
+"""
+
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+from redact import mask_secrets  # noqa: E402
+from sanitize_review_markdown import sanitize_markdown  # noqa: E402
+
+
+_HUNK_RE = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@")
+
+_SEVERITY_LABELS = {
+    "blocker": "🛑 Blocker",
+    "major": "⚠️ Major",
+    "minor": "Minor",
+    "info": "Info",
+}
+
+
+def commentable_lines(diff_text: str) -> dict:
+    """Map new-side file path -> set of commentable line numbers.
+
+    Commentable lines are added (+) and context lines inside hunks — the
+    new-side lines GitHub accepts for a review comment with side=RIGHT.
+    """
+    lines_by_path: dict = {}
+    current_path = None
+    new_line = 0
+    in_hunk = False
+
+    for raw in diff_text.splitlines():
+        if raw.startswith("diff --git "):
+            current_path = None
+            in_hunk = False
+            continue
+        if raw.startswith("+++ "):
+            target = raw[4:].strip()
+            if target == "/dev/null":
+                current_path = None
+            else:
+                current_path = target[2:] if target.startswith("b/") else target
+            continue
+        match = _HUNK_RE.match(raw)
+        if match:
+            new_line = int(match.group(1))
+            in_hunk = True
+            continue
+        if not in_hunk or current_path is None:
+            continue
+        if raw.startswith("+"):
+            lines_by_path.setdefault(current_path, set()).add(new_line)
+            new_line += 1
+        elif raw.startswith("-"):
+            continue
+        elif raw.startswith("\\"):
+            # "\ No newline at end of file"
+            continue
+        else:
+            lines_by_path.setdefault(current_path, set()).add(new_line)
+            new_line += 1
+
+    return lines_by_path
+
+
+def _safe_path(path) -> bool:
+    if not isinstance(path, str) or not path:
+        return False
+    if path.startswith("/"):
+        return False
+    return ".." not in path.split("/")
+
+
+def finding_to_body(finding: dict) -> str:
+    severity = finding.get("severity") or "info"
+    label = _SEVERITY_LABELS.get(severity, severity)
+    category = finding.get("category")
+    suffix = f" ({category})" if category and category != "other" else ""
+    message = str(finding.get("message") or "").strip()
+    body = f"**{label}{suffix}:** {message}\n\n_Automated finding from AI PR review._"
+    return sanitize_markdown(mask_secrets(body))
+
+
+def build_comments(findings, diff_text: str, max_comments: int = 20):
+    """Return (comments, skipped_count) for the anchorable findings."""
+    if not isinstance(findings, list):
+        return [], 0
+
+    anchors = commentable_lines(diff_text)
+    comments = []
+    skipped = 0
+
+    for finding in findings:
+        if not isinstance(finding, dict):
+            skipped += 1
+            continue
+        path = finding.get("file")
+        line = finding.get("line")
+        if (
+            not _safe_path(path)
+            or not isinstance(line, int)
+            or line <= 0
+            or path not in anchors
+            or line not in anchors[path]
+        ):
+            skipped += 1
+            continue
+        comments.append(
+            {
+                "path": path,
+                "line": line,
+                "side": "RIGHT",
+                "body": finding_to_body(finding),
+            }
+        )
+        if len(comments) >= max_comments:
+            break
+
+    return comments, skipped
+
+
+def main(argv) -> int:
+    findings_path, diff_path, output_path = argv[1], argv[2], argv[3]
+
+    try:
+        findings = json.loads(Path(findings_path).read_text(encoding="utf-8", errors="replace"))
+    except Exception:
+        findings = []
+    try:
+        diff_text = Path(diff_path).read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        diff_text = ""
+
+    try:
+        max_comments = max(1, int(os.getenv("INLINE_FINDINGS_MAX", "20")))
+    except ValueError:
+        max_comments = 20
+
+    comments, skipped = build_comments(findings, diff_text, max_comments)
+    Path(output_path).write_text(
+        json.dumps(comments, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
+    print(
+        f"inline findings: {len(comments)} anchored comment(s), {skipped} finding(s) not anchorable",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/tests/test_build_review_comments.py
+++ b/tests/test_build_review_comments.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""Tests for scripts/build_review_comments.py — diff anchoring, filtering,
+caps, body sanitization — plus action.yml wiring for inline_findings."""
+
+import json
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SCRIPTS_DIR = _REPO_ROOT / "scripts"
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+import pytest
+
+from build_review_comments import (
+    build_comments,
+    commentable_lines,
+    finding_to_body,
+    main,
+)
+
+
+DIFF = """\
+diff --git a/app/serve.py b/app/serve.py
+index 1111111..2222222 100644
+--- a/app/serve.py
++++ b/app/serve.py
+@@ -10,5 +10,5 @@ def serve():
+ context10
+ context11
++added12
++added13
+ context14
+@@ -30,4 +32,4 @@ def other():
+ context32
+-removed line
++added33
+ context34
+diff --git a/old.txt b/new.txt
+similarity index 90%
+rename from old.txt
+rename to new.txt
+--- a/old.txt
++++ b/new.txt
+@@ -1,2 +1,2 @@
+ keep1
++added2
+diff --git a/gone.py b/gone.py
+deleted file mode 100644
+--- a/gone.py
++++ /dev/null
+@@ -1,2 +0,0 @@
+-bye1
+-bye2
+"""
+
+
+def _finding(file="app/serve.py", line=12, severity="blocker", message="bad", category="security"):
+    return {"severity": severity, "category": category, "file": file, "line": line, "message": message}
+
+
+class TestCommentableLines:
+    def test_added_and_context_lines_anchorable(self):
+        lines = commentable_lines(DIFF)
+        assert lines["app/serve.py"] == {10, 11, 12, 13, 14, 32, 33, 34}
+
+    def test_renamed_file_uses_new_path(self):
+        lines = commentable_lines(DIFF)
+        assert "new.txt" in lines
+        assert "old.txt" not in lines
+        assert lines["new.txt"] == {1, 2}
+
+    def test_deleted_file_not_anchorable(self):
+        assert "gone.py" not in commentable_lines(DIFF)
+
+    def test_empty_diff(self):
+        assert commentable_lines("") == {}
+
+
+class TestBuildComments:
+    def test_anchorable_finding_becomes_comment(self):
+        comments, skipped = build_comments([_finding(line=12)], DIFF)
+        assert skipped == 0
+        assert comments == [{
+            "path": "app/serve.py",
+            "line": 12,
+            "side": "RIGHT",
+            "body": comments[0]["body"],
+        }]
+        assert "bad" in comments[0]["body"]
+        assert "Blocker" in comments[0]["body"]
+        assert "(security)" in comments[0]["body"]
+
+    def test_line_outside_hunks_skipped(self):
+        comments, skipped = build_comments([_finding(line=20)], DIFF)
+        assert comments == [] and skipped == 1
+
+    def test_file_not_in_diff_skipped(self):
+        comments, skipped = build_comments([_finding(file="not/in/diff.py")], DIFF)
+        assert comments == [] and skipped == 1
+
+    def test_missing_file_or_line_skipped(self):
+        findings = [
+            _finding(file=None),
+            _finding(line=None),
+            {"severity": "info", "message": "no anchor at all"},
+        ]
+        comments, skipped = build_comments(findings, DIFF)
+        assert comments == [] and skipped == 3
+
+    def test_traversal_and_absolute_paths_rejected(self):
+        findings = [
+            _finding(file="../app/serve.py"),
+            _finding(file="/etc/passwd", line=1),
+        ]
+        comments, skipped = build_comments(findings, DIFF)
+        assert comments == [] and skipped == 2
+
+    def test_cap_respected(self):
+        findings = [_finding(line=line) for line in (10, 11, 12, 13, 14)]
+        comments, _ = build_comments(findings, DIFF, max_comments=3)
+        assert len(comments) == 3
+
+    def test_non_list_findings(self):
+        assert build_comments("nope", DIFF) == ([], 0)
+
+    def test_non_dict_entries_skipped(self):
+        comments, skipped = build_comments(["x", 5, _finding()], DIFF)
+        assert len(comments) == 1 and skipped == 2
+
+
+class TestFindingBody:
+    def test_mentions_neutralized(self):
+        body = finding_to_body(_finding(message="ping @someuser please"))
+        assert "@someuser" not in body  # zero-width space inserted after @
+
+    def test_secrets_masked(self):
+        body = finding_to_body(
+            _finding(message="leaked token=ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij")
+        )
+        assert "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij" not in body
+
+    def test_other_category_omitted(self):
+        body = finding_to_body(_finding(category="other"))
+        assert "(other)" not in body
+
+
+class TestMainCli:
+    def test_end_to_end(self, tmp_path):
+        findings_file = tmp_path / "findings.json"
+        diff_file = tmp_path / "pr.diff"
+        out_file = tmp_path / "comments.json"
+        findings_file.write_text(json.dumps([_finding(line=12), _finding(line=999)]))
+        diff_file.write_text(DIFF)
+        assert main(["prog", str(findings_file), str(diff_file), str(out_file)]) == 0
+        comments = json.loads(out_file.read_text())
+        assert len(comments) == 1
+        assert comments[0]["line"] == 12
+
+    def test_garbage_inputs_produce_empty_array(self, tmp_path):
+        findings_file = tmp_path / "findings.json"
+        out_file = tmp_path / "comments.json"
+        findings_file.write_text("not json")
+        assert main(["prog", str(findings_file), str(tmp_path / "missing.diff"), str(out_file)]) == 0
+        assert json.loads(out_file.read_text()) == []
+
+
+class TestActionWiring:
+    ACTION = (_REPO_ROOT / "action.yml").read_text()
+
+    def test_inline_findings_input_declared(self):
+        assert "inline_findings:" in self.ACTION
+        assert "inline_findings_max:" in self.ACTION
+
+    def test_native_steps_receive_findings(self):
+        assert self.ACTION.count("FINDINGS: ${{ steps.review.outputs.findings }}") == 2
+        assert self.ACTION.count("INLINE_FINDINGS: ${{ inputs.inline_findings }}") == 2
+
+    def test_review_verdict_falls_back_on_failure(self):
+        assert "falling back to plain review" in self.ACTION
+        assert "submit_native_review APPROVE" in self.ACTION
+        assert "submit_native_review REQUEST_CHANGES" in self.ACTION
+
+    def test_inline_review_carries_managed_marker(self):
+        # The extra COMMENT review in review_comment mode must carry the
+        # marker so cleanup supersedes it on the next run.
+        assert "inline-findings-body.md" in self.ACTION
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Second of the two stacked PRs (base: `feat/structured-findings` / #181 — design confirmed: opt-in, default off). When `inline_findings: "true"` and a native publish mode is used, structured findings that anchor to the PR diff become **native line-anchored review comments**.

### How it works
- New [build_review_comments.py](scripts/build_review_comments.py) parses the unified diff into commentable new-side lines per file (added + context lines inside hunks — exactly what GitHub accepts for `side=RIGHT`), handles renames (new path) and deletions (not anchorable), and filters findings to valid anchors. Traversal (`../`) and absolute paths are rejected outright.
- Comment bodies are severity-labelled (`🛑 Blocker (security): …`), run through the existing secret-masking and @-mention-neutralizing sanitizers, and capped by `inline_findings_max` (default 20).
- **review_verdict**: the approve/request_changes review itself carries `comments[]` via `POST /pulls/N/reviews`. If GitHub rejects the payload (e.g. an anchor raced a new push), the step **falls back to the plain `gh pr review` submission** — publishing never fails because of inline findings. Approval guardrails (`allow_approve`, fork gate, incremental baseline) are untouched.
- **review_comment**: sticky summary comment unchanged; inline comments ride a separate native `COMMENT` review that carries the managed marker, so the existing cleanup supersedes it on the next run.
- **comment** mode ignores the input.

### Defaults
Off by default (`inline_findings: "false"`) — no behavior change for any existing workflow.

## Tests
`tests/test_build_review_comments.py` (21 cases): hunk/rename/deletion anchoring, line-outside-hunk and file-not-in-diff filtering, traversal/absolute rejection, caps, mention neutralization + secret masking in bodies, CLI end-to-end with garbage inputs, and action.yml wiring assertions (both native steps receive findings; fallback path present; marker on the inline review). Full suite green: 457 pytest + bash suites.
