### PR TITLE
fix: actually hide superseded native reviews (minimize + correct body endpoint)

### DIFF
--- a/scripts/publish_helpers.sh
+++ b/scripts/publish_helpers.sh
@@ -76,9 +76,9 @@ cleanup_native_reviews() {
                    or ((.body // "") | startswith("<!-- ai-pr-reviewer")))
              | select(((.state // "") == "APPROVED" or (.state // "") == "CHANGES_REQUESTED")
                    or (((.body // "") | contains("_Outdated: superseded")) | not))
-             | "\(.id)\t\(.state // "")"' 2>/dev/null || echo "")"
+             | "\(.id)\t\(.node_id // "")\t\(.state // "")"' 2>/dev/null || echo "")"
   if [ -n "$PREV_REVIEWS" ]; then
-    while IFS=$'\t' read -r REVIEW_ID REVIEW_STATE; do
+    while IFS=$'\t' read -r REVIEW_ID REVIEW_NODE_ID REVIEW_STATE; do
       if [ -z "$REVIEW_ID" ]; then continue; fi
       # Dismiss approval/request-changes reviews to stop stale verdicts from counting
       if [ "$REVIEW_STATE" = "APPROVED" ] || [ "$REVIEW_STATE" = "CHANGES_REQUESTED" ]; then
@@ -88,10 +88,26 @@ cleanup_native_reviews() {
           echo "  WARN: Could not dismiss review #$REVIEW_ID (may require additional permissions)" >&2
         fi
       fi
-      # Update body to compact outdated stub (best-effort)
+      # Hide the review in the PR timeline. Dismissal only strikes the verdict;
+      # the full review text stays expanded without this. PullRequestReview
+      # implements GraphQL's Minimizable, the same mechanism as the UI's
+      # "Hide" menu.
+      if [ -n "$REVIEW_NODE_ID" ]; then
+        if gh api graphql \
+            -f query='mutation($id: ID!) { minimizeComment(input: {subjectId: $id, classifier: OUTDATED}) { minimizedComment { isMinimized } } }' \
+            -f id="$REVIEW_NODE_ID" >/dev/null 2>&1; then
+          echo "  Minimized (hidden as outdated) review #$REVIEW_ID"
+        else
+          echo "  WARN: Could not minimize review #$REVIEW_ID (may require additional permissions)" >&2
+        fi
+      fi
+      # Collapse the body to a one-line stub so even an expanded review stays
+      # compact (and so already-processed reviews are skipped next run). The
+      # endpoint is PUT — the previous PATCH was a 404 that the old code
+      # misreported as "reviews may be read-only".
       OUTDATED_BODY="$(printf '<!-- ai-pr-reviewer -->\n_Outdated: superseded by a newer automated review._')"
-      if ! gh api "repos/$REPO/pulls/$PR_NUMBER/reviews/$REVIEW_ID" --method PATCH -f body="$OUTDATED_BODY" >/dev/null 2>&1; then
-        echo "  WARN: Could not update review #$REVIEW_ID body (submitted reviews may be read-only)" >&2
+      if ! gh api "repos/$REPO/pulls/$PR_NUMBER/reviews/$REVIEW_ID" --method PUT -f body="$OUTDATED_BODY" >/dev/null 2>&1; then
+        echo "  WARN: Could not update review #$REVIEW_ID body" >&2
       else
         echo "  Marked review #$REVIEW_ID as outdated/superseded"
       fi

--- a/tests/test_cleanup_native_reviews_behavior.sh
+++ b/tests/test_cleanup_native_reviews_behavior.sh
@@ -52,7 +52,8 @@ fi
 case "$*" in
   *"/reviews --paginate"*) cat "$FIXTURE" ;;
   *"/dismissals --method PUT"*) echo '{"id": 1}' ;;
-  *"--method PATCH"*) echo '{}' ;;
+  *"api graphql"*) echo '{"data":{"minimizeComment":{"minimizedComment":{"isMinimized":true}}}}' ;;
+  *"--method PUT"*) echo '{}' ;;
   *) echo '{}' ;;
 esac
 MOCK
@@ -68,17 +69,17 @@ unset COMMENT_MARKER
 # publish steps actually emit (marker first line). Review 101 is authored by
 # an app bot, 102 by the default-token bot — author must not matter.
 jq -n '[
-  {id: 101, state: "APPROVED", user: {login: "its-saffron[bot]"},
+  {id: 101, node_id: "PRR_node101", state: "APPROVED", user: {login: "its-saffron[bot]"},
    body: "<!-- ai-pr-reviewer -->\n<!-- ai-pr-reviewer:{\"version\":1} -->\n# AI Automated Review\nLooks fine."},
-  {id: 102, state: "CHANGES_REQUESTED", user: {login: "github-actions[bot]"},
+  {id: 102, node_id: "PRR_node102", state: "CHANGES_REQUESTED", user: {login: "github-actions[bot]"},
    body: "<!-- ai-pr-reviewer:{\"version\":1} -->\nOld-era managed review."},
-  {id: 103, state: "APPROVED", user: {login: "human-reviewer"},
+  {id: 103, node_id: "PRR_node103", state: "APPROVED", user: {login: "human-reviewer"},
    body: "LGTM, nice work"},
-  {id: 104, state: "COMMENTED", user: {login: "another-human"},
+  {id: 104, node_id: "PRR_node104", state: "COMMENTED", user: {login: "another-human"},
    body: "I noticed the bot marker <!-- ai-pr-reviewer --> appears mid-body here."},
-  {id: 105, state: "DISMISSED", user: {login: "its-saffron[bot]"},
+  {id: 105, node_id: "PRR_node105", state: "DISMISSED", user: {login: "its-saffron[bot]"},
    body: "<!-- ai-pr-reviewer -->\n_Outdated: superseded by a newer automated review._"},
-  {id: 106, state: "APPROVED", user: {login: "its-saffron[bot]"},
+  {id: 106, node_id: "PRR_node106", state: "APPROVED", user: {login: "its-saffron[bot]"},
    body: "<!-- ai-pr-reviewer -->\n_Outdated: superseded by a newer automated review._"}
 ]' > "$FIXTURE"
 
@@ -88,22 +89,26 @@ OUT="$(cleanup_native_reviews "true" 2>&1)"
 CALLS="$(cat "$CALLS_LOG")"
 check_contains "app-bot APPROVED review 101 dismissed" "$CALLS" "reviews/101/dismissals --method PUT"
 check_contains "default-bot CHANGES_REQUESTED review 102 dismissed" "$CALLS" "reviews/102/dismissals --method PUT"
-check_contains "review 101 body stubbed" "$CALLS" "reviews/101 --method PATCH"
-check_contains "review 102 body stubbed" "$CALLS" "reviews/102 --method PATCH"
+check_contains "review 101 body stubbed via PUT" "$CALLS" "reviews/101 --method PUT"
+check_contains "review 101 minimized (hidden)" "$CALLS" "PRR_node101"
+check_contains "review 102 body stubbed via PUT" "$CALLS" "reviews/102 --method PUT"
+check_contains "review 102 minimized (hidden)" "$CALLS" "PRR_node102"
 check_not_contains "human review 103 untouched" "$CALLS" "reviews/103"
 check_not_contains "mid-body marker mention 104 untouched" "$CALLS" "reviews/104"
 check_not_contains "already-dismissed stub 105 skipped" "$CALLS" "reviews/105"
+check_not_contains "already-dismissed stub 105 not re-minimized" "$CALLS" "PRR_node105"
 check_contains "stubbed-but-still-APPROVED 106 re-dismissed" "$CALLS" "reviews/106/dismissals --method PUT"
 check_contains "dismissals logged" "$OUT" "Dismissed outdated managed review #101"
+check_contains "minimize logged" "$OUT" "Minimized (hidden as outdated) review #101"
 check_not_contains "no actor lookup performed" "$CALLS" "api user"
 
 echo ""
 echo "=== Custom comment_marker is matched at body start ==="
 : > "$CALLS_LOG"
 jq -n '[
-  {id: 201, state: "APPROVED", user: {login: "its-saffron[bot]"},
+  {id: 201, node_id: "PRR_node201", state: "APPROVED", user: {login: "its-saffron[bot]"},
    body: "<!-- my-custom-marker -->\nManaged with a custom marker."},
-  {id: 202, state: "APPROVED", user: {login: "human"},
+  {id: 202, node_id: "PRR_node202", state: "APPROVED", user: {login: "human"},
    body: "Unrelated approval"}
 ]' > "$FIXTURE"
 COMMENT_MARKER="<!-- my-custom-marker -->" cleanup_native_reviews "true" >/dev/null 2>&1

--- a/tests/test_cleanup_previous_native_reviews.sh
+++ b/tests/test_cleanup_previous_native_reviews.sh
@@ -257,13 +257,13 @@ CALL_LOG="$CLEANUP_TMP/gh-calls.log"
 # v1.1.x JSON metadata marker, 33 is a human review, 44 is unmanaged bot output.
 cat > "$CLEANUP_TMP/reviews.json" <<'JSONEOF'
 [
-  {"id": 11, "state": "APPROVED", "user": {"login": "test-bot"},
+  {"id": 11, "node_id": "PRR_node11", "state": "APPROVED", "user": {"login": "test-bot"},
    "body": "<!-- my-marker -->\n<!-- ai-pr-review-sha:abc -->\nold review"},
-  {"id": 22, "state": "CHANGES_REQUESTED", "user": {"login": "test-bot"},
+  {"id": 22, "node_id": "PRR_node22", "state": "CHANGES_REQUESTED", "user": {"login": "test-bot"},
    "body": "<!-- ai-pr-reviewer:{\"version\":1,\"head_sha\":\"abc\"} -->\nlegacy review"},
-  {"id": 33, "state": "APPROVED", "user": {"login": "human"},
+  {"id": 33, "node_id": "PRR_node33", "state": "APPROVED", "user": {"login": "human"},
    "body": "Quoting the bot here: <!-- my-marker -->\nhuman pasted the marker mid-body"},
-  {"id": 44, "state": "COMMENTED", "user": {"login": "test-bot"},
+  {"id": 44, "node_id": "PRR_node44", "state": "COMMENTED", "user": {"login": "test-bot"},
    "body": "unrelated bot output"}
 ]
 JSONEOF
@@ -274,7 +274,8 @@ echo "\$*" >> "$CALL_LOG"
 case "\$*" in
   *"/reviews --paginate"*) cat "$CLEANUP_TMP/reviews.json" ;;
   *dismissals*) echo '{"id": 1}' ;;
-  *"--method PATCH"*) echo '{}' ;;
+  *"api graphql"*) echo '{"data":{"minimizeComment":{"minimizedComment":{"isMinimized":true}}}}' ;;
+  *"--method PUT"*) echo '{}' ;;
 esac
 exit 0
 SHELLEOF
@@ -311,11 +312,11 @@ echo "=== Functional: identity-independent matching (installation tokens) ==="
 # bot identity without ever calling /user.
 cat > "$CLEANUP_TMP/reviews.json" <<'JSONEOF'
 [
-  {"id": 55, "state": "APPROVED", "user": {"login": "github-actions[bot]"},
+  {"id": 55, "node_id": "PRR_node55", "state": "APPROVED", "user": {"login": "github-actions[bot]"},
    "body": "<!-- ai-pr-reviewer -->\nold default-token review"},
-  {"id": 66, "state": "APPROVED", "user": {"login": "its-saffron[bot]"},
+  {"id": 66, "node_id": "PRR_node66", "state": "APPROVED", "user": {"login": "its-saffron[bot]"},
    "body": "<!-- ai-pr-reviewer -->\nold app-token review"},
-  {"id": 77, "state": "APPROVED", "user": {"login": "human"},
+  {"id": 77, "node_id": "PRR_node77", "state": "APPROVED", "user": {"login": "human"},
    "body": "LGTM"}
 ]
 JSONEOF
@@ -332,7 +333,8 @@ fi
 case "\$*" in
   *"/reviews --paginate"*) cat "$CLEANUP_TMP/reviews.json" ;;
   *dismissals*) echo '{"id": 1}' ;;
-  *"--method PATCH"*) echo '{}' ;;
+  *"api graphql"*) echo '{"data":{"minimizeComment":{"minimizedComment":{"isMinimized":true}}}}' ;;
+  *"--method PUT"*) echo '{}' ;;
 esac
 exit 0
 SHELLEOF
@@ -348,6 +350,8 @@ check_contains "default-token bot review is dismissed" \
   "$CLEANUP_OUTPUT" "Dismissed outdated managed review #55 (APPROVED)"
 check_contains "app-token bot review is dismissed (no identity needed)" \
   "$CLEANUP_OUTPUT" "Dismissed outdated managed review #66 (APPROVED)"
+check_contains "reviews are minimized (hidden) in the timeline" \
+  "$CLEANUP_OUTPUT" "Minimized (hidden as outdated) review #55"
 check_not_contains "human review untouched" \
   "$CLEANUP_OUTPUT" "#77"
 check_not_contains "cleanup is not skipped" \


### PR DESCRIPTION
Follow-up to #190. Dismissal worked, but dismissed reviews still showed their full text in the PR timeline — the original complaint (giant blocks of text to scroll past) was only half-fixed.

## What was wrong

1. **Dismissal ≠ hiding.** Dismissing a review only strikes the verdict; the body stays expanded in the timeline.
2. **The body-stub call never worked**: GitHub's update-review endpoint is `PUT /pulls/{n}/reviews/{id}`, but the code called `--method PATCH` → 404 on every call, misreported by the old WARN as "submitted reviews may be read-only".

## Fix

For each superseded managed review: dismiss the verdict (as before), then **minimize it via GraphQL `minimizeComment` with classifier `OUTDATED`** — the same mechanism as the UI's Hide menu (`PullRequestReview` implements `Minimizable`; verified live on misospace/dispatch#344, where the stale review now shows collapsed as "outdated"), then stub the body via `PUT` so even an expanded review is one line. With the stub functional, the skip logic from #190 engages and already-processed reviews aren't touched on subsequent runs.

## Tests

Both cleanup suites extended: mocked `gh` now serves the graphql mutation, fixtures carry `node_id`, and assertions cover minimize calls, PUT (not PATCH), skip-idempotency. 74 checks across the two suites; full suite green (560 pytest + all shell).
