### PR TITLE
ci: bump self-review pin to v1.2.2

### DIFF
--- a/.github/workflows/ai-pr-review.yaml
+++ b/.github/workflows/ai-pr-review.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Review PR with reusable AI reviewer
         if: github.event_name == 'pull_request'
         id: review
-        uses: misospace/pr-reviewer-action@8f72b519d2aaa4824673f5f4cbaafb7aba299349 # v1.1.5
+        uses: misospace/pr-reviewer-action@ff03870002ecee692bfcfe9ad6e5dd1cb36f3ddd # v1.2.0
         with:
           github_token: ${{ steps.app-token.outputs.token }}
           ai_primary_retries: "8"


### PR DESCRIPTION
Updates the self-review workflow pin to the [v1.2.0](https://github.com/misospace/pr-reviewer-action/releases/tag/v1.2.0) release SHA (`ff03870`), per the documented release process (the stale `# v1.1.5` comment is corrected too — the previous release was actually v1.1.1).
