### PR TITLE
fix: native review cleanup never matched — match managed reviews by marker, not author

### DIFF
--- a/scripts/publish_helpers.sh
+++ b/scripts/publish_helpers.sh
@@ -39,8 +39,18 @@ resolve_cleanup_flag() {
 }
 
 # Cleanup previous managed native reviews.
-# Requires env: GH_TOKEN, REPO, PR_NUMBER
+# Requires env: GH_TOKEN, REPO, PR_NUMBER; optional COMMENT_MARKER.
 # Args: $1 = resolved cleanup flag ("true"/"false")
+#
+# Managed reviews are matched by the marker their bodies START with, never by
+# author. Author matching via `gh api user` was structurally broken: /user
+# returns 403 for installation tokens (both the default GITHUB_TOKEN and
+# GitHub App tokens), and on HTTP errors gh prints the JSON error body to
+# stdout — so the "actor" became a JSON blob that matched no review and
+# cleanup silently did nothing on every run (#190). Marker matching is safe
+# because cleanup runs before the new review is posted, so it can never touch
+# the review the current run is about to create, and it keeps working when
+# the workflow's token identity changes (e.g. default token → app token).
 cleanup_native_reviews() {
   local should_cleanup="$1"
   if [ "$should_cleanup" != "true" ]; then
@@ -48,51 +58,46 @@ cleanup_native_reviews() {
   fi
 
   echo "Cleaning up previous managed native reviews for #$PR_NUMBER"
-  CURRENT_ACTOR="$(gh api user --jq .login 2>/dev/null || echo "")"
-  if [ -z "$CURRENT_ACTOR" ]; then
-    # The default GITHUB_TOKEN is an installation token and cannot call /user
-    # (403 Resource not accessible by integration). Reviews created with it
-    # are authored by github-actions[bot], so fall back to that identity
-    # instead of silently skipping cleanup.
-    CURRENT_ACTOR="github-actions[bot]"
-    echo "  Could not resolve current actor from /user; assuming $CURRENT_ACTOR (default GITHUB_TOKEN)"
+  local reviews_json
+  if ! reviews_json="$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" --paginate 2>/dev/null)"; then
+    echo "  WARN: Could not list reviews for #$PR_NUMBER; skipping cleanup" >&2
+    return 0
   fi
-  if [ -n "$CURRENT_ACTOR" ]; then
-    # Managed bodies start with the configured marker (or, for reviews created
-    # by older action versions, the bare/JSON "<!-- ai-pr-reviewer" prefix).
-    # Matching both fixes cleanup misses when comment_marker is customized or
-    # when v1.1.x-era reviews carried only the JSON metadata marker (#162).
-    # The list query carries id and state together so no per-review GET is
-    # needed afterwards.
-    PREV_REVIEWS="$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" --paginate 2>/dev/null \
-      | jq -r --arg actor "$CURRENT_ACTOR" \
-          --arg marker "${COMMENT_MARKER:-<!-- ai-pr-reviewer -->}" \
-          '.[] | select(.user.login == $actor
-                and (((.body // "") | contains($marker))
-                     or ((.body // "") | startswith("<!-- ai-pr-reviewer"))))
-              | "\(.id)\t\(.state // "")"' 2>/dev/null || echo "")"
-    if [ -n "$PREV_REVIEWS" ]; then
-      while IFS=$'\t' read -r REVIEW_ID REVIEW_STATE; do
-        if [ -z "$REVIEW_ID" ]; then continue; fi
-        # Dismiss approval/request-changes reviews to stop stale verdicts from counting
-        if [ "$REVIEW_STATE" = "APPROVED" ] || [ "$REVIEW_STATE" = "CHANGES_REQUESTED" ]; then
-          if gh api "repos/$REPO/pulls/$PR_NUMBER/reviews/$REVIEW_ID/dismissals" --method PUT -f message="Superseded by a newer automated review for this pull request." --jq '.id' >/dev/null 2>&1; then
-            echo "  Dismissed outdated managed review #$REVIEW_ID ($REVIEW_STATE)"
-          else
-            echo "  WARN: Could not dismiss review #$REVIEW_ID (may require additional permissions)" >&2
-          fi
-        fi
-        # Update body to compact outdated stub (best-effort)
-        OUTDATED_BODY="$(printf '<!-- ai-pr-reviewer -->\n_Outdated: superseded by a newer automated review._')"
-        if ! gh api "repos/$REPO/pulls/$PR_NUMBER/reviews/$REVIEW_ID" --method PATCH -f body="$OUTDATED_BODY" >/dev/null 2>&1; then
-          echo "  WARN: Could not update review #$REVIEW_ID body (submitted reviews may be read-only)" >&2
+
+  # Managed bodies start with the configured marker (or, for reviews created
+  # by older action versions, the bare/JSON "<!-- ai-pr-reviewer" prefix).
+  # Reviews already stubbed as outdated are skipped unless they still carry a
+  # live verdict (a previous run may have patched the body but failed the
+  # dismissal). The list query carries id and state together so no per-review
+  # GET is needed afterwards.
+  PREV_REVIEWS="$(printf '%s' "$reviews_json" \
+    | jq -r --arg marker "${COMMENT_MARKER:-<!-- ai-pr-reviewer -->}" \
+        '.[] | select(((.body // "") | startswith($marker))
+                   or ((.body // "") | startswith("<!-- ai-pr-reviewer")))
+             | select(((.state // "") == "APPROVED" or (.state // "") == "CHANGES_REQUESTED")
+                   or (((.body // "") | contains("_Outdated: superseded")) | not))
+             | "\(.id)\t\(.state // "")"' 2>/dev/null || echo "")"
+  if [ -n "$PREV_REVIEWS" ]; then
+    while IFS=$'\t' read -r REVIEW_ID REVIEW_STATE; do
+      if [ -z "$REVIEW_ID" ]; then continue; fi
+      # Dismiss approval/request-changes reviews to stop stale verdicts from counting
+      if [ "$REVIEW_STATE" = "APPROVED" ] || [ "$REVIEW_STATE" = "CHANGES_REQUESTED" ]; then
+        if gh api "repos/$REPO/pulls/$PR_NUMBER/reviews/$REVIEW_ID/dismissals" --method PUT -f message="Superseded by a newer automated review for this pull request." --jq '.id' >/dev/null 2>&1; then
+          echo "  Dismissed outdated managed review #$REVIEW_ID ($REVIEW_STATE)"
         else
-          echo "  Marked review #$REVIEW_ID as outdated/superseded"
+          echo "  WARN: Could not dismiss review #$REVIEW_ID (may require additional permissions)" >&2
         fi
-      done <<< "$PREV_REVIEWS"
-    else
-      echo "  No previous managed native reviews found for #$PR_NUMBER"
-    fi
+      fi
+      # Update body to compact outdated stub (best-effort)
+      OUTDATED_BODY="$(printf '<!-- ai-pr-reviewer -->\n_Outdated: superseded by a newer automated review._')"
+      if ! gh api "repos/$REPO/pulls/$PR_NUMBER/reviews/$REVIEW_ID" --method PATCH -f body="$OUTDATED_BODY" >/dev/null 2>&1; then
+        echo "  WARN: Could not update review #$REVIEW_ID body (submitted reviews may be read-only)" >&2
+      else
+        echo "  Marked review #$REVIEW_ID as outdated/superseded"
+      fi
+    done <<< "$PREV_REVIEWS"
+  else
+    echo "  No previous managed native reviews found for #$PR_NUMBER"
   fi
 }
 

--- a/tests/test_cleanup_native_reviews_behavior.sh
+++ b/tests/test_cleanup_native_reviews_behavior.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# Bash >= 4 required: empty-array expansion under `set -u` and other 4.x
+# behaviors break on macOS stock bash 3.2. Skip (not fail) so local runs
+# explain themselves; CI runs bash 5.
+if [ -z "${BASH_VERSINFO:-}" ] || [ "${BASH_VERSINFO[0]}" -lt 4 ]; then
+  echo "SKIP: bash >= 4 required (found ${BASH_VERSION:-unknown}); on macOS run with PATH=\"/opt/homebrew/bin:\$PATH\"" >&2
+  exit 0
+fi
+
+# Behavioral tests for cleanup_native_reviews (#190): run the real function
+# against a mocked `gh` and assert which reviews get dismissed/stubbed.
+# The prior author-matching implementation passed every structural test while
+# never dismissing anything in production — these tests exercise the data path.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+PASS=0
+FAIL=0
+check_contains() {
+  local desc="$1" haystack="$2" needle="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    echo "  PASS: $desc"; PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc (expected to contain '$needle')"; FAIL=$((FAIL + 1))
+  fi
+}
+check_not_contains() {
+  local desc="$1" haystack="$2" needle="$3"
+  if [[ "$haystack" != *"$needle"* ]]; then
+    echo "  PASS: $desc"; PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc (should not contain '$needle')"; FAIL=$((FAIL + 1))
+  fi
+}
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+export CALLS_LOG="$TMP/calls.log"
+export FIXTURE="$TMP/reviews.json"
+
+# Mock gh: logs every invocation; serves the fixture for the reviews list.
+mkdir -p "$TMP/bin"
+cat > "$TMP/bin/gh" <<'MOCK'
+#!/usr/bin/env bash
+echo "$*" >> "$CALLS_LOG"
+if [ "${GH_MOCK_FAIL_LIST:-}" = "1" ] && [[ "$*" == *"/reviews --paginate"* ]]; then
+  exit 1
+fi
+case "$*" in
+  *"/reviews --paginate"*) cat "$FIXTURE" ;;
+  *"/dismissals --method PUT"*) echo '{"id": 1}' ;;
+  *"--method PATCH"*) echo '{}' ;;
+  *) echo '{}' ;;
+esac
+MOCK
+chmod +x "$TMP/bin/gh"
+export PATH="$TMP/bin:$PATH"
+
+# shellcheck source=/dev/null
+source "$ROOT_DIR/scripts/publish_helpers.sh"
+export REPO="misospace/example" PR_NUMBER=42 GH_TOKEN=dummy
+unset COMMENT_MARKER
+
+# Fixture: the realistic mix that production produced. Bodies are what the
+# publish steps actually emit (marker first line). Review 101 is authored by
+# an app bot, 102 by the default-token bot — author must not matter.
+jq -n '[
+  {id: 101, state: "APPROVED", user: {login: "its-saffron[bot]"},
+   body: "<!-- ai-pr-reviewer -->\n<!-- ai-pr-reviewer:{\"version\":1} -->\n# AI Automated Review\nLooks fine."},
+  {id: 102, state: "CHANGES_REQUESTED", user: {login: "github-actions[bot]"},
+   body: "<!-- ai-pr-reviewer:{\"version\":1} -->\nOld-era managed review."},
+  {id: 103, state: "APPROVED", user: {login: "human-reviewer"},
+   body: "LGTM, nice work"},
+  {id: 104, state: "COMMENTED", user: {login: "another-human"},
+   body: "I noticed the bot marker <!-- ai-pr-reviewer --> appears mid-body here."},
+  {id: 105, state: "DISMISSED", user: {login: "its-saffron[bot]"},
+   body: "<!-- ai-pr-reviewer -->\n_Outdated: superseded by a newer automated review._"},
+  {id: 106, state: "APPROVED", user: {login: "its-saffron[bot]"},
+   body: "<!-- ai-pr-reviewer -->\n_Outdated: superseded by a newer automated review._"}
+]' > "$FIXTURE"
+
+echo "=== Managed reviews are dismissed and stubbed regardless of author ==="
+: > "$CALLS_LOG"
+OUT="$(cleanup_native_reviews "true" 2>&1)"
+CALLS="$(cat "$CALLS_LOG")"
+check_contains "app-bot APPROVED review 101 dismissed" "$CALLS" "reviews/101/dismissals --method PUT"
+check_contains "default-bot CHANGES_REQUESTED review 102 dismissed" "$CALLS" "reviews/102/dismissals --method PUT"
+check_contains "review 101 body stubbed" "$CALLS" "reviews/101 --method PATCH"
+check_contains "review 102 body stubbed" "$CALLS" "reviews/102 --method PATCH"
+check_not_contains "human review 103 untouched" "$CALLS" "reviews/103"
+check_not_contains "mid-body marker mention 104 untouched" "$CALLS" "reviews/104"
+check_not_contains "already-dismissed stub 105 skipped" "$CALLS" "reviews/105"
+check_contains "stubbed-but-still-APPROVED 106 re-dismissed" "$CALLS" "reviews/106/dismissals --method PUT"
+check_contains "dismissals logged" "$OUT" "Dismissed outdated managed review #101"
+check_not_contains "no actor lookup performed" "$CALLS" "api user"
+
+echo ""
+echo "=== Custom comment_marker is matched at body start ==="
+: > "$CALLS_LOG"
+jq -n '[
+  {id: 201, state: "APPROVED", user: {login: "its-saffron[bot]"},
+   body: "<!-- my-custom-marker -->\nManaged with a custom marker."},
+  {id: 202, state: "APPROVED", user: {login: "human"},
+   body: "Unrelated approval"}
+]' > "$FIXTURE"
+COMMENT_MARKER="<!-- my-custom-marker -->" cleanup_native_reviews "true" >/dev/null 2>&1
+CALLS="$(cat "$CALLS_LOG")"
+check_contains "custom-marker review 201 dismissed" "$CALLS" "reviews/201/dismissals --method PUT"
+check_not_contains "human review 202 untouched" "$CALLS" "reviews/202"
+
+echo ""
+echo "=== List failure warns and returns cleanly ==="
+: > "$CALLS_LOG"
+OUT="$(GH_MOCK_FAIL_LIST=1 cleanup_native_reviews "true" 2>&1)"; RC=$?
+check_contains "warns on list failure" "$OUT" "WARN: Could not list reviews"
+[ "$RC" -eq 0 ] && { echo "  PASS: returns 0 on list failure"; PASS=$((PASS + 1)); } \
+                || { echo "  FAIL: returned $RC on list failure"; FAIL=$((FAIL + 1)); }
+CALLS="$(cat "$CALLS_LOG")"
+check_not_contains "no mutations attempted after list failure" "$CALLS" "--method"
+
+echo ""
+echo "=== Disabled flag is a no-op ==="
+: > "$CALLS_LOG"
+cleanup_native_reviews "false" >/dev/null 2>&1
+check_not_contains "no API calls when cleanup disabled" "$(cat "$CALLS_LOG")" "api"
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ]

--- a/tests/test_cleanup_previous_native_reviews.sh
+++ b/tests/test_cleanup_previous_native_reviews.sh
@@ -262,7 +262,7 @@ cat > "$CLEANUP_TMP/reviews.json" <<'JSONEOF'
   {"id": 22, "state": "CHANGES_REQUESTED", "user": {"login": "test-bot"},
    "body": "<!-- ai-pr-reviewer:{\"version\":1,\"head_sha\":\"abc\"} -->\nlegacy review"},
   {"id": 33, "state": "APPROVED", "user": {"login": "human"},
-   "body": "<!-- my-marker -->\nhuman pasted the marker"},
+   "body": "Quoting the bot here: <!-- my-marker -->\nhuman pasted the marker mid-body"},
   {"id": 44, "state": "COMMENTED", "user": {"login": "test-bot"},
    "body": "unrelated bot output"}
 ]
@@ -271,7 +271,6 @@ JSONEOF
 cat > "$CLEANUP_TMP/bin/gh" <<SHELLEOF
 #!/usr/bin/env bash
 echo "\$*" >> "$CALL_LOG"
-if [ "\$1" = "api" ] && [ "\$2" = "user" ]; then echo "test-bot"; exit 0; fi
 case "\$*" in
   *"/reviews --paginate"*) cat "$CLEANUP_TMP/reviews.json" ;;
   *dismissals*) echo '{"id": 1}' ;;
@@ -303,24 +302,31 @@ LIST_QUERIES="$(grep -c '/reviews --paginate' "$CALL_LOG" || true)"
 check "exactly one review list query" "$LIST_QUERIES" "1"
 
 echo ""
-echo "=== Functional: default GITHUB_TOKEN (no /user access) falls back to github-actions[bot] ==="
+echo "=== Functional: identity-independent matching (installation tokens) ==="
 
-# Reviews authored by github-actions[bot] — the identity used when reviews
-# were created with the default GITHUB_TOKEN, whose /user endpoint 403s.
+# Under installation tokens (default GITHUB_TOKEN and GitHub App tokens),
+# /user returns 403 — and gh prints the JSON error body to STDOUT, which is
+# how the old author-matching cleanup silently dismissed nothing on every
+# production run (#190). Matching is now marker-based and must work for any
+# bot identity without ever calling /user.
 cat > "$CLEANUP_TMP/reviews.json" <<'JSONEOF'
 [
   {"id": 55, "state": "APPROVED", "user": {"login": "github-actions[bot]"},
-   "body": "<!-- ai-pr-reviewer -->\nold bot review"},
-  {"id": 66, "state": "APPROVED", "user": {"login": "someone-else"},
-   "body": "<!-- ai-pr-reviewer -->\nnot ours"}
+   "body": "<!-- ai-pr-reviewer -->\nold default-token review"},
+  {"id": 66, "state": "APPROVED", "user": {"login": "its-saffron[bot]"},
+   "body": "<!-- ai-pr-reviewer -->\nold app-token review"},
+  {"id": 77, "state": "APPROVED", "user": {"login": "human"},
+   "body": "LGTM"}
 ]
 JSONEOF
 
+# True-to-production mock: /user prints the JSON error body to stdout and
+# exits 1 (gh api does NOT apply --jq to error responses).
 cat > "$CLEANUP_TMP/bin/gh" <<SHELLEOF
 #!/usr/bin/env bash
 echo "\$*" >> "$CALL_LOG"
 if [ "\$1" = "api" ] && [ "\$2" = "user" ]; then
-  echo "Resource not accessible by integration (HTTP 403)" >&2
+  printf '{\n  "message": "Resource not accessible by integration",\n  "status": "403"\n}\n'
   exit 1
 fi
 case "\$*" in
@@ -338,14 +344,18 @@ CLEANUP_OUTPUT="$(
   bash -c 'source "'"$HELPER_SCRIPT"'"; cleanup_native_reviews true' 2>&1
 )"
 
