### PR TITLE
chore: post-merge cleanup of routing/escalation rough edges

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ The result is exposed as the `required_checks` output (`complete` / `incomplete`
 | `evidence_enable_for_forks` | Allow evidence providers on cross-repository PRs | No | `false` |
 | `tool_mode` | Tool harness mode: `off` or `plan_execute_once` | No | `off` |
 | `tool_max_requests` | Maximum tool requests executed in one harness run | No | `4` |
-| `tool_planning_timeout_sec` | Timeout in seconds for tool harness planning model call | No | `30` |
+| `tool_planning_timeout_sec` | Timeout in seconds for tool harness planning model call | No | `60` |
 | `tool_planning_max_context_bytes` | Maximum corpus bytes passed to planning | No | `50000` |
 | `tool_planning_max_tokens` | Maximum completion tokens for tool harness planning call | No | `400` |
 | `tool_max_response_bytes` | Maximum bytes captured from each tool response | No | `12000` |

--- a/pr_reviewer/enforcement.py
+++ b/pr_reviewer/enforcement.py
@@ -15,7 +15,7 @@ from pathlib import Path
 def apply_evidence_blocker_enforcement(
     evidence_path: str = "evidence-providers.json",
     output_path: str = "ai-output.json",
-) -> bool:
+) -> tuple[bool, str]:
     """Override verdict to request_changes if any evidence provider reported a blocker.
 
     Parameters
@@ -27,8 +27,8 @@ def apply_evidence_blocker_enforcement(
 
     Returns
     -------
-    bool
-        True if enforcement was applied, False otherwise.
+    tuple[bool, str]
+        (applied, reason) — reason is empty when not applied.
     """
     if not Path(evidence_path).exists():
         return False, ""
@@ -48,7 +48,6 @@ def apply_evidence_blocker_enforcement(
     ids_str = ", ".join(blocker_ids)
 
     data = json.loads(Path(output_path).read_text(encoding="utf-8", errors="replace"))
-    verdict = data.get("verdict")
     markdown = str(data.get("review_markdown") or "")
 
     markdown = (
@@ -118,7 +117,7 @@ def _harness_requested_tools(tool_harness_path: str = "tool-harness.json") -> bo
 def apply_tool_harness_failure_enforcement(
     tool_harness_path: str = "tool-harness.json",
     output_path: str = "ai-output.json",
-) -> bool:
+) -> tuple[bool, str]:
     """Override verdict to request_changes if tool harness planning or execution failed.
 
     Parameters
@@ -130,8 +129,8 @@ def apply_tool_harness_failure_enforcement(
 
     Returns
     -------
-    bool
-        True if enforcement was applied, False otherwise.
+    tuple[bool, str]
+        (applied, reason) — reason is empty when not applied.
     """
     reason = _get_tool_harness_failure_reason(tool_harness_path)
     if not reason:
@@ -163,7 +162,7 @@ def apply_tool_min_successful_enforcement(
     min_required: int,
     tool_harness_path: str = "tool-harness.json",
     output_path: str = "ai-output.json",
-) -> bool:
+) -> tuple[bool, str]:
     """Override verdict to request_changes if fewer than ``min_required`` tool requests succeeded.
 
     Parameters
@@ -177,8 +176,8 @@ def apply_tool_min_successful_enforcement(
 
     Returns
     -------
-    bool
-        True if enforcement was applied, False otherwise.
+    tuple[bool, str]
+        (applied, reason) — reason is empty when not applied.
     """
     successful = _count_successful_requests(tool_harness_path)
     if successful >= min_required:

--- a/scripts/run_review.sh
+++ b/scripts/run_review.sh
@@ -85,7 +85,7 @@ EVIDENCE_ENABLE_FOR_FORKS="${EVIDENCE_ENABLE_FOR_FORKS:-false}"
 TOOL_MODE="${TOOL_MODE:-off}"
 TOOL_MAX_REQUESTS="${TOOL_MAX_REQUESTS:-4}"
 TOOL_MAX_RESPONSE_BYTES="${TOOL_MAX_RESPONSE_BYTES:-12000}"
