### PR TITLE
feat: risk-flag-driven required checks + review completeness validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,33 @@ Before invoking the AI model, the action runs a deterministic classification ste
 
 The classification is purely rule-based — no model calls are involved. It uses pattern matching on file paths, diff content, and linked issue metadata to determine the PR type and associated risk flags.
 
+**Default required checks per risk class** (`must_check` is the union of the checks for the `pr_kind` and every detected risk flag — a PR classified as `app_code` that still trips the `auth_changes` flag gets the auth checklist):
+
+| Risk class | Required checks |
+|------------|-----------------|
+| `renovate_digest_only` | verify no functional changes beyond lockfile hashes |
+| `dependency_upgrade` | breaking API changes in updated dependencies; run full test suite after upgrade |
+| `k8s_manifest` | validate manifest against target cluster version; resource quota / limit changes |
+| `auth_changes` | review auth flow for regression; session token handling |
+| `public_route_changes` | route access controls; unintended public endpoints |
+| `file_serving_changes` | file path sanitization; directory traversal |
+| `path_handling_changes` | path traversal; edge-case paths (null bytes, symlinks) |
+| `secret_handling_changes` | secrets not logged/exposed; secret rotation impact |
+| `db_or_migration_changes` | migration data-loss risk; test on a copy of production schema |
+| `linked_security_issue` / `linked_audit_issue` / `linked_priority_p0`/`p1` | explicitly address the linked issue / verify thoroughly |
+
+These checklists exist to keep weaker local models honest on high-risk PRs: the items are injected into the model's instructions ("address EACH of these"), and the review is then **validated** against them.
+
+### Required-check completeness validation
+
+After the model returns, the action deterministically checks whether `review_markdown` actually discussed each `must_check` item (shallow keyword matching — it catches reviews that never mentioned a required check, not incorrect discussion). Controlled by `validate_required_checks` (`auto` = validate when must_check is non-empty) and `required_check_validation_mode`:
+
+- `warn` (default): an **Unaddressed required checks** section listing the missing items is appended to the published review, so a human sees exactly what the model skipped. The verdict is not changed.
+- `fail`: additionally forces a `request_changes` verdict.
+- `metadata_only`: records the result without touching the published review — for downstream automation.
+
+The result is exposed as the `required_checks` output (`complete` / `incomplete` / `none`), written to the run's step summary, and recorded in the managed metadata marker for future runs. Low-risk PRs (empty `must_check`) produce no validation noise.
+
 ## Requirements
 
 - The repository under review must already be checked out.