-check_contains "falls back to the github-actions[bot] identity" \
-  "$CLEANUP_OUTPUT" "assuming github-actions[bot]"
-check_contains "github-actions[bot] review is dismissed" \
+check_contains "default-token bot review is dismissed" \
   "$CLEANUP_OUTPUT" "Dismissed outdated managed review #55 (APPROVED)"
-check_not_contains "other users' reviews untouched" \
-  "$CLEANUP_OUTPUT" "#66"
-check_not_contains "cleanup is no longer skipped" \
+check_contains "app-token bot review is dismissed (no identity needed)" \
+  "$CLEANUP_OUTPUT" "Dismissed outdated managed review #66 (APPROVED)"
+check_not_contains "human review untouched" \
+  "$CLEANUP_OUTPUT" "#77"
+check_not_contains "cleanup is not skipped" \
   "$CLEANUP_OUTPUT" "skipping cleanup"
+check_not_contains "no identity fallback remains" \
+  "$CLEANUP_OUTPUT" "assuming github-actions"
+USER_CALLS="$(grep -c '^api user' "$CALL_LOG" || true)"
+check "no /user lookup is made" "$USER_CALLS" "0"
 
 echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="


### PR DESCRIPTION
Fixes the bug observed on misospace/dispatch#344: previous native reviews are never hidden/dismissed when a new review is posted.

