### PR TITLE
feat: fast/smart reviewer model routing (review_routing_mode)

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,16 @@ The result is exposed as the `required_checks` output (`complete` / `incomplete`
 | `inline_findings_max` | Maximum inline review comments per review when `inline_findings=true` | No | `20` |
 | `validate_required_checks` | Validate the final review against the classifier's `must_check` items: `auto` (when must_check is non-empty), `true`, or `false` | No | `auto` |
 | `required_check_validation_mode` | Action on unaddressed required checks: `warn` (append a section to the review), `fail` (also force `request_changes`), or `metadata_only` | No | `warn` |
+| `review_routing_mode` | Route reviews between fast and smart models from the classification: `off` (existing primary/fallback behavior) or `auto` | No | `off` |
+| `ai_fast_model` | Fast model for low-risk reviews in `auto` mode; defaults to `ai_model` | No | `""` |
+| `ai_fast_base_url` | Base URL for the fast model; defaults to `ai_base_url` | No | `""` |
+| `ai_fast_api_format` | API format for the fast model; defaults to `ai_api_format` | No | `""` |
+| `ai_fast_api_key` | API key for the fast model; defaults to `ai_api_key` | No | `""` |
+| `ai_smart_model` | Smart model for high-risk reviews in `auto` mode; defaults to `ai_fallback_model` | No | `""` |
+| `ai_smart_base_url` | Base URL for the smart model; defaults to `ai_fallback_base_url` | No | `""` |
+| `ai_smart_api_format` | API format for the smart model; defaults to `ai_fallback_api_format`, then `ai_api_format` | No | `""` |
+| `ai_smart_api_key` | API key for the smart model; defaults to `ai_fallback_api_key` | No | `""` |
+| `escalate_on_risk_flags` | Comma-separated `pr_kind`/`risk_flag` names that route to the smart model in `auto` mode | No | security/priority/auth/route/file-serving/path/secret/db list |
 | `ai_primary_retry_delay_sec` | Delay between retries in seconds | No | `15` |
 | `allowed_source_hosts` | Comma-separated allowlist for linked URL fetching | No | `github.com,api.github.com,gitlab.com,registry.terraform.io,artifacthub.io` |
 | `system_prompt` | Optional system prompt override | No | bundled prompt |
@@ -155,6 +165,7 @@ The result is exposed as the `required_checks` output (`complete` / `incomplete`
 | `verdict` | `approve` or `request_changes` |
 | `verdict_source` | `model` or `findings`, per `verdict_policy` |
 | `required_checks` | Required-check validation status: `complete`, `incomplete`, or `none` (validation did not run) |
+| `review_route` | Model route used: `legacy` (routing off), `fast`, or `smart` |
 | `findings` | Normalized structured findings as a JSON array (`[]` when the model produced none) |
 | `review_markdown` | Full markdown review body |
 | `analysis_engine` | Model and endpoint that produced the final result |
@@ -612,6 +623,30 @@ Anchors are validated against the diff before submission (GitHub only accepts co
     verdict_policy: findings_severity_gated
     inline_findings: "true"
 ```
+
+### Fast/smart model routing
+
+With `review_routing_mode: auto`, the deterministic classification decides which model reviews the PR — boring PRs go to a fast/local model, scary ones go straight to a smarter model:
+
+```yaml
+- uses: misospace/pr-reviewer-action@v1
+  with:
+    github_token: ${{ secrets.GITHUB_TOKEN }}
+    ai_base_url: http://llama-server.internal:8080/v1   # fast (default = primary)
+    ai_model: qwen3-32b
+    ai_smart_base_url: https://api.anthropic.com/v1
+    ai_smart_api_format: anthropic
+    ai_smart_model: claude-sonnet-4-6
+    ai_smart_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+    review_routing_mode: auto
+```
+
+Routing rules:
+- A PR whose `pr_kind` **or** any `risk_flags` entry matches `escalate_on_risk_flags` routes to the **smart** model; everything else routes to the **fast** model.
+- The fast config defaults to the primary `ai_*` inputs; the smart config defaults to the `ai_fallback_*` inputs. If a risky PR is detected but no smart/fallback model is configured, the review stays on the fast model (logged, never fails).
+- `off` (the default) preserves the existing primary/fallback behavior exactly (`review_route` output reports `legacy`).
+- The retry and failure-fallback machinery is unchanged — routing only picks which model it talks to.
+- The chosen route appears in the `review_route` output, the step summary, and the managed metadata marker; routing config is part of the precheck fingerprint, so changing it forces a fresh review.
 
 ### Token-saving with incremental reviews
 

--- a/action.yml
+++ b/action.yml
@@ -125,6 +125,52 @@ inputs:
       output and metadata marker) without changing the published review.
     required: false
     default: "warn"
+  review_routing_mode:
+    description: >-
+      Route PR reviews between fast and smart models based on the deterministic
+      classification. 'off' (default) preserves existing primary/fallback behavior.
+      'auto' sends PRs whose pr_kind or risk_flags match escalate_on_risk_flags to the
+      smart model and everything else to the fast model.
+    required: false
+    default: "off"
+  ai_fast_model:
+    description: Fast/local model for low-risk reviews when review_routing_mode=auto. Defaults to ai_model.
+    required: false
+    default: ""
+  ai_fast_base_url:
+    description: Base URL for the fast model. Defaults to ai_base_url.
+    required: false
+    default: ""
+  ai_fast_api_format:
+    description: API format for the fast model (openai or anthropic). Defaults to ai_api_format.
+    required: false
+    default: ""
+  ai_fast_api_key:
+    description: API key for the fast model. Defaults to ai_api_key.
+    required: false
+    default: ""
+  ai_smart_model:
+    description: Smarter model for high-risk reviews when review_routing_mode=auto. Defaults to ai_fallback_model; with neither set, risky PRs stay on the fast model.
+    required: false
+    default: ""
+  ai_smart_base_url:
+    description: Base URL for the smart model. Defaults to ai_fallback_base_url.
+    required: false
+    default: ""
+  ai_smart_api_format:
+    description: API format for the smart model (openai or anthropic). Defaults to ai_fallback_api_format, then ai_api_format.
+    required: false
+    default: ""
+  ai_smart_api_key:
+    description: API key for the smart model. Defaults to ai_fallback_api_key.
+    required: false
+    default: ""
+  escalate_on_risk_flags:
+    description: >-
+      Comma-separated pr_kind / risk_flag names that route directly to the smart model
+      when review_routing_mode=auto.
+    required: false
+    default: "linked_security_issue,linked_priority_p0,linked_priority_p1,auth_changes,public_route_changes,file_serving_changes,path_handling_changes,secret_handling_changes,db_or_migration_changes"
   ai_stream:
     description: If true, use streaming responses to avoid timeouts behind proxies with short read timeouts (e.g. Cloudflare 100s edge timer)
     required: false
@@ -337,6 +383,9 @@ outputs:
   required_checks:
     description: Required-check validation status ('complete', 'incomplete', or 'none' when validation did not run)
     value: ${{ steps.review.outputs.required_checks }}
+  review_route:
+    description: Model route used for this review ('legacy', 'fast', or 'smart')
+    value: ${{ steps.review.outputs.review_route }}
   findings:
     description: Normalized structured findings as a JSON array (empty array when the model produced none)
     value: ${{ steps.review.outputs.findings }}
@@ -402,6 +451,10 @@ runs:
         AI_RESPONSE_FORMAT: ${{ inputs.ai_response_format }}
         AI_TOKENS_PARAM: ${{ inputs.ai_tokens_param }}
         AI_FALLBACK_MODEL: ${{ inputs.ai_fallback_model }}
+        REVIEW_ROUTING_MODE: ${{ inputs.review_routing_mode }}
+        AI_FAST_MODEL: ${{ inputs.ai_fast_model }}
+        AI_SMART_MODEL: ${{ inputs.ai_smart_model }}
+        ESCALATE_ON_RISK_FLAGS: ${{ inputs.escalate_on_risk_flags }}
         ANTHROPIC_VERSION: ${{ inputs.anthropic_version }}
         SYSTEM_PROMPT: ${{ inputs.system_prompt }}
         SYSTEM_PROMPT_FILE: ${{ inputs.system_prompt_file }}
@@ -474,6 +527,16 @@ runs:
         VERDICT_POLICY: ${{ inputs.verdict_policy }}
         VALIDATE_REQUIRED_CHECKS: ${{ inputs.validate_required_checks }}
         REQUIRED_CHECK_VALIDATION_MODE: ${{ inputs.required_check_validation_mode }}
+        REVIEW_ROUTING_MODE: ${{ inputs.review_routing_mode }}
+        AI_FAST_BASE_URL: ${{ inputs.ai_fast_base_url }}
+        AI_FAST_MODEL: ${{ inputs.ai_fast_model }}
+        AI_FAST_API_FORMAT: ${{ inputs.ai_fast_api_format }}
+        AI_FAST_API_KEY: ${{ inputs.ai_fast_api_key }}
+        AI_SMART_BASE_URL: ${{ inputs.ai_smart_base_url }}
+        AI_SMART_MODEL: ${{ inputs.ai_smart_model }}
+        AI_SMART_API_FORMAT: ${{ inputs.ai_smart_api_format }}
+        AI_SMART_API_KEY: ${{ inputs.ai_smart_api_key }}
+        ESCALATE_ON_RISK_FLAGS: ${{ inputs.escalate_on_risk_flags }}
         AI_STREAM: ${{ inputs.ai_stream }}
         AI_FALLBACK_STREAM: ${{ inputs.ai_fallback_stream }}
         ALLOWED_SOURCE_HOSTS: ${{ inputs.allowed_source_hosts }}
@@ -525,6 +588,7 @@ runs:
         BROAD_FINGERPRINT: ${{ steps.precheck.outputs.diff_fingerprint }}
         VERDICT: ${{ steps.review.outputs.verdict }}
         REQUIRED_CHECKS: ${{ steps.review.outputs.required_checks }}
+        REVIEW_ROUTE: ${{ steps.review.outputs.review_route }}
         REVIEW_MARKDOWN: ${{ steps.review.outputs.review_markdown }}
         ANALYSIS_ENGINE: ${{ steps.review.outputs.analysis_engine }}
         COMMENT_MARKER: ${{ inputs.comment_marker }}
@@ -587,6 +651,7 @@ runs:
         HEAD_SHA: ${{ github.event.pull_request.head.sha || steps.precheck.outputs.head_sha }}
         VERDICT: ${{ steps.review.outputs.verdict }}
         REQUIRED_CHECKS: ${{ steps.review.outputs.required_checks }}
+        REVIEW_ROUTE: ${{ steps.review.outputs.review_route }}
         REVIEW_MARKDOWN: ${{ steps.review.outputs.review_markdown }}
         FINDINGS: ${{ steps.review.outputs.findings }}
         INLINE_FINDINGS: ${{ inputs.inline_findings }}
@@ -687,6 +752,7 @@ runs:
         HEAD_SHA: ${{ github.event.pull_request.head.sha || steps.precheck.outputs.head_sha }}
         VERDICT: ${{ steps.review.outputs.verdict }}
         REQUIRED_CHECKS: ${{ steps.review.outputs.required_checks }}
+        REVIEW_ROUTE: ${{ steps.review.outputs.review_route }}
         REVIEW_MARKDOWN: ${{ steps.review.outputs.review_markdown }}
         FINDINGS: ${{ steps.review.outputs.findings }}
         INLINE_FINDINGS: ${{ inputs.inline_findings }}

--- a/scripts/check_review_needed.sh
+++ b/scripts/check_review_needed.sh
@@ -162,6 +162,20 @@ compute_config_hash() {
     parts+=("tool_forks:${TOOL_ENABLE_FOR_FORKS}")
   fi
 
+  # Model routing (#159): a routing change must force a fresh review
+  if [[ -n "${REVIEW_ROUTING_MODE:-}" ]]; then
+    parts+=("routing_mode:${REVIEW_ROUTING_MODE}")
+  fi
+  if [[ -n "${AI_FAST_MODEL:-}" ]]; then
+    parts+=("fast_model:${AI_FAST_MODEL}")
+  fi
+  if [[ -n "${AI_SMART_MODEL:-}" ]]; then
+    parts+=("smart_model:${AI_SMART_MODEL}")
+  fi
+  if [[ -n "${ESCALATE_ON_RISK_FLAGS:-}" ]]; then
+    parts+=("escalate_flags:${ESCALATE_ON_RISK_FLAGS}")
+  fi
+
   # Review scope
   if [[ -n "${REVIEW_SCOPE:-}" ]]; then
     parts+=("review_scope:${REVIEW_SCOPE}")

--- a/scripts/publish_helpers.sh
+++ b/scripts/publish_helpers.sh
@@ -115,9 +115,11 @@ build_metadata_marker() {
     --arg scope "${EFFECTIVE_SCOPE}" \
     --arg result "${REVIEW_RESULT}" \
     --arg checks "${REQUIRED_CHECKS:-}" \
+    --arg route "${REVIEW_ROUTE:-}" \
     --arg prev "$previous_head_sha" \
     '{version: 1, head_sha: $head, base_sha: $base, review_scope: $scope, review_result: $result}
      + (if $checks == "" or $checks == "none" then {} else {required_checks: $checks} end)
+     + (if $route == "" or $route == "legacy" then {} else {review_route: $route} end)
      + (if $scope == "incremental" and $prev != "" then {previous_head_sha: $prev} else {} end)')"
   printf '<!-- ai-pr-reviewer:%s -->' "$marker_json"
 }

--- a/scripts/run_review.sh
+++ b/scripts/run_review.sh
@@ -102,6 +102,16 @@ ON_MODEL_FAILURE="${ON_MODEL_FAILURE:-fail}"
 VERDICT_POLICY="${VERDICT_POLICY:-model}"
 VALIDATE_REQUIRED_CHECKS="${VALIDATE_REQUIRED_CHECKS:-auto}"
 REQUIRED_CHECK_VALIDATION_MODE="${REQUIRED_CHECK_VALIDATION_MODE:-warn}"
+REVIEW_ROUTING_MODE="${REVIEW_ROUTING_MODE:-off}"
+AI_FAST_BASE_URL="${AI_FAST_BASE_URL:-}"
+AI_FAST_MODEL="${AI_FAST_MODEL:-}"
+AI_FAST_API_FORMAT="${AI_FAST_API_FORMAT:-}"
+AI_FAST_API_KEY="${AI_FAST_API_KEY:-}"
+AI_SMART_BASE_URL="${AI_SMART_BASE_URL:-}"
+AI_SMART_MODEL="${AI_SMART_MODEL:-}"
+AI_SMART_API_FORMAT="${AI_SMART_API_FORMAT:-}"
+AI_SMART_API_KEY="${AI_SMART_API_KEY:-}"
+ESCALATE_ON_RISK_FLAGS="${ESCALATE_ON_RISK_FLAGS:-linked_security_issue,linked_priority_p0,linked_priority_p1,auth_changes,public_route_changes,file_serving_changes,path_handling_changes,secret_handling_changes,db_or_migration_changes}"
 REVIEW_SCOPE="${REVIEW_SCOPE:-auto}"
 EFFECTIVE_SCOPE="${EFFECTIVE_SCOPE:-full}"
 PREVIOUS_HEAD_SHA="${PREVIOUS_HEAD_SHA:-}"
@@ -276,6 +286,23 @@ case "$(printf '%s' "$REQUIRED_CHECK_VALIDATION_MODE" | tr '[:upper:]' '[:lower:
     REQUIRED_CHECK_VALIDATION_MODE=warn
     ;;
 esac
+
+case "$(printf '%s' "$REVIEW_ROUTING_MODE" | tr '[:upper:]' '[:lower:]')" in
+  off|auto) REVIEW_ROUTING_MODE="$(printf '%s' "$REVIEW_ROUTING_MODE" | tr '[:upper:]' '[:lower:]')" ;;
+  *)
+    error "Invalid REVIEW_ROUTING_MODE '$REVIEW_ROUTING_MODE'; defaulting to off"
+    REVIEW_ROUTING_MODE=off
+    ;;
+esac
+
+if [[ -n "$AI_FAST_API_FORMAT" ]] && ! AI_FAST_API_FORMAT="$(normalize_api_format "$AI_FAST_API_FORMAT")"; then
+  error "Invalid AI_FAST_API_FORMAT '$AI_FAST_API_FORMAT'; expected openai or anthropic"
+  exit 1
+fi
+if [[ -n "$AI_SMART_API_FORMAT" ]] && ! AI_SMART_API_FORMAT="$(normalize_api_format "$AI_SMART_API_FORMAT")"; then
+  error "Invalid AI_SMART_API_FORMAT '$AI_SMART_API_FORMAT'; expected openai or anthropic"
+  exit 1
+fi
 
 if [[ -n "$AI_FALLBACK_BASE_URL" && -z "$AI_FALLBACK_MODEL" ]]; then
   error "AI_FALLBACK_MODEL is required when AI_FALLBACK_BASE_URL is set"
@@ -896,6 +923,77 @@ else
 fi
 section_timer_end
 
+# ── Model routing (#159) ─────────────────────────────────────────────
+# With review_routing_mode=auto, low-risk PRs go to the fast model and PRs
+# whose pr_kind or risk_flags match ESCALATE_ON_RISK_FLAGS go straight to the
+# smart model. The fast config defaults to the primary model; the smart config
+# defaults to the fallback model. Routing only rebinds which model the
+# existing retry/fallback machinery talks to — that machinery is unchanged.
+resolve_review_route() {
+  REVIEW_ROUTE="legacy"
+  ROUTE_REASON="routing off"
+  if [[ "$(printf '%s' "$REVIEW_ROUTING_MODE" | tr '[:upper:]' '[:lower:]')" != "auto" ]]; then
+    return
+  fi
+
+  local kind flags candidates matched="" raw_flag flag
+  kind="$(jq -r '.pr_kind // ""' classification.json 2>/dev/null || echo "")"
+  flags="$(jq -r '(.risk_flags // []) | join(",")' classification.json 2>/dev/null || echo "")"
+  # Match against the union of pr_kind and risk_flags: the default escalation
+  # list mixes kind names (auth_changes, ...) and flag names (linked_*).
+  candidates=",${kind},${flags},"
+
+  IFS=',' read -ra _esc_flags <<< "$ESCALATE_ON_RISK_FLAGS"
+  for raw_flag in "${_esc_flags[@]}"; do
+    flag="$(printf '%s' "$raw_flag" | xargs)"
+    [ -n "$flag" ] || continue
+    if [[ "$candidates" == *",${flag},"* ]]; then
+      matched="$flag"
+      break
+    fi
+  done
+
+  if [[ -n "$matched" ]]; then
+    if [[ -n "$SMART_MODEL_RESOLVED" ]]; then
+      REVIEW_ROUTE="smart"
+      ROUTE_REASON="risk match: ${matched}"
+    else
+      REVIEW_ROUTE="fast"
+      ROUTE_REASON="risk match: ${matched}, but no smart model configured"
+    fi
+  else
+    REVIEW_ROUTE="fast"
+    ROUTE_REASON="no escalation flags matched"
+  fi
+}
+
+# Fast defaults to the primary config; smart defaults to the fallback config.
+FAST_BASE_URL="${AI_FAST_BASE_URL:-$AI_BASE_URL}"
+FAST_MODEL="${AI_FAST_MODEL:-$AI_MODEL}"
+FAST_API_FORMAT="${AI_FAST_API_FORMAT:-$AI_API_FORMAT}"
+FAST_API_KEY="${AI_FAST_API_KEY:-$AI_API_KEY}"
+SMART_BASE_URL="${AI_SMART_BASE_URL:-$AI_FALLBACK_BASE_URL}"
+SMART_MODEL="${AI_SMART_MODEL:-$AI_FALLBACK_MODEL}"
+SMART_API_FORMAT="${AI_SMART_API_FORMAT:-${AI_FALLBACK_API_FORMAT:-$AI_API_FORMAT}}"
+SMART_API_KEY="${AI_SMART_API_KEY:-$AI_FALLBACK_API_KEY}"
+SMART_MODEL_RESOLVED=""
+if [[ -n "$SMART_BASE_URL" && -n "$SMART_MODEL" ]]; then
+  SMART_MODEL_RESOLVED=1
+fi
+
+resolve_review_route
+if [[ "$REVIEW_ROUTE" == "fast" ]]; then
+  AI_BASE_URL="$FAST_BASE_URL"
+  AI_MODEL="$FAST_MODEL"
+  AI_API_FORMAT="$FAST_API_FORMAT"
+  AI_API_KEY="$FAST_API_KEY"
+elif [[ "$REVIEW_ROUTE" == "smart" ]]; then
+  AI_BASE_URL="$SMART_BASE_URL"
+  AI_MODEL="$SMART_MODEL"
+  AI_API_FORMAT="$SMART_API_FORMAT"
+  AI_API_KEY="$SMART_API_KEY"
+fi
+log "Review route: $REVIEW_ROUTE ($ROUTE_REASON) → $AI_MODEL"
 
 log "Building review corpus..."
 : > standards-context.md
@@ -1271,6 +1369,7 @@ echo "analysis_engine=$ANALYSIS_ENGINE" >> "$OUTPUT_FILE"
 echo "verdict=$(jq -r '.verdict' ai-output.json)" >> "$OUTPUT_FILE"
 echo "verdict_source=$(jq -r '.verdict_source // "model"' ai-output.json)" >> "$OUTPUT_FILE"
 echo "required_checks=$(jq -r '.required_checks // "none"' ai-output.json)" >> "$OUTPUT_FILE"
+echo "review_route=${REVIEW_ROUTE:-legacy}" >> "$OUTPUT_FILE"
 
 # Use a random heredoc delimiter so model-controlled review text (which can be
 # influenced by prompt injection in the PR diff/title/body) cannot terminate the
@@ -1348,6 +1447,7 @@ write_step_summary() {
     echo "| Verdict | ${verdict} (source: ${verdict_source}) |"
     echo "| Findings | ${findings_count} (blockers: ${blockers_count}) |"
     echo "| Required checks | ${required_checks_status} |"
+    echo "| Route | ${REVIEW_ROUTE:-legacy} (${ROUTE_REASON:-}) |"
     echo "| Scope | ${EFFECTIVE_SCOPE} |"
     echo "| Budget | ${budget_desc} |"
     echo "| Diff bytes | ${diff_bytes} (truncated: ${diff_trunc}) |"

--- a/tests/test_review_routing.sh
+++ b/tests/test_review_routing.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Bash >= 4 required: empty-array expansion under `set -u` and other 4.x
+# behaviors break on macOS stock bash 3.2. Skip (not fail) so local runs
+# explain themselves; CI runs bash 5.
+if [ -z "${BASH_VERSINFO:-}" ] || [ "${BASH_VERSINFO[0]}" -lt 4 ]; then
+  echo "SKIP: bash >= 4 required (found ${BASH_VERSION:-unknown}); on macOS run with PATH=\"/opt/homebrew/bin:\$PATH\"" >&2
+  exit 0
+fi
+
+# Tests for fast/smart model routing (#159): resolve_review_route() extracted
+# from run_review.sh, plus wiring assertions.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+PASS=0
+FAIL=0
+check() {
+  local desc="$1" result="$2" expected="$3"
+  if [[ "$result" == "$expected" ]]; then
+    echo "  PASS: $desc"; PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc (got '$result', expected '$expected')"; FAIL=$((FAIL + 1))
+  fi
+}
+check_contains() {
+  local desc="$1" haystack="$2" needle="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    echo "  PASS: $desc"; PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc (expected to contain '$needle')"; FAIL=$((FAIL + 1))
+  fi
+}
+
+# Extract resolve_review_route from run_review.sh (same pattern as
+# test_context_budget.sh / test_classification_steering.sh).
+FUNCS="$(mktemp)"
+WORKDIR="$(mktemp -d)"
+trap 'rm -f "$FUNCS"; rm -rf "$WORKDIR"' EXIT
+python3 - "$ROOT_DIR/scripts/run_review.sh" "$FUNCS" <<'PY'
+import re, sys
+src = open(sys.argv[1]).read()
+m = re.search(r"^resolve_review_route\(\) \{\n(.*?)\n\}", src, re.S | re.M)
+if not m:
+    sys.exit("could not extract resolve_review_route")
+open(sys.argv[2], "w").write("resolve_review_route() {\n%s\n}\n" % m.group(1))
+PY
+# shellcheck source=/dev/null
+source "$FUNCS"
+
+cd "$WORKDIR"
+DEFAULT_FLAGS="linked_security_issue,linked_priority_p0,linked_priority_p1,auth_changes,public_route_changes,file_serving_changes,path_handling_changes,secret_handling_changes,db_or_migration_changes"
+
+route_for() {
+  # $1 = routing mode, $2 = pr_kind, $3 = risk_flags csv, $4 = smart resolved, [$5 = escalate list]
+  local flags_json="[]"
+  if [ -n "$3" ]; then
+    flags_json="$(printf '%s' "$3" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read().split(",")))')"
+  fi
+  printf '{"pr_kind": "%s", "risk_flags": %s}' "$2" "$flags_json" > classification.json
+  REVIEW_ROUTING_MODE="$1" \
+  SMART_MODEL_RESOLVED="$4" \
+  ESCALATE_ON_RISK_FLAGS="${5:-$DEFAULT_FLAGS}" \
+  REVIEW_ROUTE="" ROUTE_REASON=""
+  REVIEW_ROUTING_MODE="$1" SMART_MODEL_RESOLVED="$4" ESCALATE_ON_RISK_FLAGS="${5:-$DEFAULT_FLAGS}" resolve_review_route
+  echo "$REVIEW_ROUTE"
+}
+
+echo "=== Test: routing off → legacy ==="
+check "off mode is legacy" "$(route_for off auth_changes "" 1)" "legacy"
+check "default-ish empty mode handled upstream (off)" "$(route_for off app_code "" 1)" "legacy"
+
+echo ""
+echo "=== Test: auto + low risk → fast ==="
+check "app_code with no flags routes fast" "$(route_for auto app_code "" 1)" "fast"
+check "renovate digest routes fast" "$(route_for auto renovate_digest_only "" 1)" "fast"
+
+echo ""
+echo "=== Test: auto + risky pr_kind → smart ==="
+check "auth_changes kind routes smart" "$(route_for auto auth_changes "" 1)" "smart"
+check "db_or_migration_changes kind routes smart" "$(route_for auto db_or_migration_changes "" 1)" "smart"
+
+echo ""
+echo "=== Test: auto + risky flag on benign kind → smart (union matching) ==="
+check "app_code with linked_security_issue flag routes smart" \
+  "$(route_for auto app_code "linked_security_issue" 1)" "smart"
+check "app_code with path_handling_changes flag routes smart" \
+  "$(route_for auto app_code "other_flag,path_handling_changes" 1)" "smart"
+
+echo ""
+echo "=== Test: smart route without smart config stays fast ==="
+check "risky PR without smart model stays fast" "$(route_for auto auth_changes "" "")" "fast"
+
+echo ""
+echo "=== Test: custom escalation list ==="
+check "custom list: kind not in list routes fast" \
+  "$(route_for auto auth_changes "" 1 "db_or_migration_changes")" "fast"
+check "custom list: matching kind routes smart" \
+  "$(route_for auto db_or_migration_changes "" 1 "db_or_migration_changes")" "smart"
+
+echo ""
+echo "=== Test: wiring ==="
+RUN_REVIEW="$(cat "$ROOT_DIR/scripts/run_review.sh")"
+check_contains "fast config defaults to primary" "$RUN_REVIEW" 'FAST_MODEL="${AI_FAST_MODEL:-$AI_MODEL}"'
+check_contains "smart config defaults to fallback" "$RUN_REVIEW" 'SMART_MODEL="${AI_SMART_MODEL:-$AI_FALLBACK_MODEL}"'
+check "review_route output emitted" "$(grep -c '^echo "review_route=' "$ROOT_DIR/scripts/run_review.sh")" "1"
+check "precheck fingerprints routing mode" "$(grep -c 'routing_mode:' "$ROOT_DIR/scripts/check_review_needed.sh")" "1"
+check "precheck fingerprints escalate flags" "$(grep -c 'escalate_flags:' "$ROOT_DIR/scripts/check_review_needed.sh")" "1"
+ACTION="$(cat "$ROOT_DIR/action.yml")"
+check_contains "action.yml declares review_routing_mode" "$ACTION" "review_routing_mode:"
+check_contains "action.yml declares ai_smart_model" "$ACTION" "ai_smart_model:"
+check_contains "action.yml declares review_route output" "$ACTION" "review_route:"
+check "publish steps receive REVIEW_ROUTE" \
+  "$(grep -c 'REVIEW_ROUTE: \${{ steps.review.outputs.review_route }}' "$ROOT_DIR/action.yml")" "3"
+check_contains "marker carries review_route" "$(cat "$ROOT_DIR/scripts/publish_helpers.sh")" "review_route"
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

Second of the three stacked feature PRs (#185 merged; next: #160 escalation stacked on this). Implements #159 as specced: routing config + selection plumbing, no multi-pass.

### Behavior
- `review_routing_mode: off` (default) — exactly today's primary/fallback behavior; `review_route` output reports `legacy`.
- `review_routing_mode: auto` — `resolve_review_route()` runs right after the deterministic classification:
  - matches the **union of `pr_kind` and `risk_flags`** against `escalate_on_risk_flags` (the default list mixes kind names and flag names, as flagged in the issue triage);
  - a match routes to the **smart** model, otherwise the **fast** model;
  - fast defaults to the primary `ai_*` config; smart defaults to the `ai_fallback_*` config; a risky PR with no smart/fallback model configured **stays on fast** with a logged reason (never fail-closed on optional config).
- Routing only rebinds `AI_BASE_URL/AI_MODEL/AI_API_FORMAT/AI_API_KEY` before the request is built — the retry loop and failure-fallback machinery are untouched and apply to whichever route won.

### Observability / correctness plumbing
- `review_route` step+action output, step-summary row (`Route | smart (risk match: auth_changes)`), and a `review_route` field in the managed metadata marker (omitted for `legacy`).
- Routing inputs are part of the precheck **config fingerprint**, so flipping routing config forces a fresh review instead of being skipped as "diff unchanged".
- Fast/smart `api_format` values are validated like the primary one.

## Tests
`tests/test_review_routing.sh` (new, auto-discovered by CI; 21 checks): extracted `resolve_review_route()` exercised for legacy mode, auto low-risk→fast, risky kind→smart, risky *flag* on benign kind→smart (union matching), missing-smart-config→fast, custom escalation lists; plus wiring assertions (defaults chain, outputs, fingerprint parts, marker field, publish-step env). Full suite green: 544 pytest + all 17 bash suites.

Closes #159