@@ -73,6 +100,8 @@ The classification is purely rule-based — no model calls are involved. It uses
 | `verdict_policy` | How the final verdict is decided: `model` (the model's own verdict) or `findings_severity_gated` (derived from structured findings: `request_changes` iff any blocker finding; falls back to the model verdict when no findings). Enforcement settings still apply afterwards | No | `model` |
 | `inline_findings` | Attach diff-anchorable structured findings as native line-anchored review comments in `review_comment`/`review_verdict` modes. Ignored for `comment` mode | No | `false` |
 | `inline_findings_max` | Maximum inline review comments per review when `inline_findings=true` | No | `20` |
+| `validate_required_checks` | Validate the final review against the classifier's `must_check` items: `auto` (when must_check is non-empty), `true`, or `false` | No | `auto` |
+| `required_check_validation_mode` | Action on unaddressed required checks: `warn` (append a section to the review), `fail` (also force `request_changes`), or `metadata_only` | No | `warn` |
 | `ai_primary_retry_delay_sec` | Delay between retries in seconds | No | `15` |
 | `allowed_source_hosts` | Comma-separated allowlist for linked URL fetching | No | `github.com,api.github.com,gitlab.com,registry.terraform.io,artifacthub.io` |
 | `system_prompt` | Optional system prompt override | No | bundled prompt |
@@ -125,6 +154,7 @@ The classification is purely rule-based — no model calls are involved. It uses
 |--------|-------------|
 | `verdict` | `approve` or `request_changes` |
 | `verdict_source` | `model` or `findings`, per `verdict_policy` |
+| `required_checks` | Required-check validation status: `complete`, `incomplete`, or `none` (validation did not run) |
 | `findings` | Normalized structured findings as a JSON array (`[]` when the model produced none) |
 | `review_markdown` | Full markdown review body |
 | `analysis_engine` | Model and endpoint that produced the final result |

--- a/action.yml
+++ b/action.yml
@@ -109,6 +109,22 @@ inputs:
     description: Maximum inline review comments attached per review when inline_findings=true.
     required: false
     default: "20"
+  validate_required_checks:
+    description: >-
+      Whether to validate the final review against the classifier's must_check items.
+      'auto' (default) validates whenever must_check is non-empty; 'true' and 'false'
+      force it on or off. Validation is deterministic keyword matching — it catches
+      reviews that never discussed a required check, not incorrect discussion.
+    required: false
+    default: "auto"
+  required_check_validation_mode:
+    description: >-
+      What to do when required checks are unaddressed. 'warn' (default) appends an
+      'Unaddressed required checks' section to the published review. 'fail' also forces
+      a request_changes verdict. 'metadata_only' records the result (required_checks
+      output and metadata marker) without changing the published review.
+    required: false
+    default: "warn"
   ai_stream:
     description: If true, use streaming responses to avoid timeouts behind proxies with short read timeouts (e.g. Cloudflare 100s edge timer)
     required: false
@@ -318,6 +334,9 @@ outputs:
   verdict_source:
     description: Where the final verdict came from ('model' or 'findings', per verdict_policy)
     value: ${{ steps.review.outputs.verdict_source }}
+  required_checks:
+    description: Required-check validation status ('complete', 'incomplete', or 'none' when validation did not run)
+    value: ${{ steps.review.outputs.required_checks }}
   findings:
     description: Normalized structured findings as a JSON array (empty array when the model produced none)
     value: ${{ steps.review.outputs.findings }}
@@ -453,6 +472,8 @@ runs:
         AI_PRIMARY_RETRY_DELAY_SEC: ${{ inputs.ai_primary_retry_delay_sec }}
         ON_MODEL_FAILURE: ${{ inputs.on_model_failure }}
         VERDICT_POLICY: ${{ inputs.verdict_policy }}
+        VALIDATE_REQUIRED_CHECKS: ${{ inputs.validate_required_checks }}
+        REQUIRED_CHECK_VALIDATION_MODE: ${{ inputs.required_check_validation_mode }}
         AI_STREAM: ${{ inputs.ai_stream }}
         AI_FALLBACK_STREAM: ${{ inputs.ai_fallback_stream }}
         ALLOWED_SOURCE_HOSTS: ${{ inputs.allowed_source_hosts }}
@@ -503,6 +524,7 @@ runs:
         HEAD_SHA: ${{ github.event.pull_request.head.sha || steps.precheck.outputs.head_sha }}
         BROAD_FINGERPRINT: ${{ steps.precheck.outputs.diff_fingerprint }}
         VERDICT: ${{ steps.review.outputs.verdict }}
+        REQUIRED_CHECKS: ${{ steps.review.outputs.required_checks }}
         REVIEW_MARKDOWN: ${{ steps.review.outputs.review_markdown }}
         ANALYSIS_ENGINE: ${{ steps.review.outputs.analysis_engine }}
         COMMENT_MARKER: ${{ inputs.comment_marker }}
@@ -564,6 +586,7 @@ runs:
         PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
         HEAD_SHA: ${{ github.event.pull_request.head.sha || steps.precheck.outputs.head_sha }}
         VERDICT: ${{ steps.review.outputs.verdict }}
+        REQUIRED_CHECKS: ${{ steps.review.outputs.required_checks }}
         REVIEW_MARKDOWN: ${{ steps.review.outputs.review_markdown }}
         FINDINGS: ${{ steps.review.outputs.findings }}
         INLINE_FINDINGS: ${{ inputs.inline_findings }}
@@ -663,6 +686,7 @@ runs:
         PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
         HEAD_SHA: ${{ github.event.pull_request.head.sha || steps.precheck.outputs.head_sha }}
         VERDICT: ${{ steps.review.outputs.verdict }}
+        REQUIRED_CHECKS: ${{ steps.review.outputs.required_checks }}
         REVIEW_MARKDOWN: ${{ steps.review.outputs.review_markdown }}
         FINDINGS: ${{ steps.review.outputs.findings }}
         INLINE_FINDINGS: ${{ inputs.inline_findings }}

--- a/pr_reviewer/classifier.py
+++ b/pr_reviewer/classifier.py
@@ -325,45 +325,71 @@ def _detect_risk_flags(
     return flags
 
 
+# Checklist items per risk class. Keys are pr_kind values AND the file-based
+# risk flags (which share names), so a flag like auth_changes detected on an
+# app_code PR still pulls in the auth checklist (#157).
+KIND_CHECKS: dict[str, list[str]] = {
+    "renovate_digest_only": [
+        "verify no functional changes beyond lockfile hashes",
+    ],
+    "dependency_upgrade": [
+        "check for breaking API changes in updated dependencies",
+        "run full test suite after upgrade",
+    ],
+    "k8s_manifest": [
+        "validate manifest against target cluster version",
+        "check for resource quota / limit changes",
+    ],
+    "auth_changes": [
+        "review auth flow for regression",
+        "verify session token handling is correct",
+    ],
+    "public_route_changes": [
+        "verify route access controls are in place",
+        "check for unintended public endpoints",
+    ],
+    "file_serving_changes": [
+        "verify file path sanitization",
+        "check for directory traversal vulnerabilities",
+    ],
+    "path_handling_changes": [
+        "review for path traversal vulnerabilities",
+        "test with edge-case paths (null bytes, symlinks)",
+    ],
+    "secret_handling_changes": [
+        "verify secrets are not logged or exposed in diffs",
+        "check secret rotation impact",
+    ],
+    "db_or_migration_changes": [
+        "review migration for data loss risk",
+        "test migration on a copy of production schema",
+    ],
+}
+
+# Checklist items per linked-issue risk flag.
+FLAG_CHECKS: dict[str, list[str]] = {
+    "linked_security_issue": ["explicitly address the linked security issue"],
+    "linked_audit_issue": ["verify audit findings are addressed"],
+    "linked_priority_p0": ["treat as critical — verify all changes thoroughly"],
+    "linked_priority_p1": ["treat as high priority — verify correctness carefully"],
+}
+
+
 def _build_must_check(pr_kind: str, risk_flags: list[str]) -> list[str]:
-    """Generate explicit must-check items based on classification."""
+    """Generate explicit must-check items based on classification.
+
+    Checks come from the union of the pr_kind and every detected risk flag
+    (deduplicated, pr_kind first) — not the pr_kind alone, so secondary risk
+    signals still produce their checklists.
+    """
     checks: list[str] = []
+    seen: set[str] = set()
 
-    if pr_kind == "renovate_digest_only":
-        checks.append("verify no functional changes beyond lockfile hashes")
-    elif pr_kind == "dependency_upgrade":
-        checks.append("check for breaking API changes in updated dependencies")
-        checks.append("run full test suite after upgrade")
-    elif pr_kind == "k8s_manifest":
-        checks.append("validate manifest against target cluster version")
-        checks.append("check for resource quota / limit changes")
-    elif pr_kind == "auth_changes":
-        checks.append("review auth flow for regression")
-        checks.append("verify session token handling is correct")
-    elif pr_kind == "public_route_changes":
-        checks.append("verify route access controls are in place")
-        checks.append("check for unintended public endpoints")
-    elif pr_kind == "file_serving_changes":
-        checks.append("verify file path sanitization")
-        checks.append("check for directory traversal vulnerabilities")
-    elif pr_kind == "path_handling_changes":
-        checks.append("review for path traversal vulnerabilities")
-        checks.append("test with edge-case paths (null bytes, symlinks)")
-    elif pr_kind == "secret_handling_changes":
-        checks.append("verify secrets are not logged or exposed in diffs")
-        checks.append("check secret rotation impact")
-    elif pr_kind == "db_or_migration_changes":
-        checks.append("review migration for data loss risk")
-        checks.append("test migration on a copy of production schema")
-
-    if "linked_security_issue" in risk_flags:
-        checks.append("explicitly address the linked security issue")
-    if "linked_audit_issue" in risk_flags:
-        checks.append("verify audit findings are addressed")
-    if "linked_priority_p0" in risk_flags:
-        checks.append("treat as critical — verify all changes thoroughly")
-    if "linked_priority_p1" in risk_flags:
-        checks.append("treat as high priority — verify correctness carefully")
+    for key in [pr_kind, *risk_flags]:
+        for check in KIND_CHECKS.get(key, []) + FLAG_CHECKS.get(key, []):
+            if check not in seen:
+                seen.add(check)
+                checks.append(check)
 
     return checks
 

--- a/pr_reviewer/completeness.py
+++ b/pr_reviewer/completeness.py
@@ -1,0 +1,187 @@
+"""Deterministic review-completeness validation against must_check items.
+
+The classifier (pr_reviewer/classifier.py) emits a must_check list for risky
+PRs and the prompt instructs the model to address each item. This module
+checks whether review_markdown actually *discussed* each required check, by
+shallow keyword matching. It deliberately does not judge correctness — it
+only catches reviews that never mentioned a required check at all, which is
+the common weak-model failure (#158).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+# Concept keywords per exact must_check string emitted by the classifier.
+# An item counts as addressed when ANY keyword appears in the review text.
+# Keep entries short and high-recall: a false "addressed" is cheaper than
+# spamming complete reviews with warnings.
+CHECK_CONCEPTS: dict[str, list[str]] = {
+    "verify no functional changes beyond lockfile hashes": [
+        "lockfile", "hash", "digest", "functional change",
+    ],
+    "check for breaking API changes in updated dependencies": [
+        "breaking", "backward", "compatib", "api change",
+    ],
+    "run full test suite after upgrade": [
+        "test",
+    ],
+    "validate manifest against target cluster version": [
+        "cluster", "api version", "apiversion", "manifest",
+    ],
+    "check for resource quota / limit changes": [
+        "quota", "limit", "resource",
+    ],
+    "review auth flow for regression": [
+        "auth",
+    ],
+    "verify session token handling is correct": [
+        "session", "token",
+    ],
+    "verify route access controls are in place": [
+        "access control", "authoriz", "route",
+    ],
+    "check for unintended public endpoints": [
+        "public", "unauthenticated", "endpoint",
+    ],
+    "verify file path sanitization": [
+        "sanitiz", "normaliz", "realpath", "resolved path", "path containment",
+    ],
+    "check for directory traversal vulnerabilities": [
+        "traversal", "../", "symlink", "escape",
+    ],
+    "review for path traversal vulnerabilities": [
+        "traversal", "../", "symlink", "escape",
+    ],
+    "test with edge-case paths (null bytes, symlinks)": [
+        "null byte", "symlink", "edge case", "edge-case",
+    ],
+    "verify secrets are not logged or exposed in diffs": [
+        "secret", "leak", "exposed", "logged",
+    ],
+    "check secret rotation impact": [
+        "rotat",
+    ],
+    "review migration for data loss risk": [
+        "data loss", "destructive", "migration",
+    ],
+    "test migration on a copy of production schema": [
+        "schema", "migration",
+    ],
+    "explicitly address the linked security issue": [
+        "security",
+    ],
+    "verify audit findings are addressed": [
+        "audit",
+    ],
+    "treat as critical — verify all changes thoroughly": [
+        "critical", "p0", "thorough",
+    ],
+    "treat as high priority — verify correctness carefully": [
+        "high priority", "p1", "correct",
+    ],
+}
+
+_FALLBACK_STOPWORDS = {
+    "verify", "check", "review", "test", "with", "that", "this", "the",
+    "for", "and", "are", "not", "all", "any", "from", "into", "after",
+    "before", "changes", "change", "ensure", "explicitly",
+}
+
+
+def _fallback_keywords(item: str) -> list[str]:
+    """Derive match keywords from the item text for unknown checks
+    (e.g. when the classifier gains new items before this table does)."""
+    words = re.findall(r"[a-z][a-z-]{3,}", item.lower())
+    return [w for w in words if w not in _FALLBACK_STOPWORDS] or [item.lower()]
+
+
+def is_addressed(item: str, review_lower: str) -> bool:
+    keywords = CHECK_CONCEPTS.get(item) or _fallback_keywords(item)
+    return any(keyword in review_lower for keyword in keywords)
+
+
+def validate_review(must_check: list[str], review_markdown: str) -> dict:
+    """Return {"validated": bool, "missing": [...], "addressed": [...]}."""
+    review_lower = (review_markdown or "").lower()
+    missing = [item for item in must_check if not is_addressed(item, review_lower)]
+    addressed = [item for item in must_check if item not in missing]
+    return {"validated": not missing, "missing": missing, "addressed": addressed}
+
+
+def apply_required_check_validation(
+    enabled: str = "auto",
+    mode: str = "warn",
+    classification_path: str = "classification.json",
+    output_path: str = "ai-output.json",
+    result_path: str = "completeness.json",
+) -> str:
+    """Validate the final review against must_check and act per *mode*.
+
+    enabled: auto (validate when must_check is non-empty) | true | false.
+    mode:    warn (append an Unaddressed-required-checks section; never flips
+             the verdict) | fail (also force request_changes) | metadata_only
+             (record the result without touching the published review).
+
+    Returns and records the status: "complete" | "incomplete" | "none"
+    (none = validation did not run). The status is written to result_path and
+    into the output JSON as "required_checks".
+    """
+    must_check: list[str] = []
+    try:
+        classification = json.loads(
+            Path(classification_path).read_text(encoding="utf-8", errors="replace")
+        )
+        raw = classification.get("must_check")
+        if isinstance(raw, list):
+            must_check = [str(item) for item in raw if item]
+    except (OSError, json.JSONDecodeError, ValueError):
+        must_check = []
+
+    enabled = (enabled or "auto").strip().lower()
+    mode = (mode or "warn").strip().lower()
+    if mode not in ("warn", "fail", "metadata_only"):
+        mode = "warn"
+
+    data = json.loads(Path(output_path).read_text(encoding="utf-8", errors="replace"))
+
+    if enabled == "false" or (enabled in ("auto", "true") and not must_check):
+        status = "none"
+        result = {"status": status, "mode": mode, "missing": [], "addressed": []}
+    else:
+        outcome = validate_review(must_check, str(data.get("review_markdown") or ""))
+        status = "complete" if outcome["validated"] else "incomplete"
+        result = {
+            "status": status,
+            "mode": mode,
+            "missing": outcome["missing"],
+            "addressed": outcome["addressed"],
+        }
+
+        if status == "incomplete" and mode in ("warn", "fail"):
+            bullets = "\n".join(f"- {item}" for item in outcome["missing"])
+            data["review_markdown"] = (
+                str(data.get("review_markdown") or "")
+                + "\n\n### Unaddressed required checks\n"
+                + "The classifier marked these checks as required for this PR's "
+                + "risk profile, but the review above does not appear to discuss "
+                + "them:\n\n"
+                + bullets
+            )
+        if status == "incomplete" and mode == "fail":
+            data["verdict"] = "request_changes"
+            data["review_markdown"] += (
+                "\n\n_required_check_validation_mode=fail: treating the missing "
+                "required checks as blocking._"
+            )
+
+    data["required_checks"] = status
+    Path(output_path).write_text(
+        json.dumps(data, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
+    Path(result_path).write_text(
+        json.dumps(result, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
+    return status

--- a/scripts/publish_helpers.sh
+++ b/scripts/publish_helpers.sh
@@ -104,11 +104,22 @@ build_metadata_marker() {
   local base_sha="$1"
   local previous_head_sha="${2:-}"
 
-  local marker="<!-- ai-pr-reviewer:{\"version\":1,\"head_sha\":\"${HEAD_SHA:-unknown}\",\"base_sha\":\"${base_sha}\",\"review_scope\":\"${EFFECTIVE_SCOPE}\",\"review_result\":\"${REVIEW_RESULT}\"} -->"
-  if [ "$EFFECTIVE_SCOPE" = "incremental" ] && [ -n "$previous_head_sha" ]; then
-    marker="${marker%,*},\"previous_head_sha\":\"${previous_head_sha}\"}"
-  fi
-  printf '%s' "$marker"
+  # Built with jq instead of string surgery: the old "${marker%,*}" trick for
+  # appending previous_head_sha cut at the LAST comma, silently dropping
+  # review_result and the closing " -->" — which made incremental markers
+  # unparseable and degraded the next run back to a full review.
+  local marker_json
+  marker_json="$(jq -nc \
+    --arg head "${HEAD_SHA:-unknown}" \
+    --arg base "$base_sha" \
+    --arg scope "${EFFECTIVE_SCOPE}" \
+    --arg result "${REVIEW_RESULT}" \
+    --arg checks "${REQUIRED_CHECKS:-}" \
+    --arg prev "$previous_head_sha" \
+    '{version: 1, head_sha: $head, base_sha: $base, review_scope: $scope, review_result: $result}
+     + (if $checks == "" or $checks == "none" then {} else {required_checks: $checks} end)
+     + (if $scope == "incremental" and $prev != "" then {previous_head_sha: $prev} else {} end)')"
+  printf '<!-- ai-pr-reviewer:%s -->' "$marker_json"
 }
 
 # Validate that PR_NUMBER is set.

--- a/scripts/run_review.sh
+++ b/scripts/run_review.sh
@@ -100,6 +100,8 @@ AI_FALLBACK_CONNECT_TIMEOUT_SEC="${AI_FALLBACK_CONNECT_TIMEOUT_SEC:-${AI_CONNECT
 OUTPUT_FILE="${GITHUB_OUTPUT:-/dev/null}"
 ON_MODEL_FAILURE="${ON_MODEL_FAILURE:-fail}"
 VERDICT_POLICY="${VERDICT_POLICY:-model}"
+VALIDATE_REQUIRED_CHECKS="${VALIDATE_REQUIRED_CHECKS:-auto}"
+REQUIRED_CHECK_VALIDATION_MODE="${REQUIRED_CHECK_VALIDATION_MODE:-warn}"
 REVIEW_SCOPE="${REVIEW_SCOPE:-auto}"
 EFFECTIVE_SCOPE="${EFFECTIVE_SCOPE:-full}"
 PREVIOUS_HEAD_SHA="${PREVIOUS_HEAD_SHA:-}"
@@ -259,6 +261,22 @@ case "$VERDICT_POLICY" in
     ;;
 esac
 
+case "$(printf '%s' "$VALIDATE_REQUIRED_CHECKS" | tr '[:upper:]' '[:lower:]')" in
+  auto|true|false) VALIDATE_REQUIRED_CHECKS="$(printf '%s' "$VALIDATE_REQUIRED_CHECKS" | tr '[:upper:]' '[:lower:]')" ;;
+  *)
+    error "Invalid VALIDATE_REQUIRED_CHECKS '$VALIDATE_REQUIRED_CHECKS'; defaulting to auto"
+    VALIDATE_REQUIRED_CHECKS=auto
+    ;;
+esac
+
+case "$(printf '%s' "$REQUIRED_CHECK_VALIDATION_MODE" | tr '[:upper:]' '[:lower:]')" in
+  warn|fail|metadata_only) REQUIRED_CHECK_VALIDATION_MODE="$(printf '%s' "$REQUIRED_CHECK_VALIDATION_MODE" | tr '[:upper:]' '[:lower:]')" ;;
+  *)
+    error "Invalid REQUIRED_CHECK_VALIDATION_MODE '$REQUIRED_CHECK_VALIDATION_MODE'; defaulting to warn"
+    REQUIRED_CHECK_VALIDATION_MODE=warn
+    ;;
+esac
+
 if [[ -n "$AI_FALLBACK_BASE_URL" && -z "$AI_FALLBACK_MODEL" ]]; then
   error "AI_FALLBACK_MODEL is required when AI_FALLBACK_BASE_URL is set"
   exit 1
@@ -358,11 +376,16 @@ apply_all_enforcement_wrapper() {
   local tool_failure_enabled="$2"
   local tool_min_successful="$3"
   local verdict_policy="$4"
+  local validate_checks="$5"
+  local validation_mode="$6"
   PYTHONPATH="${SCRIPT_DIR}/.." python3 -c "
+from pr_reviewer.completeness import apply_required_check_validation
 from pr_reviewer.enforcement import apply_all_enforcement, apply_verdict_policy
-# Verdict policy first (may derive the verdict from findings); enforcement
-# overlays run after and can still force request_changes.
+# Order: verdict policy (may derive the verdict from findings), then
+# completeness validation (may warn or fail on unaddressed required checks),
+# then enforcement overlays, which can still force request_changes.
 apply_verdict_policy('$verdict_policy')
+apply_required_check_validation('$validate_checks', '$validation_mode')
 apply_all_enforcement(
   evidence_blocker_enabled=('$evidence_blocker_enabled' == 'true'),
   tool_failure_enabled=('$tool_failure_enabled' == 'true'),
@@ -1242,11 +1265,12 @@ if [[ "$(printf '%s' "$TOOL_MODE" | tr '[:upper:]' '[:lower:]')" == "plan_execut
   TOOL_FAILURE_ENABLED="true"
 fi
 
-apply_all_enforcement_wrapper "$EVIDENCE_BLOCKER_ENABLED" "$TOOL_FAILURE_ENABLED" "$TOOL_MIN_SUCCESSFUL_REQUESTS" "$VERDICT_POLICY"
+apply_all_enforcement_wrapper "$EVIDENCE_BLOCKER_ENABLED" "$TOOL_FAILURE_ENABLED" "$TOOL_MIN_SUCCESSFUL_REQUESTS" "$VERDICT_POLICY" "$VALIDATE_REQUIRED_CHECKS" "$REQUIRED_CHECK_VALIDATION_MODE"
 
 echo "analysis_engine=$ANALYSIS_ENGINE" >> "$OUTPUT_FILE"
 echo "verdict=$(jq -r '.verdict' ai-output.json)" >> "$OUTPUT_FILE"
 echo "verdict_source=$(jq -r '.verdict_source // "model"' ai-output.json)" >> "$OUTPUT_FILE"
+echo "required_checks=$(jq -r '.required_checks // "none"' ai-output.json)" >> "$OUTPUT_FILE"
 
 # Use a random heredoc delimiter so model-controlled review text (which can be
 # influenced by prompt injection in the PR diff/title/body) cannot terminate the
@@ -1312,6 +1336,8 @@ write_step_summary() {
   findings_count="$(jq -r '.findings | length' ai-output.json 2>/dev/null || echo 0)"
   blockers_count="$(jq -r '[.findings[]? | select(.severity == "blocker")] | length' ai-output.json 2>/dev/null || echo 0)"
   verdict_source="$(jq -r '.verdict_source // "model"' ai-output.json 2>/dev/null || echo model)"
+  local required_checks_status
+  required_checks_status="$(jq -r '.required_checks // "none"' ai-output.json 2>/dev/null || echo none)"
 
   {
     echo "### AI PR Review"
@@ -1321,6 +1347,7 @@ write_step_summary() {
     echo "| Engine | ${ANALYSIS_ENGINE} |"
     echo "| Verdict | ${verdict} (source: ${verdict_source}) |"
     echo "| Findings | ${findings_count} (blockers: ${blockers_count}) |"
+    echo "| Required checks | ${required_checks_status} |"
     echo "| Scope | ${EFFECTIVE_SCOPE} |"
     echo "| Budget | ${budget_desc} |"
     echo "| Diff bytes | ${diff_bytes} (truncated: ${diff_trunc}) |"

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -274,6 +274,29 @@ class TestMustCheck:
             "app_code", ["linked_security_issue"])
         assert any("security issue" in c for c in checks)
 
+    def test_risk_flag_adds_checks_beyond_pr_kind(self):
+        # An auth_changes flag on an app_code PR must still pull in the auth
+        # checklist (#157) — checks are not keyed off pr_kind alone.
+        checks = _build_must_check("app_code", ["auth_changes"])
+        assert any("auth flow" in c for c in checks)
+        assert any("session token" in c for c in checks)
+
+    def test_multiple_risk_flags_union(self):
+        checks = _build_must_check(
+            "app_code", ["auth_changes", "path_handling_changes"])
+        assert any("auth flow" in c for c in checks)
+        assert any("path traversal" in c for c in checks)
+
+    def test_kind_equal_to_flag_deduplicates(self):
+        # auth_changes as both pr_kind and risk flag yields each check once.
+        checks = _build_must_check("auth_changes", ["auth_changes"])
+        assert len(checks) == len(set(checks))
+        assert sum(1 for c in checks if "auth flow" in c) == 1
+
+    def test_pr_kind_checks_come_first(self):
+        checks = _build_must_check("file_serving_changes", ["auth_changes"])
+        assert "sanitization" in checks[0] or "traversal" in checks[0]
+
 
 # ---------------------------------------------------------------------------
 # Full classify_pr integration tests

--- a/tests/test_completeness.py
+++ b/tests/test_completeness.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Tests for pr_reviewer.completeness — required-check validation (#158)."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+import pytest
+
+from pr_reviewer.completeness import (
+    apply_required_check_validation,
+    is_addressed,
+    validate_review,
+)
+
+
+FILE_SERVING_CHECKS = [
+    "verify file path sanitization",
+    "check for directory traversal vulnerabilities",
+]
+AUTH_CHECKS = [
+    "review auth flow for regression",
+    "verify session token handling is correct",
+]
+
+
+class TestValidateReview:
+    def test_complete_file_serving_review(self):
+        review = (
+            "The handler normalizes the requested path with realpath and "
+            "rejects anything outside the data root, so directory traversal "
+            "via ../ or symlink is not possible."
+        )
+        result = validate_review(FILE_SERVING_CHECKS, review)
+        assert result["validated"] is True
+        assert result["missing"] == []
+
+    def test_incomplete_file_serving_review(self):
+        review = "Adds media extension filtering. Code looks clean, approve."
+        result = validate_review(FILE_SERVING_CHECKS, review)
+        assert result["validated"] is False
+        assert set(result["missing"]) == set(FILE_SERVING_CHECKS)
+
+    def test_complete_auth_review(self):
+        review = (
+            "Auth flow unchanged for existing users; session cookies keep the "
+            "same token lifetime and rotation."
+        )
+        result = validate_review(AUTH_CHECKS, review)
+        assert result["validated"] is True
+
+    def test_incomplete_auth_review(self):
+        review = "Refactors the controller; naming follows conventions."
+        result = validate_review(AUTH_CHECKS, review)
+        assert result["validated"] is False
+        assert set(result["missing"]) == set(AUTH_CHECKS)
+
+    def test_partial_review_lists_only_missing(self):
+        review = "Path sanitization is handled via realpath checks."
+        result = validate_review(FILE_SERVING_CHECKS, review)
+        assert result["missing"] == ["check for directory traversal vulnerabilities"]
+        assert result["addressed"] == ["verify file path sanitization"]
+
+    def test_empty_must_check_validates(self):
+        assert validate_review([], "anything")["validated"] is True
+
+
+class TestUnknownItemsFallback:
+    def test_unknown_item_matches_significant_words(self):
+        # Items the concept table does not know fall back to word matching.
+        assert is_addressed(
+            "confirm helm values render correctly",
+            "the helm values render fine with the new chart",
+        )
+
+    def test_unknown_item_not_mentioned(self):
+        assert not is_addressed(
+            "confirm helm values render correctly",
+            "code style looks good",
+        )
+
+
+class TestApplyRequiredCheckValidation:
+    def _setup(self, tmp_path, monkeypatch, must_check, review, verdict="approve"):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "classification.json").write_text(
+            json.dumps({"pr_kind": "file_serving_changes", "must_check": must_check})
+        )
+        (tmp_path / "ai-output.json").write_text(
+            json.dumps({"verdict": verdict, "review_markdown": review})
+        )
+
+    def _output(self, tmp_path):
+        return json.loads((tmp_path / "ai-output.json").read_text())
+
+    def test_warn_appends_section_keeps_verdict(self, tmp_path, monkeypatch):
+        self._setup(tmp_path, monkeypatch, FILE_SERVING_CHECKS, "Looks good, approve.")
+        status = apply_required_check_validation("auto", "warn")
+        assert status == "incomplete"
+        data = self._output(tmp_path)
+        assert data["verdict"] == "approve"
+        assert "Unaddressed required checks" in data["review_markdown"]
+        assert "verify file path sanitization" in data["review_markdown"]
+        assert data["required_checks"] == "incomplete"
+
+    def test_fail_forces_request_changes(self, tmp_path, monkeypatch):
+        self._setup(tmp_path, monkeypatch, FILE_SERVING_CHECKS, "Looks good, approve.")
+        status = apply_required_check_validation("auto", "fail")
+        assert status == "incomplete"
+        data = self._output(tmp_path)
+        assert data["verdict"] == "request_changes"
+        assert "Unaddressed required checks" in data["review_markdown"]
+
+    def test_metadata_only_leaves_review_untouched(self, tmp_path, monkeypatch):
+        self._setup(tmp_path, monkeypatch, FILE_SERVING_CHECKS, "Looks good, approve.")
+        status = apply_required_check_validation("auto", "metadata_only")
+        assert status == "incomplete"
+        data = self._output(tmp_path)
+        assert data["verdict"] == "approve"
+        assert "Unaddressed" not in data["review_markdown"]
+        assert data["required_checks"] == "incomplete"
+
+    def test_complete_review_status_complete(self, tmp_path, monkeypatch):
+        self._setup(
+            tmp_path, monkeypatch, FILE_SERVING_CHECKS,
+            "Sanitization via realpath; traversal through ../ rejected.",
+        )
+        assert apply_required_check_validation("auto", "warn") == "complete"
+        data = self._output(tmp_path)
+        assert "Unaddressed" not in data["review_markdown"]
+        assert data["required_checks"] == "complete"
+
+    def test_auto_with_empty_must_check_is_none(self, tmp_path, monkeypatch):
+        self._setup(tmp_path, monkeypatch, [], "anything")
+        assert apply_required_check_validation("auto", "warn") == "none"
+        assert self._output(tmp_path)["required_checks"] == "none"
+
+    def test_disabled_is_none_even_with_checks(self, tmp_path, monkeypatch):
+        self._setup(tmp_path, monkeypatch, FILE_SERVING_CHECKS, "Looks good.")
+        assert apply_required_check_validation("false", "warn") == "none"
+        data = self._output(tmp_path)
+        assert "Unaddressed" not in data["review_markdown"]
+
+    def test_missing_classification_is_none(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "ai-output.json").write_text(
+            json.dumps({"verdict": "approve", "review_markdown": "ok"})
+        )
+        assert apply_required_check_validation("auto", "warn") == "none"
+
+    def test_completeness_json_written(self, tmp_path, monkeypatch):
+        self._setup(tmp_path, monkeypatch, FILE_SERVING_CHECKS, "Looks good.")
+        apply_required_check_validation("auto", "warn")
+        result = json.loads((tmp_path / "completeness.json").read_text())
+        assert result["status"] == "incomplete"
+        assert result["mode"] == "warn"
+        assert set(result["missing"]) == set(FILE_SERVING_CHECKS)
+
+    def test_invalid_mode_falls_back_to_warn(self, tmp_path, monkeypatch):
+        self._setup(tmp_path, monkeypatch, FILE_SERVING_CHECKS, "Looks good.")
+        apply_required_check_validation("auto", "explode")
+        data = self._output(tmp_path)
+        assert data["verdict"] == "approve"
+        assert "Unaddressed required checks" in data["review_markdown"]
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_required_checks.sh
+++ b/tests/test_required_checks.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Bash >= 4 required: empty-array expansion under `set -u` and other 4.x
+# behaviors break on macOS stock bash 3.2. Skip (not fail) so local runs
+# explain themselves; CI runs bash 5.
+if [ -z "${BASH_VERSINFO:-}" ] || [ "${BASH_VERSINFO[0]}" -lt 4 ]; then
+  echo "SKIP: bash >= 4 required (found ${BASH_VERSION:-unknown}); on macOS run with PATH=\"/opt/homebrew/bin:\$PATH\"" >&2
+  exit 0
+fi
+
+# Wiring tests for required-check validation (#157/#158) and the
+# build_metadata_marker rewrite (required_checks field + the incremental
+# marker corruption fix).
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+HELPER_SCRIPT="$ROOT_DIR/scripts/publish_helpers.sh"
+
+PASS=0
+FAIL=0
+check() {
+  local desc="$1" result="$2" expected="$3"
+  if [[ "$result" == "$expected" ]]; then
+    echo "  PASS: $desc"; PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc (got '$result', expected '$expected')"; FAIL=$((FAIL + 1))
+  fi
+}
+check_contains() {
+  local desc="$1" haystack="$2" needle="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    echo "  PASS: $desc"; PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc (expected to contain '$needle')"; FAIL=$((FAIL + 1))
+  fi
+}
+
+echo "=== Wiring: run_review.sh and action.yml ==="
+check "run_review validates VALIDATE_REQUIRED_CHECKS values" \
+  "$(grep -c 'Invalid VALIDATE_REQUIRED_CHECKS' "$ROOT_DIR/scripts/run_review.sh")" "1"
+check "run_review validates REQUIRED_CHECK_VALIDATION_MODE values" \
+  "$(grep -c 'Invalid REQUIRED_CHECK_VALIDATION_MODE' "$ROOT_DIR/scripts/run_review.sh")" "1"
+check "wrapper calls apply_required_check_validation" \
+  "$(grep -c 'apply_required_check_validation' "$ROOT_DIR/scripts/run_review.sh")" "2"
+check "required_checks step output emitted" \
+  "$(grep -c '^echo "required_checks=' "$ROOT_DIR/scripts/run_review.sh")" "1"
+ACTION="$(cat "$ROOT_DIR/action.yml")"
+check_contains "action.yml declares validate_required_checks input" "$ACTION" "validate_required_checks:"
+check_contains "action.yml declares required_check_validation_mode input" "$ACTION" "required_check_validation_mode:"
+check_contains "action.yml declares required_checks output" "$ACTION" "required_checks:"
+check "publish steps receive REQUIRED_CHECKS" \
+  "$(grep -c 'REQUIRED_CHECKS: \${{ steps.review.outputs.required_checks }}' "$ROOT_DIR/action.yml")" "3"
+
+echo ""
+echo "=== Functional: build_metadata_marker carries required_checks ==="
+# shellcheck source=/dev/null
+source "$HELPER_SCRIPT"
+
+MARKER="$(HEAD_SHA=headsha EFFECTIVE_SCOPE=full REVIEW_RESULT=clean REQUIRED_CHECKS=incomplete \
+  build_metadata_marker "basesha" "")"
+check_contains "marker carries required_checks" "$MARKER" '"required_checks":"incomplete"'
+check_contains "marker keeps review_result" "$MARKER" '"review_result":"clean"'
+check_contains "marker terminates with -->" "$MARKER" " -->"
+
+MARKER_NONE="$(HEAD_SHA=headsha EFFECTIVE_SCOPE=full REVIEW_RESULT=clean REQUIRED_CHECKS=none \
+  build_metadata_marker "basesha" "")"
+check "required_checks=none omitted from marker" \
+  "$(printf '%s' "$MARKER_NONE" | grep -c 'required_checks' || true)" "0"
+
+echo ""
+echo "=== Functional: incremental marker is complete and parseable (regression) ==="
+# The old string-surgery builder dropped review_result and the closing ' -->'
+# whenever previous_head_sha was appended, making incremental markers
+# unparseable (next run silently degraded to a full review).
+MARKER_INC="$(HEAD_SHA=headsha EFFECTIVE_SCOPE=incremental REVIEW_RESULT=issues REQUIRED_CHECKS=complete \
+  build_metadata_marker "basesha" "prevsha")"
+check_contains "incremental marker keeps review_result" "$MARKER_INC" '"review_result":"issues"'
+check_contains "incremental marker carries previous_head_sha" "$MARKER_INC" '"previous_head_sha":"prevsha"'
+check_contains "incremental marker terminates with -->" "$MARKER_INC" " -->"
+
+PARSED="$(printf '%s' "$MARKER_INC" | PYTHONPATH="$ROOT_DIR" python3 -c "
+import sys
+from pr_reviewer.metadata import parse_metadata
+data = parse_metadata(sys.stdin.read())
+print('unparseable' if data is None else f\"{data['review_scope']}|{data['review_result']}|{data['previous_head_sha']}|{data.get('required_checks')}\")
+")"
+check "parse_metadata reads the incremental marker" "$PARSED" "incremental|issues|prevsha|complete"
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

First of the three stacked feature PRs (next: #159 routing, then #160 escalation). Closes the remaining #157 scope and implements #158 per the design on the issue.

### #157 remainder — risk-flag-driven checks
`_build_must_check` is now a table (`KIND_CHECKS` + `FLAG_CHECKS`) applied to the **union of pr_kind and every detected risk flag** (deduplicated, pr_kind's checks first). Previously checks were keyed off pr_kind alone, so an `auth_changes` flag detected on an `app_code` PR produced no auth checklist. README now documents the default required checks per risk class (the missing acceptance criterion).

### #158 — completeness validation
New [pr_reviewer/completeness.py](pr_reviewer/completeness.py): after the model returns (and after `verdict_policy`, before enforcement overlays), the review text is deterministically checked against each `must_check` item via a concept-keyword table keyed by the exact classifier strings, with significant-word fallback for unknown items. It catches reviews that never *discussed* a required check — it does not judge correctness.

**Inputs** (as specced on the issue):
- `validate_required_checks`: `auto` (default — validate when must_check is non-empty) | `true` | `false`
- `required_check_validation_mode`: `warn` (default — append an "Unaddressed required checks" section listing the missing items) | `fail` (also force `request_changes`) | `metadata_only` (record only)

**Plumbing:** `required_checks` output (`complete`/`incomplete`/`none`), step-summary row, `completeness.json` artifact, and a `required_checks` field in the managed metadata marker (for #159/#160 routing to consume).

### Drive-by bug fix: incremental metadata markers were corrupt
`build_metadata_marker` appended `previous_head_sha` with `${marker%,*}` string surgery, which cuts at the **last comma** — silently dropping `review_result` and the closing ` -->`. Result: every incremental-scope native publish emitted an unparseable marker, so the *next* run found no metadata and silently degraded to a full review. Rewritten with `jq`; regression test asserts the incremental marker keeps all fields, terminates properly, and round-trips through `parse_metadata`.

## Tests
- `tests/test_completeness.py` (new, 17 cases): complete/incomplete reviews for the file-serving and auth risk classes (the issue's acceptance criteria), partial reviews, all three modes, auto/true/false gating, unknown-item fallback, missing classification, invalid-mode fallback.
- `tests/test_classifier.py`: +5 cases for flag-driven checks, unions, dedup, ordering.
- `tests/test_required_checks.sh` (new, auto-discovered by CI): wiring assertions + functional marker tests including the incremental-corruption regression.
- Full suite green: 544 pytest + all 16 bash suites.

Closes #157
Closes #158