-TOOL_PLANNING_TIMEOUT_SEC="${TOOL_PLANNING_TIMEOUT_SEC:-30}"
+TOOL_PLANNING_TIMEOUT_SEC="${TOOL_PLANNING_TIMEOUT_SEC:-60}"
 TOOL_PLANNING_MAX_CONTEXT_BYTES="${TOOL_PLANNING_MAX_CONTEXT_BYTES:-50000}"
 TOOL_PLANNING_MAX_TOKENS="${TOOL_PLANNING_MAX_TOKENS:-400}"
 TOOL_REQUEST_TIMEOUT_SEC="${TOOL_REQUEST_TIMEOUT_SEC:-20}"
@@ -1375,6 +1375,13 @@ maybe_escalate_review() {
   if [[ "$SMART_BASE_URL" == "$AI_BASE_URL" && "$SMART_MODEL" == "$AI_MODEL" ]]; then
     return 0  # nothing distinct to escalate to
   fi
+  # If the fast primary failed and the fallback produced this review, and the
+  # smart config is that same fallback (the default mapping), escalating would
+  # just re-call the model that already reviewed this corpus.
+  if [[ "${PRIMARY_OK:-0}" -ne 1 && "$SMART_BASE_URL" == "$AI_FALLBACK_BASE_URL" && "$SMART_MODEL" == "$AI_FALLBACK_MODEL" ]]; then
+    log "Skipping escalation: the fallback model that produced this review is the smart model"
+    return 0
+  fi
 
   # Decide on the RAW fast output, before verdict policy / completeness
   # validation / enforcement mutate it.
@@ -1502,6 +1509,7 @@ write_step_summary() {
   usage_file=""
   [ -f ai-response.primary.json ] && usage_file="ai-response.primary.json"
   [[ "$ANALYSIS_ENGINE" == *fallback* || "$ANALYSIS_ENGINE" == "$AI_FALLBACK_MODEL"* ]] && [ -f ai-response.fallback.json ] && usage_file="ai-response.fallback.json"
+  [[ "${REVIEW_ROUTE:-}" == "escalated" ]] && [ -f ai-response.smart.json ] && usage_file="ai-response.smart.json"
   prompt_tok="-"; comp_tok="-"
   if [ -n "$usage_file" ]; then
     prompt_tok="$(jq -r '.usage.prompt_tokens // "-"' "$usage_file" 2>/dev/null || echo -)"

--- a/tests/test_review_escalation.sh
+++ b/tests/test_review_escalation.sh
@@ -43,6 +43,8 @@ check_contains "escalation requires auto routing" "$SRC" '[[ "$REVIEW_ROUTING_MO
 check_contains "escalation requires the fast route" "$SRC" '[[ "${REVIEW_ROUTE:-legacy}" == "fast" ]] || return 0'
 check_contains "escalation requires a smart model" "$SRC" '[[ -n "$SMART_MODEL_RESOLVED" ]] || return 0'
 check_contains "no-op when smart equals the active fast config" "$SRC" 'nothing distinct to escalate to'
+check_contains "no-op when the fallback already produced the review on the smart config" "$SRC" 'the fallback model that produced this review is the smart model'
+check_contains "step summary reads smart-response usage when escalated" "$SRC" 'usage_file="ai-response.smart.json"'
 
 echo ""
 echo "=== Decision and publication contracts ==="


### PR DESCRIPTION
Fresh-eyes pass after the #169–#187 merge waves. Four small, test-backed fixes; nothing design-bearing.

## Fixes

- **Escalation double-call guard** (`scripts/run_review.sh`): when the fast primary fails and the *fallback* model produces the review, escalation could fire and re-call the smart model — which by default *is* the fallback config — re-reviewing the same corpus with the same model. Now skipped when the fallback that produced the review equals the smart config.
- **Step summary token usage**: `write_step_summary` never read `ai-response.smart.json`, so escalated runs showed `-` for prompt/completion tokens. Now picks the smart response when `review_route=escalated`.
- **`tool_planning_timeout_sec` drift**: action.yml deliberately defaults to 60 (82c4ebe, "set generously for local models") but README and the script's standalone fallback still said 30. Aligned both to 60 (no behavior change for action users).
- **`pr_reviewer/enforcement.py`**: the three `apply_*` enforcement functions are annotated `-> bool` but return `(applied, reason)` tuples since the escalation work; fixed annotations + docstrings and dropped a dead variable. No behavior change.

## Tests

- Two new source-contract checks in `tests/test_review_escalation.sh` covering the new guard and the smart-usage summary line.
- Full suite green: 560 pytest + all `tests/test_*.sh`.
