### PR TITLE
fix: close out audit #183 — all 11 findings

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,11 @@ jobs:
         run: ruby -e 'require "yaml"; YAML.load_file("examples/workflow-self-hosted.yml"); YAML.load_file("examples/workflow-cloud.yml")'
 
       - name: Check shell scripts
-        run: bash -n scripts/check_review_needed.sh && bash -n scripts/run_review.sh && bash -n tests/test_model_failure.sh && bash -n tests/test_step_summary.sh && bash -n scripts/model_call.sh && bash -n tests/smoke_test.sh && bash -n tests/test_check_review_needed.sh && bash -n tests/test_approval_guardrails.sh && bash -n tests/test_tool_harness_enforcement.sh && bash -n tests/test_cleanup_previous_native_reviews.sh && bash -n tests/test_model_call.sh && bash -n tests/test_context_budget.sh && bash -n tests/test_classification_steering.sh
+        run: |
+          set -euo pipefail
+          for f in scripts/*.sh tests/*.sh; do
+            bash -n "$f"
+          done
 
       - name: Check Python scripts
         run: python3 -m py_compile scripts/image_digest_analysis.py scripts/run_evidence_providers.py scripts/run_tool_harness.py tests/mock_openai_server.py tests/test_model_parsing.py tests/test_redact.py tests/test_strip_metadata_markers.py tests/test_evidence_providers.py
@@ -44,26 +48,18 @@ jobs:
       - name: Run Python tests (auto-discover all 215)
         run: pytest tests/ -v --tb=short
 
-      - name: Run precheck guardrails tests
-        run: bash tests/test_check_review_needed.sh
-
-      - name: Run approval guardrails tests
-        run: bash tests/test_approval_guardrails.sh
-
-      - name: Run tool harness enforcement tests
-        run: bash tests/test_tool_harness_enforcement.sh
-
-      - name: Run model-failure + step-summary tests
-        run: bash tests/test_model_failure.sh && bash tests/test_step_summary.sh
-
-      - name: Run native review cleanup + marker emission tests
-        run: bash tests/test_cleanup_previous_native_reviews.sh
-
-      - name: Run model-call (curl_model) tests
-        run: bash tests/test_model_call.sh
-
-      - name: Run context-budget tests
-        run: bash tests/test_context_budget.sh
-
-      - name: Run classification steering tests
-        run: bash tests/test_classification_steering.sh
+      # Auto-discover every bash suite so a new (or previously unlisted) suite
+      # cannot silently stay out of CI. The smoke test runs separately above.
+      - name: Run bash test suites (auto-discover)
+        run: |
+          set -euo pipefail
+          failed=0
+          for t in tests/test_*.sh; do
+            echo "::group::$t"
+            if ! bash "$t"; then
+              echo "::error::$t failed"
+              failed=1
+            fi
+            echo "::endgroup::"
+          done
+          exit "$failed"

--- a/README.md
+++ b/README.md
@@ -664,6 +664,14 @@ If the endpoint rejects the request after enabling this (HTTP 400 mentioning `re
 - **Proxies with idle-read timeouts** (e.g. Cloudflare's ~100s edge timer): keep `ai_stream: "true"` (the default) so bytes flow before the timer fires.
 - **Models that reject sampling params**: set `ai_temperature: ""` to omit the field entirely; set `ai_tokens_param: max_completion_tokens` for newer OpenAI reasoning models.
 - **Endpoint not always up** (homelab): configure `ai_fallback_base_url`/`ai_fallback_model` (e.g. a small cloud model) or set `on_model_failure: notice` so the PR gets a visible explanation instead of a bare red check.
+- **Don't burn 10 minutes on a dead endpoint**: the defaults (`ai_primary_retries: "8"`, 15s delay with backoff, 300s request timeout) are tuned for flaky-but-alive endpoints and can spend ~10 minutes before giving up. If your endpoint is either up or down (typical homelab), use a low-retry profile:
+
+```yaml
+ai_primary_retries: "2"
+ai_primary_retry_delay_sec: "5"
+ai_connect_timeout_sec: "10"
+on_model_failure: notice   # visible explanation instead of a long red check
+```
 
 ### Quick symptom table
 

--- a/pr_reviewer/metadata.py
+++ b/pr_reviewer/metadata.py
@@ -4,23 +4,31 @@ import json
 import re
 from typing import Optional
 
-MARKER_PATTERN = re.compile(
-    r'<!--\s*ai-pr-reviewer:\s*(\{.*?\})\s*-->'
-)
+MARKER_PREFIX_PATTERN = re.compile(r'<!--\s*ai-pr-reviewer:\s*(?=\{)')
 
 
 def parse_metadata(body: str) -> Optional[dict]:
-    """Extract the latest ai-pr-reviewer metadata JSON from a comment/review body.
+    """Extract the first ai-pr-reviewer metadata JSON from a comment/review body.
+
+    Uses json.JSONDecoder.raw_decode from the opening brace so nested objects
+    and arrays in future marker schema versions parse correctly (a `\\{.*?\\}`
+    regex stopped at the first `}` and silently truncated nested payloads).
 
     Returns None if no marker is found or parsing fails.
     """
-    match = MARKER_PATTERN.search(body)
+    match = MARKER_PREFIX_PATTERN.search(body)
     if not match:
         return None
+    decoder = json.JSONDecoder()
     try:
-        return json.loads(match.group(1))
-    except (json.JSONDecodeError, IndexError):
+        data, end = decoder.raw_decode(body, match.end())
+    except (json.JSONDecodeError, ValueError):
         return None
+    # The JSON must still be terminated by the comment closer to count as a
+    # well-formed marker.
+    if not body[end:].lstrip().startswith("-->"):
+        return None
+    return data if isinstance(data, dict) else None
 
 
 def build_marker(version: int = 1, head_sha: str = "", base_sha: str = "",

--- a/scripts/model_call.sh
+++ b/scripts/model_call.sh
@@ -170,6 +170,7 @@ build_model_request() {
       '{model:$model,stream:$stream,messages:[{role:"system",content:$system},{role:"user",content:($user + "\n\n" + $corpus)}]}
        + {($tokfield): $max_tokens}
        + (if $temp == null then {} else {temperature:$temp} end)
-       + (if $rf == null then {} else {response_format:$rf} end)' > "$output_file"
+       + (if $rf == null then {} else {response_format:$rf} end)
+       + (if $stream then {stream_options:{include_usage:true}} else {} end)' > "$output_file"
   fi
 }

--- a/scripts/publish_helpers.sh
+++ b/scripts/publish_helpers.sh
@@ -49,6 +49,14 @@ cleanup_native_reviews() {
 
   echo "Cleaning up previous managed native reviews for #$PR_NUMBER"
   CURRENT_ACTOR="$(gh api user --jq .login 2>/dev/null || echo "")"
+  if [ -z "$CURRENT_ACTOR" ]; then
+    # The default GITHUB_TOKEN is an installation token and cannot call /user
+    # (403 Resource not accessible by integration). Reviews created with it
+    # are authored by github-actions[bot], so fall back to that identity
+    # instead of silently skipping cleanup.
+    CURRENT_ACTOR="github-actions[bot]"
+    echo "  Could not resolve current actor from /user; assuming $CURRENT_ACTOR (default GITHUB_TOKEN)"
+  fi
   if [ -n "$CURRENT_ACTOR" ]; then
     # Managed bodies start with the configured marker (or, for reviews created
     # by older action versions, the bare/JSON "<!-- ai-pr-reviewer" prefix).
@@ -85,8 +93,6 @@ cleanup_native_reviews() {
     else
       echo "  No previous managed native reviews found for #$PR_NUMBER"
     fi
-  else
-    echo "  WARN: Could not determine current actor; skipping cleanup" >&2
   fi
 }
 

--- a/scripts/redact.py
+++ b/scripts/redact.py
@@ -27,9 +27,13 @@ _RE_KV_SECRET = re.compile(
 # AWS-style access keys
 _RE_AWS_KEY = re.compile(r"AKIA[0-9A-Z]{16}")
 
-# Kubernetes / kubeconfig snippets (base64-encoded credentials)
+# Kubernetes / kubeconfig credentials. Only credential-bearing keys are
+# matched: the old (server|username|...) form redacted every ordinary
+# `server:` line in YAML evidence output, destroying legitimate review
+# context for zero secrecy gain (server URLs and usernames are not secrets).
 _RE_KUBE_CRED = re.compile(
-    r"(?i)(server|username|password)\s*:\s*\S+", re.IGNORECASE
+    r"(?i)(password|client-certificate-data|client-key-data|"
+    r"certificate-authority-data|bearer[_-]?token)\s*:\s*\S+"
 )
 
 

--- a/scripts/run_evidence_providers.py
+++ b/scripts/run_evidence_providers.py
@@ -96,6 +96,20 @@ def parse_findings(payload: object) -> tuple[str, list[dict[str, str]]]:
     return highest, findings[:40]
 
 
+# Model API keys are stripped from provider subprocess environments: providers
+# talk to the repo, not the model, so they have no legitimate use for them,
+# and this keeps a misbehaving provider command from echoing them into
+# captured output. GH_TOKEN is intentionally kept — providers commonly use gh.
+_SCRUBBED_ENV_KEYS = ("AI_API_KEY", "AI_FALLBACK_API_KEY")
+
+
+def provider_env() -> dict:
+    env = dict(os.environ)
+    for key in _SCRUBBED_ENV_KEYS:
+        env.pop(key, None)
+    return env
+
+
 def run_provider(
     index: int, provider: object, default_timeout: int, default_max_output: int
 ) -> dict:
@@ -150,6 +164,7 @@ def run_provider(
                 stderr=subprocess.PIPE,
                 timeout=timeout,
                 check=False,
+                env=provider_env(),
             )
         else:
             command_text = str(command)
@@ -160,6 +175,7 @@ def run_provider(
                 stderr=subprocess.PIPE,
                 timeout=timeout,
                 check=False,
+                env=provider_env(),
             )
 
         entry["duration_sec"] = round(time.monotonic() - start, 3)

--- a/scripts/run_review.sh
+++ b/scripts/run_review.sh
@@ -174,9 +174,17 @@ fetch_incremental_patch() {
   compare_url="$(gh api "repos/$REPO/compare/${previous_head}...${current_head}" --jq '.url' 2>/dev/null || echo "")"
 
   if [[ -n "$compare_url" ]]; then
-    curl -q -fsSL -H "Authorization: token $GH_TOKEN" \
+    # The token goes through a 0600 curl --config file rather than argv (same
+    # treatment as model API keys in model_call.sh) so it never appears in
+    # /proc/<pid>/cmdline on shared runners.
+    local auth_config
+    auth_config="$(mktemp)"
+    chmod 600 "$auth_config"
+    printf 'header = "%s"\n' "$(curl_config_escape "Authorization: token $GH_TOKEN")" > "$auth_config"
+    curl -q -fsSL --config "$auth_config" \
       -H "Accept: application/vnd.github.v3.diff" \
       "$compare_url" > "$output_file" 2>/dev/null || true
+    rm -f "$auth_config"
   fi
 
   if [[ ! -s "$output_file" ]]; then

--- a/scripts/run_tool_harness.py
+++ b/scripts/run_tool_harness.py
@@ -971,10 +971,13 @@ def main():
             for raw_req in requests_list[:max_requests]
             if isinstance(raw_req, dict)
         ]
+        # Use the same normalized repo set the planner was shown — the raw
+        # env-parsed set treated unnormalized entries ("Owner/Repo/")
+        # differently between prompt and execution.
         tool_results = execute_tool_requests(
             normalized,
             workspace_root,
-            allowed_gh_repos,
+            allowed_gh_api_repos,
             current_repo,
             allowed_hosts,
             max_response_bytes,

--- a/scripts/sanitize_review_markdown.py
+++ b/scripts/sanitize_review_markdown.py
@@ -122,20 +122,17 @@ def sanitize_mention(match: re.Match) -> str:
     return "@\u200b" + match.group(1)
 
 
-def sanitize_markdown(text: str) -> str:
-    """Return *text* with upstream references neutralized.
+# Inline code spans (single line, balanced backticks). GitHub neither
+# auto-links nor notifies inside code, so sanitizing spans only mangles quoted
+# code (`#123` in a YAML example, `@decorator` in Python). Fenced blocks are
+# intentionally NOT excluded: a weak model emitting an unbalanced ``` fence
+# would otherwise disable sanitization for the rest of the body, which is the
+# higher-risk failure.
+_RE_CODE_SEGMENT = re.compile(r"(`[^`\n]+`)")
 
-    Applies sanitization in a specific order:
-    1. URLs first (so we don't partially match parts of URLs)
-    2. Cross-repo references (#123 patterns with owner/repo prefix)
-    3. Bare references (#123 standalone)
 
-    Preserves:
-    - Markdown formatting (headers, lists, code blocks, etc.)
-    - File paths and image digests
-    - Release URLs (not sanitized — they are safe single links)
-    - Local repo references that are part of the review context
-    """
+def _sanitize_prose(text: str) -> str:
+    """Apply all substitutions to a prose (non-code) segment."""
     # 1. Sanitize URLs first (most specific patterns)
     text = _RE_GH_PR_URL.sub(sanitize_pr_url, text)
     text = _RE_GH_ISSUE_URL.sub(sanitize_issue_url, text)
@@ -152,6 +149,27 @@ def sanitize_markdown(text: str) -> str:
     text = _RE_MENTION.sub(sanitize_mention, text)
 
     return text
+
+
+def sanitize_markdown(text: str) -> str:
+    """Return *text* with upstream references neutralized.
+
+    Substitutions skip inline code spans — GitHub does not auto-link or ping
+    there, and rewriting quoted code (e.g. `#123` in a YAML example) corrupts
+    it for no gain. Fenced blocks are still sanitized (see _RE_CODE_SEGMENT).
+
+    Preserves:
+    - Markdown formatting (headers, lists, code blocks, etc.)
+    - File paths and image digests
+    - Release URLs (not sanitized — they are safe single links)
+    - Local repo references that are part of the review context
+    """
+    parts = _RE_CODE_SEGMENT.split(text)
+    # re.split with one capture group alternates prose / code segments.
+    return "".join(
+        part if index % 2 else _sanitize_prose(part)
+        for index, part in enumerate(parts)
+    )
 
 
 def main() -> None:

--- a/tests/test_approval_guardrails.sh
+++ b/tests/test_approval_guardrails.sh
@@ -1,6 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Bash >= 4 required: empty-array expansion under `set -u` and other 4.x
+# behaviors break on macOS stock bash 3.2. Skip (not fail) so local runs
+# explain themselves; CI runs bash 5.
+if [ -z "${BASH_VERSINFO:-}" ] || [ "${BASH_VERSINFO[0]}" -lt 4 ]; then
+  echo "SKIP: bash >= 4 required (found ${BASH_VERSION:-unknown}); on macOS run with PATH=\"/opt/homebrew/bin:\$PATH\"" >&2
+  exit 0
+fi
+
 # Tests for PR #40: guarded approval controls for review_verdict mode
 # These tests validate the shell logic used by the "Publish review verdict" step.
 

--- a/tests/test_check_review_needed.sh
+++ b/tests/test_check_review_needed.sh
@@ -1,6 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Bash >= 4 required: empty-array expansion under `set -u` and other 4.x
+# behaviors break on macOS stock bash 3.2. Skip (not fail) so local runs
+# explain themselves; CI runs bash 5.
+if [ -z "${BASH_VERSINFO:-}" ] || [ "${BASH_VERSINFO[0]}" -lt 4 ]; then
+  echo "SKIP: bash >= 4 required (found ${BASH_VERSION:-unknown}); on macOS run with PATH=\"/opt/homebrew/bin:\$PATH\"" >&2
+  exit 0
+fi
+
 # Dependency preflight
 for dep in python3; do
   if ! command -v "$dep" &>/dev/null; then

--- a/tests/test_ci_status_check.sh
+++ b/tests/test_ci_status_check.sh
@@ -1,6 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Bash >= 4 required: empty-array expansion under `set -u` and other 4.x
+# behaviors break on macOS stock bash 3.2. Skip (not fail) so local runs
+# explain themselves; CI runs bash 5.
+if [ -z "${BASH_VERSINFO:-}" ] || [ "${BASH_VERSINFO[0]}" -lt 4 ]; then
+  echo "SKIP: bash >= 4 required (found ${BASH_VERSION:-unknown}); on macOS run with PATH=\"/opt/homebrew/bin:\$PATH\"" >&2
+  exit 0
+fi
+
 # Tests for wait_for_ci.sh CI status check behavior
 # Validates exit codes, timeout handling, and action.yml integration.
 

--- a/tests/test_classification_steering.sh
+++ b/tests/test_classification_steering.sh
@@ -1,6 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Bash >= 4 required: empty-array expansion under `set -u` and other 4.x
+# behaviors break on macOS stock bash 3.2. Skip (not fail) so local runs
+# explain themselves; CI runs bash 5.
+if [ -z "${BASH_VERSINFO:-}" ] || [ "${BASH_VERSINFO[0]}" -lt 4 ]; then
+  echo "SKIP: bash >= 4 required (found ${BASH_VERSION:-unknown}); on macOS run with PATH=\"/opt/homebrew/bin:\$PATH\"" >&2
+  exit 0
+fi
+
 # Tests for classification→prompt steering: build_user_message() in
 # run_review.sh injects pr_kind / risk_flags / must_check into the user
 # message, and the default system prompt explains how to treat them.

--- a/tests/test_cleanup_previous_native_reviews.sh
+++ b/tests/test_cleanup_previous_native_reviews.sh
@@ -1,6 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Bash >= 4 required: empty-array expansion under `set -u` and other 4.x
+# behaviors break on macOS stock bash 3.2. Skip (not fail) so local runs
+# explain themselves; CI runs bash 5.
+if [ -z "${BASH_VERSINFO:-}" ] || [ "${BASH_VERSINFO[0]}" -lt 4 ]; then
+  echo "SKIP: bash >= 4 required (found ${BASH_VERSION:-unknown}); on macOS run with PATH=\"/opt/homebrew/bin:\$PATH\"" >&2
+  exit 0
+fi
+
 # Tests for issue #106: cleanup of superseded native PR reviews
 # These tests validate the shell logic used by the native review publish steps.
 
@@ -293,6 +301,51 @@ PER_REVIEW_GETS="$(grep -E 'reviews/[0-9]+' "$CALL_LOG" | grep -vc -- '--method'
 check "review state read from list query (no per-review GET)" "$PER_REVIEW_GETS" "0"
 LIST_QUERIES="$(grep -c '/reviews --paginate' "$CALL_LOG" || true)"
 check "exactly one review list query" "$LIST_QUERIES" "1"
+
+echo ""
+echo "=== Functional: default GITHUB_TOKEN (no /user access) falls back to github-actions[bot] ==="
+
+# Reviews authored by github-actions[bot] — the identity used when reviews
+# were created with the default GITHUB_TOKEN, whose /user endpoint 403s.
+cat > "$CLEANUP_TMP/reviews.json" <<'JSONEOF'
+[
+  {"id": 55, "state": "APPROVED", "user": {"login": "github-actions[bot]"},
+   "body": "<!-- ai-pr-reviewer -->\nold bot review"},
+  {"id": 66, "state": "APPROVED", "user": {"login": "someone-else"},
+   "body": "<!-- ai-pr-reviewer -->\nnot ours"}
+]
+JSONEOF
+
+cat > "$CLEANUP_TMP/bin/gh" <<SHELLEOF
+#!/usr/bin/env bash
+echo "\$*" >> "$CALL_LOG"
+if [ "\$1" = "api" ] && [ "\$2" = "user" ]; then
+  echo "Resource not accessible by integration (HTTP 403)" >&2
+  exit 1
+fi
+case "\$*" in
+  *"/reviews --paginate"*) cat "$CLEANUP_TMP/reviews.json" ;;
+  *dismissals*) echo '{"id": 1}' ;;
+  *"--method PATCH"*) echo '{}' ;;
+esac
+exit 0
+SHELLEOF
+chmod +x "$CLEANUP_TMP/bin/gh"
+
+CLEANUP_OUTPUT="$(
+  PATH="$CLEANUP_TMP/bin:$PATH" \
+  GH_TOKEN=test REPO="test/repo" PR_NUMBER=9 COMMENT_MARKER="<!-- ai-pr-reviewer -->" \
+  bash -c 'source "'"$HELPER_SCRIPT"'"; cleanup_native_reviews true' 2>&1
+)"
+
+check_contains "falls back to the github-actions[bot] identity" \
+  "$CLEANUP_OUTPUT" "assuming github-actions[bot]"
+check_contains "github-actions[bot] review is dismissed" \
+  "$CLEANUP_OUTPUT" "Dismissed outdated managed review #55 (APPROVED)"
+check_not_contains "other users' reviews untouched" \
+  "$CLEANUP_OUTPUT" "#66"
+check_not_contains "cleanup is no longer skipped" \
+  "$CLEANUP_OUTPUT" "skipping cleanup"
 
 echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="

--- a/tests/test_context_budget.sh
+++ b/tests/test_context_budget.sh
@@ -1,6 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Bash >= 4 required: empty-array expansion under `set -u` and other 4.x
+# behaviors break on macOS stock bash 3.2. Skip (not fail) so local runs
+# explain themselves; CI runs bash 5.
+if [ -z "${BASH_VERSINFO:-}" ] || [ "${BASH_VERSINFO[0]}" -lt 4 ]; then
+  echo "SKIP: bash >= 4 required (found ${BASH_VERSION:-unknown}); on macOS run with PATH=\"/opt/homebrew/bin:\$PATH\"" >&2
+  exit 0
+fi
+
 # Tests for the context-budget derivation (apply_context_limits) and the
 # UTF-8/newline-safe truncate_clean helper in run_review.sh. These are extracted
 # and exercised in isolation since the main driver has no end-to-end harness.
@@ -86,6 +94,13 @@ check "non-github sources go through strip_source_to_text" \
   "$(grep -c 'strip_source_to_text "source.$i.raw"' "$ROOT_DIR/scripts/run_review.sh")" "1"
 check "github.com is excluded from the parallel prefetch" \
   "$(grep -c '"\$host" != "github.com"' "$ROOT_DIR/scripts/run_review.sh")" "1"
+
+echo ""
+echo "=== Test: no tokens on curl argv in run_review.sh ==="
+check "incremental fetch passes the token via --config, not argv" \
+  "$(grep -c 'Authorization: token \$GH_TOKEN" \\' "$ROOT_DIR/scripts/run_review.sh" || true)" "0"
+check "incremental fetch uses curl_config_escape helper" \
+  "$(grep -c 'curl_config_escape "Authorization: token' "$ROOT_DIR/scripts/run_review.sh")" "1"
 check "strip helper delegates to strip_source_text.py" \
   "$(grep -c 'strip_source_text.py' "$ROOT_DIR/scripts/run_review.sh")" "1"
 

--- a/tests/test_corpus_standards_survival.sh
+++ b/tests/test_corpus_standards_survival.sh
@@ -1,6 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Bash >= 4 required: empty-array expansion under `set -u` and other 4.x
+# behaviors break on macOS stock bash 3.2. Skip (not fail) so local runs
+# explain themselves; CI runs bash 5.
+if [ -z "${BASH_VERSINFO:-}" ] || [ "${BASH_VERSINFO[0]}" -lt 4 ]; then
+  echo "SKIP: bash >= 4 required (found ${BASH_VERSION:-unknown}); on macOS run with PATH=\"/opt/homebrew/bin:\$PATH\"" >&2
+  exit 0
+fi
+
 # Dependency preflight
 for dep in python3; do
   if ! command -v "$dep" &>/dev/null; then

--- a/tests/test_evidence_providers.py
+++ b/tests/test_evidence_providers.py
@@ -627,6 +627,30 @@ class TestParallelExecution:
         # Serial execution: one window fully precedes the other.
         assert a_end <= b_start or b_end <= a_start
 
+    def test_model_api_keys_scrubbed_from_provider_env(self, tmp_path: Path):
+        config = {
+            "providers": [
+                {"id": "env-probe", "command": "echo \"key=[${AI_API_KEY:-}] fb=[${AI_FALLBACK_API_KEY:-}] gh=[${GH_TOKEN:-}]\""}
+            ]
+        }
+        result = _run_caps(
+            config,
+            tmp_path,
+            {
+                "AI_API_KEY": "sk-should-never-leak",
+                "AI_FALLBACK_API_KEY": "sk-fallback-never-leak",
+                "GH_TOKEN": "gh-token-ok",
+            },
+        )
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        data = _load_json_output(tmp_path)
+        stdout = data["providers"][0]["stdout"]
+        # Model keys are scrubbed before the provider runs (not just redacted
+        # after); GH_TOKEN stays available for gh-based providers.
+        assert "key=[]" in stdout
+        assert "fb=[]" in stdout
+        assert "gh-token-ok" not in stdout or "gh=[" in stdout
+
     def test_blocker_flag_still_aggregates(self, tmp_path: Path):
         helper = tmp_path / "blocker.py"
         helper.write_text(HELPER_BLOCKER)

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -79,6 +79,31 @@ def test_build_marker_roundtrip():
     assert parsed == original
 
 
+def test_parse_metadata_nested_object():
+    """Future marker schema versions may nest objects/arrays (e.g. escalation
+    metadata); the parser must not truncate at the first inner brace."""
+    body = (
+        '<!-- ai-pr-reviewer:{"version":2,"head_sha":"abc",'
+        '"routing":{"route":"escalated","fast_model":"m1"},'
+        '"escalation_reason":["incomplete_required_checks"]} -->'
+    )
+    parsed = parse_metadata(body)
+    assert parsed is not None
+    assert parsed["routing"]["route"] == "escalated"
+    assert parsed["escalation_reason"] == ["incomplete_required_checks"]
+
+
+def test_parse_metadata_unterminated_marker_rejected():
+    body = '<!-- ai-pr-reviewer:{"version":1,"head_sha":"abc"} no closer'
+    assert parse_metadata(body) is None
+
+
+def test_parse_metadata_non_object_rejected():
+    body = '<!-- ai-pr-reviewer:{"a":1} --> and <!-- ai-pr-reviewer:[1,2] -->'
+    parsed = parse_metadata(body)
+    assert parsed == {"a": 1}
+
+
 if __name__ == "__main__":
     test_parse_metadata_found()
     test_parse_metadata_with_previous_head()

--- a/tests/test_model_call.sh
+++ b/tests/test_model_call.sh
@@ -1,6 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Bash >= 4 required: empty-array expansion under `set -u` and other 4.x
+# behaviors break on macOS stock bash 3.2. Skip (not fail) so local runs
+# explain themselves; CI runs bash 5.
+if [ -z "${BASH_VERSINFO:-}" ] || [ "${BASH_VERSINFO[0]}" -lt 4 ]; then
+  echo "SKIP: bash >= 4 required (found ${BASH_VERSION:-unknown}); on macOS run with PATH=\"/opt/homebrew/bin:\$PATH\"" >&2
+  exit 0
+fi
+
 # Tests for scripts/model_call.sh curl_model(): HTTP-status handling, body
 # preservation, and exit-code contract, driven by a mock `curl` on PATH.
 
@@ -233,6 +241,19 @@ echo "=== Test: AI_TOKENS_PARAM=max_completion_tokens (newer OpenAI models) ==="
 T_AI_TOKENS_PARAM=max_completion_tokens build_req openai
 check "uses max_completion_tokens" "$(jq 'has("max_completion_tokens")' "$REQ")" "true"
 check "drops plain max_tokens" "$(jq 'has("max_tokens")' "$REQ")" "false"
+
+echo ""
+echo "=== Test: streaming requests ask for usage in the final chunk ==="
+( AI_MAX_TOKENS=4096
+  build_model_request openai m "sys" "usr" "$CORPUS" "$REQ" true )
+check "openai stream: stream_options.include_usage set" \
+  "$(jq -r '.stream_options.include_usage' "$REQ")" "true"
+( AI_MAX_TOKENS=4096
+  build_model_request openai m "sys" "usr" "$CORPUS" "$REQ" false )
+check "openai non-stream: no stream_options" "$(jq 'has("stream_options")' "$REQ")" "false"
+( AI_MAX_TOKENS=4096
+  build_model_request anthropic m "sys" "usr" "$CORPUS" "$REQ" true )
+check "anthropic: no stream_options (openai-only field)" "$(jq 'has("stream_options")' "$REQ")" "false"
 
 echo ""
 echo "=== Test: anthropic always sends max_tokens and never response_format ==="

--- a/tests/test_model_failure.sh
+++ b/tests/test_model_failure.sh
@@ -1,6 +1,14 @@
 #!/usr/bin/env bash
 set -uo pipefail
 
+# Bash >= 4 required: empty-array expansion under `set -u` and other 4.x
+# behaviors break on macOS stock bash 3.2. Skip (not fail) so local runs
+# explain themselves; CI runs bash 5.
+if [ -z "${BASH_VERSINFO:-}" ] || [ "${BASH_VERSINFO[0]}" -lt 4 ]; then
+  echo "SKIP: bash >= 4 required (found ${BASH_VERSION:-unknown}); on macOS run with PATH=\"/opt/homebrew/bin:\$PATH\"" >&2
+  exit 0
+fi
+
 # Tests for handle_model_failure() in run_review.sh: fail mode exits non-zero;
 # notice mode writes a request_changes notice and returns 0 so publishing can
 # post a visible explanation. Extracted and driven in isolation.

--- a/tests/test_redact.py
+++ b/tests/test_redact.py
@@ -98,6 +98,15 @@ class TestMaskSecrets:
         result = mask_secrets(text)
         # password line should be redacted
         assert "[REDACTED]" in result
+        # ...but ordinary server/username YAML lines are not secrets and must
+        # survive so evidence output stays readable.
+        assert "server: https://10.0.0.1" in result
+        assert "username: admin" in result
+
+    def test_kubeconfig_certificate_data_redacted(self):
+        text = "client-key-data: LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQ=="
+        result = mask_secrets(text)
+        assert "LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQ" not in result
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_review_scope.sh
+++ b/tests/test_review_scope.sh
@@ -1,6 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Bash >= 4 required: empty-array expansion under `set -u` and other 4.x
+# behaviors break on macOS stock bash 3.2. Skip (not fail) so local runs
+# explain themselves; CI runs bash 5.
+if [ -z "${BASH_VERSINFO:-}" ] || [ "${BASH_VERSINFO[0]}" -lt 4 ]; then
+  echo "SKIP: bash >= 4 required (found ${BASH_VERSION:-unknown}); on macOS run with PATH=\"/opt/homebrew/bin:\$PATH\"" >&2
+  exit 0
+fi
+
 # Tests for incremental PR review scope feature
 # Validates review_scope input, effective scope resolution, metadata tracking, and verdict safety.
 
@@ -88,9 +96,9 @@ case "\$1" in
     ;;
   "api")
     if echo "\$*" | grep -q 'comments'; then
-      RESULT="$(cat /tmp/testfp_comments.json)"
+      RESULT="\$(cat /tmp/testfp_comments.json)"
     elif echo "\$*" | grep -q 'pulls/42'; then
-      RESULT="$(printf '{"head":{"repo":{"full_name":"test/repo"}},"base":{"repo":{"full_name":"test/repo"},"sha":"%s"}}' "\$PR_BASE_SHA")"
+      RESULT="\$(printf '{"head":{"repo":{"full_name":"test/repo"}},"base":{"repo":{"full_name":"test/repo"},"sha":"%s"}}' "\$PR_BASE_SHA")"
     elif echo "\$*" | grep -q 'compare/'; then
       RESULT='{"status":"ok"}'
     else

--- a/tests/test_sanitize_review_markdown.py
+++ b/tests/test_sanitize_review_markdown.py
@@ -269,3 +269,32 @@ class TestSanitizeMention:
         # An @@ sequence (e.g. literal) must not be turned into a mention.
         result = sanitize_markdown("see user@@host")
         assert "​" not in result
+
+
+class TestInlineCodeSpansPreserved:
+    """Inline code spans are never auto-linked by GitHub, so quoted code must
+    survive sanitization verbatim. Fenced blocks stay sanitized by design
+    (an unbalanced fence must not disable sanitization for the rest)."""
+
+    def test_bare_ref_in_inline_span_preserved(self):
+        result = sanitize_markdown("set the color to `#404` in the config")
+        assert "`#404`" in result
+
+    def test_mention_in_inline_span_preserved(self):
+        result = sanitize_markdown("use the `@property` decorator")
+        assert "`@property`" in result
+
+    def test_cross_repo_ref_in_inline_span_preserved(self):
+        result = sanitize_markdown("pin to `acme/app#12` in the lockfile")
+        assert "`acme/app#12`" in result
+
+    def test_prose_around_span_still_sanitized(self):
+        result = sanitize_markdown("see #99 and `#404` and acme/app#12")
+        assert "PR 99" in result
+        assert "`#404`" in result
+        assert "acme/app PR 12" in result
+
+    def test_unbalanced_backtick_does_not_disable_sanitization(self):
+        result = sanitize_markdown("a stray ` here, then #123 and @user")
+        assert "PR 123" in result
+        assert "@user" not in result

--- a/tests/test_standards_file_resolution.sh
+++ b/tests/test_standards_file_resolution.sh
@@ -1,6 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Bash >= 4 required: empty-array expansion under `set -u` and other 4.x
+# behaviors break on macOS stock bash 3.2. Skip (not fail) so local runs
+# explain themselves; CI runs bash 5.
+if [ -z "${BASH_VERSINFO:-}" ] || [ "${BASH_VERSINFO[0]}" -lt 4 ]; then
+  echo "SKIP: bash >= 4 required (found ${BASH_VERSION:-unknown}); on macOS run with PATH=\"/opt/homebrew/bin:\$PATH\"" >&2
+  exit 0
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 

--- a/tests/test_step_summary.sh
+++ b/tests/test_step_summary.sh
@@ -1,6 +1,14 @@
 #!/usr/bin/env bash
 set -uo pipefail
 
+# Bash >= 4 required: empty-array expansion under `set -u` and other 4.x
+# behaviors break on macOS stock bash 3.2. Skip (not fail) so local runs
+# explain themselves; CI runs bash 5.
+if [ -z "${BASH_VERSINFO:-}" ] || [ "${BASH_VERSINFO[0]}" -lt 4 ]; then
+  echo "SKIP: bash >= 4 required (found ${BASH_VERSION:-unknown}); on macOS run with PATH=\"/opt/homebrew/bin:\$PATH\"" >&2
+  exit 0
+fi
+
 # Tests for write_step_summary() in run_review.sh: emits a markdown table to
 # GITHUB_STEP_SUMMARY with verdict, budget, and truncation flags; no-ops when
 # GITHUB_STEP_SUMMARY is unset.

--- a/tests/test_tool_harness_enforcement.sh
+++ b/tests/test_tool_harness_enforcement.sh
@@ -7,6 +7,14 @@
 
 set -euo pipefail
 
+# Bash >= 4 required: empty-array expansion under `set -u` and other 4.x
+# behaviors break on macOS stock bash 3.2. Skip (not fail) so local runs
+# explain themselves; CI runs bash 5.
+if [ -z "${BASH_VERSINFO:-}" ] || [ "${BASH_VERSINFO[0]}" -lt 4 ]; then
+  echo "SKIP: bash >= 4 required (found ${BASH_VERSION:-unknown}); on macOS run with PATH=\"/opt/homebrew/bin:\$PATH\"" >&2
+  exit 0
+fi
+
 # Dependency preflight
 for dep in jq; do
   if ! command -v "$dep" &>/dev/null; then

--- a/tests/test_verdict_safety.sh
+++ b/tests/test_verdict_safety.sh
@@ -1,6 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Bash >= 4 required: empty-array expansion under `set -u` and other 4.x
+# behaviors break on macOS stock bash 3.2. Skip (not fail) so local runs
+# explain themselves; CI runs bash 5.
+if [ -z "${BASH_VERSINFO:-}" ] || [ "${BASH_VERSINFO[0]}" -lt 4 ]; then
+  echo "SKIP: bash >= 4 required (found ${BASH_VERSION:-unknown}); on macOS run with PATH=\"/opt/homebrew/bin:\$PATH\"" >&2
+  exit 0
+fi
+
 # Tests for PR verdict safety: incremental reviews require clean full baseline for approval
 
 PASS=0


### PR DESCRIPTION
## Summary

Fixes every finding from the 2026-06-10 audit (#183).

### P2
1. **Cleanup works with the default `GITHUB_TOKEN`** — `gh api user` 403s for installation tokens, which made `cleanup_native_reviews` a silent no-op. It now falls back to the `github-actions[bot]` identity (the author of reviews created with that token). Functional stub test covers the 403 path end-to-end.
2. **`GH_TOKEN` off curl argv** — `fetch_incremental_patch` now uses a 0600 `--config` file like the model-key call sites from #179. Wiring asserted in tests.
3. **CI runs every bash suite** — `ci.yaml` replaces the hand-maintained list with `for t in tests/test_*.sh` (and `bash -n` over `scripts/*.sh tests/*.sh`), so the five previously-unlisted suites (review-scope, ci-status, verdict-safety, standards-resolution, corpus-survival) now gate merges, and new suites can't be forgotten.

### P3
4. **Redaction scoped** — the kube pattern matched any `server:`/`username:` line, redacting ordinary YAML out of evidence output. Now only credential-bearing keys (`password`, `client-certificate-data`, `client-key-data`, `certificate-authority-data`, `bearer-token`). Tests assert the password is masked **and** the server/username lines survive.
5. **Sanitizer skips inline code spans** — `` `#404` ``, `` `@property` ``, `` `acme/app#12` `` survive verbatim. Fenced blocks are deliberately **still** sanitized: existing tests document that choice, and the reason is safety — a weak model emitting an unbalanced fence must not disable sanitization for the rest of the body (test added for exactly that).
6. **Streaming token counts** — OpenAI-format streaming requests now set `stream_options.include_usage`, so the #174 step-summary table shows real prompt/completion tokens instead of dashes with the default `ai_stream: true`. Not sent for non-streaming or Anthropic requests.
7. **bash ≥ 4 guard** — every suite now SKIPs with a self-explaining message on macOS stock bash 3.2 instead of failing cryptically. Also fixed the `test_review_scope.sh` mock-`gh` heredoc: unescaped `$(cat …)` baked JSON into the script at creation time, and the `-->` inside the baked marker acted as a shell redirect, creating stray `nAPPROVE}]` litter files. Verified zero litter after the fix.
8. **`parse_metadata` nesting-safe** — switched from `\{.*?\}` (truncates at the first inner `}`) to `raw_decode` from the opening brace with a `-->` terminator check. Future marker payloads (e.g. #160's escalation metadata) can nest objects/arrays. Tests cover nested payloads, unterminated markers, and non-object rejection.
9. **Tool-harness allowlist consistency** — the direct planning path now executes with the same normalized `gh_api` repo set the planner is shown.
10. **README** — low-retry profile (`ai_primary_retries: "2"` etc.) documented for endpoints that are simply down, next to `on_model_failure: notice`.
11. **Evidence provider env scrubbing** — provider subprocesses no longer inherit `AI_API_KEY`/`AI_FALLBACK_API_KEY` (no legitimate use; defense in depth). `GH_TOKEN` is kept since providers commonly call `gh`. Test proves the keys are absent *before* the provider runs, not just redacted after.

## Tests
523 pytest + **all 15 bash suites** green locally (now the same set CI runs).

Closes #183
