### PR TITLE
feat: escalate insufficient fast reviews to the smart model

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,10 @@ The result is exposed as the `required_checks` output (`complete` / `incomplete`
 | `ai_smart_api_format` | API format for the smart model; defaults to `ai_fallback_api_format`, then `ai_api_format` | No | `""` |
 | `ai_smart_api_key` | API key for the smart model; defaults to `ai_fallback_api_key` | No | `""` |
 | `escalate_on_risk_flags` | Comma-separated `pr_kind`/`risk_flag` names that route to the smart model in `auto` mode | No | security/priority/auth/route/file-serving/path/secret/db list |
+| `escalate_on_incomplete_required_checks` | Escalate fast reviews with unaddressed required checks to the smart model (`auto` mode) | No | `true` |
+| `escalate_on_fast_request_changes` | Escalate fast reviews whose verdict is `request_changes` (`auto` mode) | No | `true` |
+| `escalate_on_fast_low_confidence` | Escalate low-confidence fast reviews (very short, or populated Unknowns section) (`auto` mode) | No | `true` |
+| `escalate_on_tool_or_evidence_blockers` | Escalate when evidence blockers or tool-harness failures exist (`auto` mode) | No | `true` |
 | `ai_primary_retry_delay_sec` | Delay between retries in seconds | No | `15` |
 | `allowed_source_hosts` | Comma-separated allowlist for linked URL fetching | No | `github.com,api.github.com,gitlab.com,registry.terraform.io,artifacthub.io` |
 | `system_prompt` | Optional system prompt override | No | bundled prompt |
@@ -165,7 +169,8 @@ The result is exposed as the `required_checks` output (`complete` / `incomplete`
 | `verdict` | `approve` or `request_changes` |
 | `verdict_source` | `model` or `findings`, per `verdict_policy` |
 | `required_checks` | Required-check validation status: `complete`, `incomplete`, or `none` (validation did not run) |
-| `review_route` | Model route used: `legacy` (routing off), `fast`, or `smart` |
+| `review_route` | Model route used: `legacy` (routing off), `fast`, `smart`, or `escalated` |
+| `escalation_reason` | Comma-separated escalation trigger names when `review_route` is `escalated` (empty otherwise) |
 | `findings` | Normalized structured findings as a JSON array (`[]` when the model produced none) |
 | `review_markdown` | Full markdown review body |
 | `analysis_engine` | Model and endpoint that produced the final result |
@@ -647,6 +652,17 @@ Routing rules:
 - `off` (the default) preserves the existing primary/fallback behavior exactly (`review_route` output reports `legacy`).
 - The retry and failure-fallback machinery is unchanged — routing only picks which model it talks to.
 - The chosen route appears in the `review_route` output, the step summary, and the managed metadata marker; routing config is part of the precheck fingerprint, so changing it forces a fresh review.
+
+#### Escalation of insufficient fast reviews
+
+In `auto` mode, a fast review can also be **escalated after the fact**: the action evaluates the raw fast output and re-runs the review on the smart model when any enabled trigger fires:
+
+- `escalate_on_fast_request_changes` — the fast model wants changes; let the smart model confirm or overturn before a human is summoned.
+- `escalate_on_incomplete_required_checks` — the fast review never discussed one of the classifier's required checks.
+- `escalate_on_fast_low_confidence` — the review is very short or carries a populated "Unknowns or Needs Verification" section.
+- `escalate_on_tool_or_evidence_blockers` — evidence providers reported a blocker or the tool harness failed.
+
+Only the **final** review is published. The fast result is kept on the runner as `ai-output.fast.json` for debugging; if the smart model fails, the fast review is published instead (never a failed run because of escalation). `review_route` reports `escalated` and `escalation_reason` lists the trigger names; both also land in the step summary and the managed metadata marker. Worst case is two model calls per review — the unchanged-diff skip and incremental scope keep that bounded.
 
 ### Token-saving with incremental reviews
 

--- a/action.yml
+++ b/action.yml
@@ -171,6 +171,22 @@ inputs:
       when review_routing_mode=auto.
     required: false
     default: "linked_security_issue,linked_priority_p0,linked_priority_p1,auth_changes,public_route_changes,file_serving_changes,path_handling_changes,secret_handling_changes,db_or_migration_changes"
+  escalate_on_incomplete_required_checks:
+    description: Escalate a fast review to the smart model when required checks are unaddressed (review_routing_mode=auto only).
+    required: false
+    default: "true"
+  escalate_on_fast_request_changes:
+    description: Escalate a fast review to the smart model when the fast verdict is request_changes (review_routing_mode=auto only).
+    required: false
+    default: "true"
+  escalate_on_fast_low_confidence:
+    description: Escalate when the fast review is low-confidence (very short, or carries a populated Unknowns/Needs Verification section). review_routing_mode=auto only.
+    required: false
+    default: "true"
+  escalate_on_tool_or_evidence_blockers:
+    description: Escalate when evidence providers report blocker severity or the tool harness failed (review_routing_mode=auto only).
+    required: false
+    default: "true"
   ai_stream:
     description: If true, use streaming responses to avoid timeouts behind proxies with short read timeouts (e.g. Cloudflare 100s edge timer)
     required: false
@@ -384,8 +400,11 @@ outputs:
     description: Required-check validation status ('complete', 'incomplete', or 'none' when validation did not run)
     value: ${{ steps.review.outputs.required_checks }}
   review_route:
-    description: Model route used for this review ('legacy', 'fast', or 'smart')
+    description: Model route used for this review ('legacy', 'fast', 'smart', or 'escalated')
     value: ${{ steps.review.outputs.review_route }}
+  escalation_reason:
+    description: Comma-separated escalation trigger names when review_route is 'escalated' (empty otherwise)
+    value: ${{ steps.review.outputs.escalation_reason }}
   findings:
     description: Normalized structured findings as a JSON array (empty array when the model produced none)
     value: ${{ steps.review.outputs.findings }}
@@ -455,6 +474,10 @@ runs:
         AI_FAST_MODEL: ${{ inputs.ai_fast_model }}
         AI_SMART_MODEL: ${{ inputs.ai_smart_model }}
         ESCALATE_ON_RISK_FLAGS: ${{ inputs.escalate_on_risk_flags }}
+        ESCALATE_ON_INCOMPLETE_REQUIRED_CHECKS: ${{ inputs.escalate_on_incomplete_required_checks }}
+        ESCALATE_ON_FAST_REQUEST_CHANGES: ${{ inputs.escalate_on_fast_request_changes }}
+        ESCALATE_ON_FAST_LOW_CONFIDENCE: ${{ inputs.escalate_on_fast_low_confidence }}
+        ESCALATE_ON_TOOL_OR_EVIDENCE_BLOCKERS: ${{ inputs.escalate_on_tool_or_evidence_blockers }}
         ANTHROPIC_VERSION: ${{ inputs.anthropic_version }}
         SYSTEM_PROMPT: ${{ inputs.system_prompt }}
         SYSTEM_PROMPT_FILE: ${{ inputs.system_prompt_file }}
@@ -537,6 +560,10 @@ runs:
         AI_SMART_API_FORMAT: ${{ inputs.ai_smart_api_format }}
         AI_SMART_API_KEY: ${{ inputs.ai_smart_api_key }}
         ESCALATE_ON_RISK_FLAGS: ${{ inputs.escalate_on_risk_flags }}
+        ESCALATE_ON_INCOMPLETE_REQUIRED_CHECKS: ${{ inputs.escalate_on_incomplete_required_checks }}
+        ESCALATE_ON_FAST_REQUEST_CHANGES: ${{ inputs.escalate_on_fast_request_changes }}
+        ESCALATE_ON_FAST_LOW_CONFIDENCE: ${{ inputs.escalate_on_fast_low_confidence }}
+        ESCALATE_ON_TOOL_OR_EVIDENCE_BLOCKERS: ${{ inputs.escalate_on_tool_or_evidence_blockers }}
         AI_STREAM: ${{ inputs.ai_stream }}
         AI_FALLBACK_STREAM: ${{ inputs.ai_fallback_stream }}
         ALLOWED_SOURCE_HOSTS: ${{ inputs.allowed_source_hosts }}
@@ -589,6 +616,7 @@ runs:
         VERDICT: ${{ steps.review.outputs.verdict }}
         REQUIRED_CHECKS: ${{ steps.review.outputs.required_checks }}
         REVIEW_ROUTE: ${{ steps.review.outputs.review_route }}
+        ESCALATION_REASON: ${{ steps.review.outputs.escalation_reason }}
         REVIEW_MARKDOWN: ${{ steps.review.outputs.review_markdown }}
         ANALYSIS_ENGINE: ${{ steps.review.outputs.analysis_engine }}
         COMMENT_MARKER: ${{ inputs.comment_marker }}
@@ -652,6 +680,7 @@ runs:
         VERDICT: ${{ steps.review.outputs.verdict }}
         REQUIRED_CHECKS: ${{ steps.review.outputs.required_checks }}
         REVIEW_ROUTE: ${{ steps.review.outputs.review_route }}
+        ESCALATION_REASON: ${{ steps.review.outputs.escalation_reason }}
         REVIEW_MARKDOWN: ${{ steps.review.outputs.review_markdown }}
         FINDINGS: ${{ steps.review.outputs.findings }}
         INLINE_FINDINGS: ${{ inputs.inline_findings }}
@@ -753,6 +782,7 @@ runs:
         VERDICT: ${{ steps.review.outputs.verdict }}
         REQUIRED_CHECKS: ${{ steps.review.outputs.required_checks }}
         REVIEW_ROUTE: ${{ steps.review.outputs.review_route }}
+        ESCALATION_REASON: ${{ steps.review.outputs.escalation_reason }}
         REVIEW_MARKDOWN: ${{ steps.review.outputs.review_markdown }}
         FINDINGS: ${{ steps.review.outputs.findings }}
         INLINE_FINDINGS: ${{ inputs.inline_findings }}

--- a/pr_reviewer/escalation.py
+++ b/pr_reviewer/escalation.py
@@ -1,0 +1,103 @@
+"""Escalation decision for fast→smart review routing (#160).
+
+After the fast model produced a review, decide deterministically whether the
+smart model should re-review. Every trigger is boring and testable on
+purpose: verdict value, required-check keyword validation, an explicit
+Unknowns/Needs-Verification section (or a suspiciously short review), and
+blocker-level evidence/tool signals.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+from pr_reviewer.completeness import validate_review
+
+# Reviews shorter than this are treated as low-confidence regardless of
+# content — a fast model that produced two sentences did not review anything.
+LOW_CONFIDENCE_MIN_CHARS = 200
+
+# Header of the section the default prompt asks for "when evidence is
+# incomplete" — its presence with real content is the model saying it is
+# unsure.
+_UNKNOWNS_HEADER_RE = re.compile(
+    r"(?im)^#{1,6}\s*unknowns?\b[^\n]*$"
+)
+
+_EMPTY_SECTION_RE = re.compile(r"(?i)^\(?(none|n/?a|nothing)\)?[.!]?$")
+
+
+def _load(path: str) -> dict:
+    try:
+        data = json.loads(Path(path).read_text(encoding="utf-8", errors="replace"))
+        return data if isinstance(data, dict) else {}
+    except (OSError, json.JSONDecodeError, ValueError):
+        return {}
+
+
+def is_low_confidence(review_markdown: str) -> bool:
+    text = (review_markdown or "").strip()
+    if len(text) < LOW_CONFIDENCE_MIN_CHARS:
+        return True
+    match = _UNKNOWNS_HEADER_RE.search(text)
+    if match:
+        rest = text[match.end():].strip()
+        section = re.split(r"(?m)^#{1,6}\s", rest, maxsplit=1)[0].strip()
+        if section and not _EMPTY_SECTION_RE.match(section) and len(section) > 40:
+            return True
+    return False
+
+
+def _has_blocker_signals(evidence: dict, harness: dict) -> bool:
+    if evidence.get("has_blocker"):
+        return True
+    if harness.get("planning_error") is not None or harness.get("error") is not None:
+        return True
+    executed = harness.get("executed_request_count", 0)
+    results = [t for t in harness.get("tool_results", []) if isinstance(t, dict)]
+    if executed and results and not any(t.get("status") == "ok" for t in results):
+        return True
+    return False
+
+
+def should_escalate(
+    on_incomplete: bool = True,
+    on_request_changes: bool = True,
+    on_low_confidence: bool = True,
+    on_blockers: bool = True,
+    output_path: str = "ai-output.json",
+    classification_path: str = "classification.json",
+    evidence_path: str = "evidence-providers.json",
+    tool_harness_path: str = "tool-harness.json",
+) -> tuple[bool, list[str]]:
+    """Return (escalate, reasons) for the fast review in *output_path*.
+
+    Must run on the raw fast output — before verdict_policy / completeness
+    validation mutate it — so the triggers see what the model actually said.
+    """
+    data = _load(output_path)
+    review = str(data.get("review_markdown") or "")
+    reasons: list[str] = []
+
+    if on_request_changes and data.get("verdict") == "request_changes":
+        reasons.append("fast_request_changes")
+
+    if on_incomplete:
+        classification = _load(classification_path)
+        must_check = [
+            str(item) for item in (classification.get("must_check") or []) if item
+        ]
+        if must_check and not validate_review(must_check, review)["validated"]:
+            reasons.append("incomplete_required_checks")
+
+    if on_low_confidence and is_low_confidence(review):
+        reasons.append("fast_low_confidence")
+
+    if on_blockers and _has_blocker_signals(
+        _load(evidence_path), _load(tool_harness_path)
+    ):
+        reasons.append("tool_or_evidence_blockers")
+
+    return bool(reasons), reasons

--- a/scripts/publish_helpers.sh
+++ b/scripts/publish_helpers.sh
@@ -116,10 +116,12 @@ build_metadata_marker() {
     --arg result "${REVIEW_RESULT}" \
     --arg checks "${REQUIRED_CHECKS:-}" \
     --arg route "${REVIEW_ROUTE:-}" \
+    --arg esc "${ESCALATION_REASON:-}" \
     --arg prev "$previous_head_sha" \
     '{version: 1, head_sha: $head, base_sha: $base, review_scope: $scope, review_result: $result}
      + (if $checks == "" or $checks == "none" then {} else {required_checks: $checks} end)
      + (if $route == "" or $route == "legacy" then {} else {review_route: $route} end)
+     + (if $esc == "" then {} else {escalation_reason: ($esc | split(","))} end)
      + (if $scope == "incremental" and $prev != "" then {previous_head_sha: $prev} else {} end)')"
   printf '<!-- ai-pr-reviewer:%s -->' "$marker_json"
 }

--- a/scripts/run_review.sh
+++ b/scripts/run_review.sh
@@ -112,6 +112,10 @@ AI_SMART_MODEL="${AI_SMART_MODEL:-}"
 AI_SMART_API_FORMAT="${AI_SMART_API_FORMAT:-}"
 AI_SMART_API_KEY="${AI_SMART_API_KEY:-}"
 ESCALATE_ON_RISK_FLAGS="${ESCALATE_ON_RISK_FLAGS:-linked_security_issue,linked_priority_p0,linked_priority_p1,auth_changes,public_route_changes,file_serving_changes,path_handling_changes,secret_handling_changes,db_or_migration_changes}"
+ESCALATE_ON_INCOMPLETE_REQUIRED_CHECKS="${ESCALATE_ON_INCOMPLETE_REQUIRED_CHECKS:-true}"
+ESCALATE_ON_FAST_REQUEST_CHANGES="${ESCALATE_ON_FAST_REQUEST_CHANGES:-true}"
+ESCALATE_ON_FAST_LOW_CONFIDENCE="${ESCALATE_ON_FAST_LOW_CONFIDENCE:-true}"
+ESCALATE_ON_TOOL_OR_EVIDENCE_BLOCKERS="${ESCALATE_ON_TOOL_OR_EVIDENCE_BLOCKERS:-true}"
 REVIEW_SCOPE="${REVIEW_SCOPE:-auto}"
 EFFECTIVE_SCOPE="${EFFECTIVE_SCOPE:-full}"
 PREVIOUS_HEAD_SHA="${PREVIOUS_HEAD_SHA:-}"
@@ -303,6 +307,11 @@ if [[ -n "$AI_SMART_API_FORMAT" ]] && ! AI_SMART_API_FORMAT="$(normalize_api_for
   error "Invalid AI_SMART_API_FORMAT '$AI_SMART_API_FORMAT'; expected openai or anthropic"
   exit 1
 fi
+
+ESCALATE_ON_INCOMPLETE_REQUIRED_CHECKS="$(printf '%s' "$ESCALATE_ON_INCOMPLETE_REQUIRED_CHECKS" | tr '[:upper:]' '[:lower:]')"
+ESCALATE_ON_FAST_REQUEST_CHANGES="$(printf '%s' "$ESCALATE_ON_FAST_REQUEST_CHANGES" | tr '[:upper:]' '[:lower:]')"
+ESCALATE_ON_FAST_LOW_CONFIDENCE="$(printf '%s' "$ESCALATE_ON_FAST_LOW_CONFIDENCE" | tr '[:upper:]' '[:lower:]')"
+ESCALATE_ON_TOOL_OR_EVIDENCE_BLOCKERS="$(printf '%s' "$ESCALATE_ON_TOOL_OR_EVIDENCE_BLOCKERS" | tr '[:upper:]' '[:lower:]')"
 
 if [[ -n "$AI_FALLBACK_BASE_URL" && -z "$AI_FALLBACK_MODEL" ]]; then
   error "AI_FALLBACK_MODEL is required when AI_FALLBACK_BASE_URL is set"
@@ -1352,6 +1361,84 @@ else
   fi
 fi
 
+# ── Escalation (#160) ────────────────────────────────────────────────
+# When the fast route produced this review and a configured trigger fires
+# (request_changes, unaddressed required checks, low confidence, blocker
+# signals), re-run the review on the smart model and publish only that
+# result. The fast output is kept as ai-output.fast.json for debugging. A
+# smart-model failure keeps the fast review — strictly better than failing.
+ESCALATION_REASONS=""
+maybe_escalate_review() {
+  [[ "$REVIEW_ROUTING_MODE" == "auto" ]] || return 0
+  [[ "${REVIEW_ROUTE:-legacy}" == "fast" ]] || return 0
+  [[ -n "$SMART_MODEL_RESOLVED" ]] || return 0
+  if [[ "$SMART_BASE_URL" == "$AI_BASE_URL" && "$SMART_MODEL" == "$AI_MODEL" ]]; then
+    return 0  # nothing distinct to escalate to
+  fi
+
+  # Decide on the RAW fast output, before verdict policy / completeness
+  # validation / enforcement mutate it.
+  local decision
+  decision="$(PYTHONPATH="${SCRIPT_DIR}/.." python3 -c "
+from pr_reviewer.escalation import should_escalate
+escalate, reasons = should_escalate(
+    on_incomplete=('$ESCALATE_ON_INCOMPLETE_REQUIRED_CHECKS' == 'true'),
+    on_request_changes=('$ESCALATE_ON_FAST_REQUEST_CHANGES' == 'true'),
+    on_low_confidence=('$ESCALATE_ON_FAST_LOW_CONFIDENCE' == 'true'),
+    on_blockers=('$ESCALATE_ON_TOOL_OR_EVIDENCE_BLOCKERS' == 'true'),
+)
+print('yes ' + ','.join(reasons) if escalate else 'no')
+" 2>/dev/null || echo no)"
+  if [[ "$decision" == "no" || -z "$decision" ]]; then
+    log "No escalation triggers fired; keeping the fast review"
+    return 0
+  fi
+  ESCALATION_REASONS="${decision#yes }"
+  log "Escalating to smart model $SMART_MODEL ($ESCALATION_REASONS)"
+
+  cp ai-output.json ai-output.fast.json
+
+  local escalated_user
+  escalated_user="$USER_MESSAGE
+This is an ESCALATED review: a faster preliminary review was judged insufficient (${ESCALATION_REASONS}). Review thoroughly and address every required check explicitly."
+
+  build_model_request \
+    "$SMART_API_FORMAT" \
+    "$SMART_MODEL" \
+    "$SYSTEM_PROMPT" \
+    "$escalated_user" \
+    review-corpus.truncated.md \
+    ai-request.smart.json \
+    "$STREAM_BOOL"
+
+  local attempt smart_ok=0
+  for attempt in 1 2; do
+    echo "Smart model attempt ${attempt}/2: $SMART_MODEL @ $SMART_BASE_URL ($SMART_API_FORMAT)"
+    if curl_model "$SMART_BASE_URL" "$SMART_API_KEY" "$SMART_API_FORMAT" ai-request.smart.json ai-response.smart.json "$STREAM_BOOL" "$AI_REQUEST_TIMEOUT_SEC" "$AI_CONNECT_TIMEOUT_SEC"; then
+      if { [[ "$STREAM_BOOL" != "true" ]] || reassemble_sse_response ai-response.smart.json "$SMART_API_FORMAT"; } && \
+        parse_and_validate ai-response.smart.json; then
+        smart_ok=1
+        break
+      fi
+    fi
+    sleep "$AI_PRIMARY_RETRY_DELAY_SEC"
+  done
+
+  if [[ "$smart_ok" -eq 1 ]]; then
+    REVIEW_ROUTE="escalated"
+    ROUTE_REASON="escalated: ${ESCALATION_REASONS}"
+    ANALYSIS_ENGINE="$SMART_MODEL@$SMART_BASE_URL ($SMART_API_FORMAT)"
+    log "Smart model succeeded; publishing the escalated review"
+  else
+    # parse_and_validate only rewrites ai-output.json on success, but restore
+    # defensively so a partial write can never replace the fast review.
+    cp ai-output.fast.json ai-output.json
+    ESCALATION_REASONS=""
+    log "Smart model failed after escalation; publishing the fast review"
+  fi
+}
+maybe_escalate_review
+
 EVIDENCE_BLOCKER_ENABLED="false"
 if [[ "$(printf '%s' "$EVIDENCE_BLOCKER_ENFORCEMENT" | tr '[:upper:]' '[:lower:]')" == "true" ]]; then
   EVIDENCE_BLOCKER_ENABLED="true"
@@ -1370,6 +1457,7 @@ echo "verdict=$(jq -r '.verdict' ai-output.json)" >> "$OUTPUT_FILE"
 echo "verdict_source=$(jq -r '.verdict_source // "model"' ai-output.json)" >> "$OUTPUT_FILE"
 echo "required_checks=$(jq -r '.required_checks // "none"' ai-output.json)" >> "$OUTPUT_FILE"
 echo "review_route=${REVIEW_ROUTE:-legacy}" >> "$OUTPUT_FILE"
+echo "escalation_reason=${ESCALATION_REASONS:-}" >> "$OUTPUT_FILE"
 
 # Use a random heredoc delimiter so model-controlled review text (which can be
 # influenced by prompt injection in the PR diff/title/body) cannot terminate the

--- a/tests/test_escalation.py
+++ b/tests/test_escalation.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Tests for pr_reviewer.escalation — fast→smart escalation triggers (#160)."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+import pytest
+
+from pr_reviewer.escalation import is_low_confidence, should_escalate
+
+
+GOOD_REVIEW = (
+    "## Recommendation\nApprove.\n\n"
+    "The auth flow is unchanged for existing sessions and token rotation is "
+    "preserved. Path sanitization uses realpath with containment checks, so "
+    "directory traversal via ../ or symlinks is rejected. Tests cover the new "
+    "edge cases and the migration carries no destructive statements.\n\n"
+    "## Standards Compliance\nFollows repository conventions throughout."
+)
+
+
+def _write_fast_output(tmp_path, verdict="approve", review=GOOD_REVIEW):
+    (tmp_path / "ai-output.json").write_text(
+        json.dumps({"verdict": verdict, "review_markdown": review})
+    )
+
+
+def _write_classification(tmp_path, must_check=None):
+    (tmp_path / "classification.json").write_text(
+        json.dumps({"pr_kind": "app_code", "must_check": must_check or []})
+    )
+
+
+class TestIsLowConfidence:
+    def test_substantial_review_is_confident(self):
+        assert is_low_confidence(GOOD_REVIEW) is False
+
+    def test_tiny_review_is_low_confidence(self):
+        assert is_low_confidence("LGTM, approve.") is True
+
+    def test_populated_unknowns_section_is_low_confidence(self):
+        review = GOOD_REVIEW + (
+            "\n\n## Unknowns or Needs Verification\n"
+            "Could not verify the upstream release notes; the changelog fetch "
+            "failed and the compare endpoint returned an error."
+        )
+        assert is_low_confidence(review) is True
+
+    def test_empty_unknowns_section_is_confident(self):
+        review = GOOD_REVIEW + "\n\n## Unknowns or Needs Verification\nNone."
+        assert is_low_confidence(review) is False
+
+    def test_unknowns_followed_by_next_header_only(self):
+        review = GOOD_REVIEW + "\n\n## Unknowns\nN/A\n\n## Sources\n- corpus"
+        assert is_low_confidence(review) is False
+
+
+class TestShouldEscalate:
+    def test_clean_confident_review_does_not_escalate(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _write_fast_output(tmp_path)
+        _write_classification(tmp_path)
+        escalate, reasons = should_escalate()
+        assert escalate is False and reasons == []
+
+    def test_request_changes_triggers(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _write_fast_output(tmp_path, verdict="request_changes")
+        _write_classification(tmp_path)
+        escalate, reasons = should_escalate()
+        assert escalate is True
+        assert "fast_request_changes" in reasons
+
+    def test_request_changes_trigger_can_be_disabled(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _write_fast_output(tmp_path, verdict="request_changes")
+        _write_classification(tmp_path)
+        escalate, reasons = should_escalate(on_request_changes=False)
+        assert escalate is False
+
+    def test_incomplete_required_checks_trigger(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _write_fast_output(
+            tmp_path,
+            review="A long enough review that talks about code style and naming "
+            "conventions in detail but never the required security topics. "
+            "It rambles for a while to clear the low-confidence length bar "
+            "and looks plausible without addressing what matters here.",
+        )
+        _write_classification(
+            tmp_path, must_check=["verify file path sanitization"]
+        )
+        escalate, reasons = should_escalate()
+        assert "incomplete_required_checks" in reasons
+
+    def test_low_confidence_trigger(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _write_fast_output(tmp_path, review="Approve. Short.")
+        _write_classification(tmp_path)
+        escalate, reasons = should_escalate()
+        assert "fast_low_confidence" in reasons
+
+    def test_evidence_blocker_trigger(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _write_fast_output(tmp_path)
+        _write_classification(tmp_path)
+        (tmp_path / "evidence-providers.json").write_text(
+            json.dumps({"has_blocker": True, "providers": []})
+        )
+        escalate, reasons = should_escalate()
+        assert reasons == ["tool_or_evidence_blockers"]
+
+    def test_tool_harness_failure_trigger(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _write_fast_output(tmp_path)
+        _write_classification(tmp_path)
+        (tmp_path / "tool-harness.json").write_text(
+            json.dumps({"planning_error": "planner timed out", "tool_results": []})
+        )
+        escalate, reasons = should_escalate()
+        assert reasons == ["tool_or_evidence_blockers"]
+
+    def test_all_tool_requests_failed_trigger(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _write_fast_output(tmp_path)
+        _write_classification(tmp_path)
+        (tmp_path / "tool-harness.json").write_text(
+            json.dumps({
+                "executed_request_count": 2,
+                "tool_results": [{"status": "error"}, {"status": "error"}],
+            })
+        )
+        escalate, reasons = should_escalate()
+        assert reasons == ["tool_or_evidence_blockers"]
+
+    def test_multiple_reasons_accumulate(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _write_fast_output(tmp_path, verdict="request_changes", review="Too short.")
+        _write_classification(tmp_path)
+        escalate, reasons = should_escalate()
+        assert escalate is True
+        assert set(reasons) >= {"fast_request_changes", "fast_low_confidence"}
+
+    def test_all_triggers_disabled(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _write_fast_output(tmp_path, verdict="request_changes", review="Short.")
+        _write_classification(tmp_path, must_check=["verify file path sanitization"])
+        escalate, reasons = should_escalate(
+            on_incomplete=False,
+            on_request_changes=False,
+            on_low_confidence=False,
+            on_blockers=False,
+        )
+        assert escalate is False and reasons == []
+
+    def test_missing_files_do_not_escalate(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _write_fast_output(tmp_path)
+        escalate, reasons = should_escalate()
+        assert escalate is False
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_review_escalation.sh
+++ b/tests/test_review_escalation.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Bash >= 4 required: empty-array expansion under `set -u` and other 4.x
+# behaviors break on macOS stock bash 3.2. Skip (not fail) so local runs
+# explain themselves; CI runs bash 5.
+if [ -z "${BASH_VERSINFO:-}" ] || [ "${BASH_VERSINFO[0]}" -lt 4 ]; then
+  echo "SKIP: bash >= 4 required (found ${BASH_VERSION:-unknown}); on macOS run with PATH=\"/opt/homebrew/bin:\$PATH\"" >&2
+  exit 0
+fi
+
+# Wiring tests for fast→smart escalation (#160). Decision logic is covered in
+# tests/test_escalation.py; these assert the orchestration contracts.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+RUN_REVIEW="$ROOT_DIR/scripts/run_review.sh"
+
+PASS=0
+FAIL=0
+check() {
+  local desc="$1" result="$2" expected="$3"
+  if [[ "$result" == "$expected" ]]; then
+    echo "  PASS: $desc"; PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc (got '$result', expected '$expected')"; FAIL=$((FAIL + 1))
+  fi
+}
+check_contains() {
+  local desc="$1" haystack="$2" needle="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    echo "  PASS: $desc"; PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc (expected to contain '$needle')"; FAIL=$((FAIL + 1))
+  fi
+}
+
+SRC="$(cat "$RUN_REVIEW")"
+ACTION="$(cat "$ROOT_DIR/action.yml")"
+
+echo "=== Escalation gating ==="
+check_contains "escalation requires auto routing" "$SRC" '[[ "$REVIEW_ROUTING_MODE" == "auto" ]] || return 0'
+check_contains "escalation requires the fast route" "$SRC" '[[ "${REVIEW_ROUTE:-legacy}" == "fast" ]] || return 0'
+check_contains "escalation requires a smart model" "$SRC" '[[ -n "$SMART_MODEL_RESOLVED" ]] || return 0'
+check_contains "no-op when smart equals the active fast config" "$SRC" 'nothing distinct to escalate to'
+
+echo ""
+echo "=== Decision and publication contracts ==="
+check_contains "decision made by pr_reviewer.escalation" "$SRC" "from pr_reviewer.escalation import should_escalate"
+check_contains "decision runs on the raw fast output (before mutation)" "$SRC" "before verdict policy / completeness"
+check_contains "fast output preserved as ai-output.fast.json" "$SRC" "cp ai-output.json ai-output.fast.json"
+check_contains "escalated prompt names the reasons" "$SRC" "ESCALATED review"
+check_contains "smart failure restores the fast review" "$SRC" "cp ai-output.fast.json ai-output.json"
+check_contains "smart failure publishes the fast review" "$SRC" "publishing the fast review"
+check_contains "route becomes escalated on success" "$SRC" 'REVIEW_ROUTE="escalated"'
+check "escalation_reason output emitted" "$(grep -c '^echo "escalation_reason=' "$RUN_REVIEW")" "1"
+# Escalation must be decided before the enforcement wrapper runs.
+ESC_LINE="$(grep -n '^maybe_escalate_review$' "$RUN_REVIEW" | cut -d: -f1)"
+ENF_LINE="$(grep -n '^apply_all_enforcement_wrapper ' "$RUN_REVIEW" | cut -d: -f1)"
+if [[ -n "$ESC_LINE" && -n "$ENF_LINE" && "$ESC_LINE" -lt "$ENF_LINE" ]]; then
+  echo "  PASS: escalation runs before enforcement/validation"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: escalation ordering (escalate=$ESC_LINE enforce=$ENF_LINE)"
+  FAIL=$((FAIL + 1))
+fi
+
+echo ""
+echo "=== action.yml wiring ==="
+check_contains "input escalate_on_incomplete_required_checks" "$ACTION" "escalate_on_incomplete_required_checks:"
+check_contains "input escalate_on_fast_request_changes" "$ACTION" "escalate_on_fast_request_changes:"
+check_contains "input escalate_on_fast_low_confidence" "$ACTION" "escalate_on_fast_low_confidence:"
+check_contains "input escalate_on_tool_or_evidence_blockers" "$ACTION" "escalate_on_tool_or_evidence_blockers:"
+check_contains "escalation_reason output declared" "$ACTION" "escalation_reason:"
+check "publish steps receive ESCALATION_REASON" \
+  "$(grep -c 'ESCALATION_REASON: \${{ steps.review.outputs.escalation_reason }}' "$ROOT_DIR/action.yml")" "3"
+
+echo ""
+echo "=== Marker carries escalation metadata ==="
+# shellcheck source=/dev/null
+source "$ROOT_DIR/scripts/publish_helpers.sh"
+MARKER="$(HEAD_SHA=h EFFECTIVE_SCOPE=full REVIEW_RESULT=issues REQUIRED_CHECKS=incomplete \
+  REVIEW_ROUTE=escalated ESCALATION_REASON="fast_request_changes,fast_low_confidence" \
+  build_metadata_marker "b" "")"
+check_contains "marker carries review_route=escalated" "$MARKER" '"review_route":"escalated"'
+check_contains "marker carries escalation_reason array" "$MARKER" '"escalation_reason":["fast_request_changes","fast_low_confidence"]'
+PARSED="$(printf '%s' "$MARKER" | PYTHONPATH="$ROOT_DIR" python3 -c "
+import sys
+from pr_reviewer.metadata import parse_metadata
+data = parse_metadata(sys.stdin.read())
+print('unparseable' if data is None else ','.join(data.get('escalation_reason', [])))
+")"
+check "nested escalation metadata round-trips through parse_metadata" \
+  "$PARSED" "fast_request_changes,fast_low_confidence"
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

Last of the three stacked feature PRs (base: `feat/model-routing` / #186). Implements #160: true escalation, not just failure fallback.

### Flow
1. Routing (#186) picks the fast or smart model up front; direct-smart and legacy paths are untouched by this PR.
2. When the **fast** route produced the review, [pr_reviewer/escalation.py](pr_reviewer/escalation.py) evaluates the **raw fast output** — before `verdict_policy`, completeness validation, or enforcement mutate it — against four deterministic triggers, each with its own input (all default `true`, only active in `auto` mode):
   - `escalate_on_fast_request_changes` — fast verdict is `request_changes`
   - `escalate_on_incomplete_required_checks` — reuses the #158 validator against `must_check`
   - `escalate_on_fast_low_confidence` — review under 200 chars, or a populated "Unknowns or Needs Verification" section (empty/None sections don't count)
   - `escalate_on_tool_or_evidence_blockers` — evidence `has_blocker`, tool-harness planning/error, or all tool requests failed
3. On escalation: the smart model re-reviews the same corpus with an explicit `ESCALATED review` instruction naming the fired triggers (2 attempts with the standard reassemble/parse pipeline).
4. **Publish only the final review.** The fast result stays on the runner as `ai-output.fast.json`. If the smart model fails, the fast review is restored and published — escalation can never turn a working review into a failed run.

### Guards
- No-ops unless `review_routing_mode=auto`, the route was `fast`, a smart model is configured, **and** the smart config differs from the active fast config.
- Escalation is decided and resolved *before* the verdict-policy/completeness/enforcement chain, so all of those apply to whichever review gets published.

### Metadata
`review_route` reports `escalated`; new `escalation_reason` output (comma-separated trigger names); both in the step summary; the managed marker gains `"review_route"` and an `"escalation_reason"` array — which round-trips through the nesting-safe `parse_metadata` from #184 (regression-tested).

## Tests
- `tests/test_escalation.py` (new, 16 cases): low-confidence heuristic (substantial/short/populated-Unknowns/empty-Unknowns), every trigger firing and disabled, blocker variants (evidence, planning error, all-tools-failed), reason accumulation, missing-files safety.
- `tests/test_review_escalation.sh` (new, 22 checks, auto-discovered by CI): gating conditions, decide-before-enforcement ordering, fast-output preservation + restore-on-failure, action.yml inputs/outputs/env, marker round-trip.
- Full suite green: 560 pytest + all 18 bash suites.

Closes #160