## Root cause

`cleanup_native_reviews` resolved the bot identity with `gh api user --jq .login`. Two compounding failures:

1. `/user` returns **403 for installation tokens** — both the default `GITHUB_TOKEN` and GitHub App tokens (its-saffron), i.e. every deployment.
2. On HTTP errors, `gh api` prints the **JSON error body to stdout** (the `--jq` filter is not applied), so `CURRENT_ACTOR=$(gh api user --jq .login 2>/dev/null || echo "")` captured `{"message": "Resource not accessible by integration"...}` — non-empty, so the `github-actions[bot]` fallback never fired, and the author filter `user.login == $actor` matched nothing.

Result: "No previous managed native reviews found" on **every run since the feature shipped** (verified in dispatch and pr-reviewer-action run logs). The fallback was doubly broken: even had it fired, `github-actions[bot]` ≠ `its-saffron[bot]` for all app-token repos.

## Fix

Match managed reviews by the marker their bodies **start with**, with no author lookup at all. This is safe because cleanup runs before the new review is posted (it can never touch its own), and it keeps working across token-identity changes (default token → app token migrations). Also:

- A failed review-list call now logs a WARN and skips cleanup instead of silently reporting "no previous reviews".
- Already-stubbed reviews are skipped (no repeat PATCHes) unless they still carry a live APPROVED/CHANGES_REQUESTED verdict from a previously failed dismissal.
- Mid-body marker mentions (humans quoting the bot) do not match — only body-start.

## Tests

- The old functional test mocked `/user` failure as stderr+exit-1 — exactly the divergence from real `gh` that let this pass CI while dismissing nothing in production. The mock now prints the error body to stdout like production does.
- New `tests/test_cleanup_native_reviews_behavior.sh`: 16 behavioral checks running the real function against a mocked `gh` (identity-independence, custom markers, mid-body false-positives, stub idempotency, list-failure, disabled flag).
- Full suite green: 560 pytest + all shell suites.
