### PR TITLE
fix: hide superseded reviews without rewriting their content

### DIFF
--- a/scripts/publish_helpers.sh
+++ b/scripts/publish_helpers.sh
@@ -64,21 +64,34 @@ cleanup_native_reviews() {
     return 0
   fi
 
+  # Minimized state lives only in GraphQL (the REST review list does not
+  # expose it); one query maps databaseId → isMinimized for skip logic. On
+  # failure the map is empty and minimization is simply retried (idempotent).
+  local minimized_ids
+  minimized_ids="$(gh api graphql \
+    -f query='query($owner: String!, $name: String!, $number: Int!) { repository(owner: $owner, name: $name) { pullRequest(number: $number) { reviews(first: 100) { nodes { databaseId isMinimized } } } } }' \
+    -f owner="${REPO%%/*}" -f name="${REPO#*/}" -F number="$PR_NUMBER" \
+    --jq '[.data.repository.pullRequest.reviews.nodes[] | select(.isMinimized) | .databaseId]' 2>/dev/null || echo '[]')"
+  printf '%s' "$minimized_ids" | jq -e 'type == "array"' >/dev/null 2>&1 || minimized_ids='[]'
+
   # Managed bodies start with the configured marker (or, for reviews created
   # by older action versions, the bare/JSON "<!-- ai-pr-reviewer" prefix).
-  # Reviews already stubbed as outdated are skipped unless they still carry a
-  # live verdict (a previous run may have patched the body but failed the
-  # dismissal). The list query carries id and state together so no per-review
-  # GET is needed afterwards.
+  # Review CONTENT is never modified — the review is hidden, not rewritten —
+  # so a human expanding an outdated review still sees what it said.
+  # Already-minimized reviews are skipped unless they still carry a live
+  # verdict (a previous run may have minimized but failed the dismissal).
+  # The list query carries id and state together so no per-review GET is
+  # needed afterwards.
   PREV_REVIEWS="$(printf '%s' "$reviews_json" \
     | jq -r --arg marker "${COMMENT_MARKER:-<!-- ai-pr-reviewer -->}" \
+        --argjson minimized "$minimized_ids" \
         '.[] | select(((.body // "") | startswith($marker))
                    or ((.body // "") | startswith("<!-- ai-pr-reviewer")))
              | select(((.state // "") == "APPROVED" or (.state // "") == "CHANGES_REQUESTED")
-                   or (((.body // "") | contains("_Outdated: superseded")) | not))
-             | "\(.id)\t\(.node_id // "")\t\(.state // "")"' 2>/dev/null || echo "")"
+                   or ((.id as $i | $minimized | index($i)) == null))
+             | "\(.id)\t\(.node_id // "")\t\(.state // "")\t\(if (.id as $i | $minimized | index($i)) != null then "minimized" else "" end)"' 2>/dev/null || echo "")"
   if [ -n "$PREV_REVIEWS" ]; then
-    while IFS=$'\t' read -r REVIEW_ID REVIEW_NODE_ID REVIEW_STATE; do
+    while IFS=$'\t' read -r REVIEW_ID REVIEW_NODE_ID REVIEW_STATE REVIEW_MINIMIZED; do
       if [ -z "$REVIEW_ID" ]; then continue; fi
       # Dismiss approval/request-changes reviews to stop stale verdicts from counting
       if [ "$REVIEW_STATE" = "APPROVED" ] || [ "$REVIEW_STATE" = "CHANGES_REQUESTED" ]; then
@@ -92,7 +105,7 @@ cleanup_native_reviews() {
       # the full review text stays expanded without this. PullRequestReview
       # implements GraphQL's Minimizable, the same mechanism as the UI's
       # "Hide" menu.
-      if [ -n "$REVIEW_NODE_ID" ]; then
+      if [ -n "$REVIEW_NODE_ID" ] && [ "$REVIEW_MINIMIZED" != "minimized" ]; then
         if gh api graphql \
             -f query='mutation($id: ID!) { minimizeComment(input: {subjectId: $id, classifier: OUTDATED}) { minimizedComment { isMinimized } } }' \
             -f id="$REVIEW_NODE_ID" >/dev/null 2>&1; then
@@ -101,19 +114,9 @@ cleanup_native_reviews() {
           echo "  WARN: Could not minimize review #$REVIEW_ID (may require additional permissions)" >&2
         fi
       fi
-      # Collapse the body to a one-line stub so even an expanded review stays
-      # compact (and so already-processed reviews are skipped next run). The
-      # endpoint is PUT — the previous PATCH was a 404 that the old code
-      # misreported as "reviews may be read-only".
-      OUTDATED_BODY="$(printf '<!-- ai-pr-reviewer -->\n_Outdated: superseded by a newer automated review._')"
-      if ! gh api "repos/$REPO/pulls/$PR_NUMBER/reviews/$REVIEW_ID" --method PUT -f body="$OUTDATED_BODY" >/dev/null 2>&1; then
-        echo "  WARN: Could not update review #$REVIEW_ID body" >&2
-      else
-        echo "  Marked review #$REVIEW_ID as outdated/superseded"
-      fi
     done <<< "$PREV_REVIEWS"
   else
-    echo "  No previous managed native reviews found for #$PR_NUMBER"
+    echo "  No previous managed native reviews to clean up for #$PR_NUMBER"
   fi
 }
 

--- a/tests/test_cleanup_native_reviews_behavior.sh
+++ b/tests/test_cleanup_native_reviews_behavior.sh
@@ -19,6 +19,14 @@ ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 PASS=0
 FAIL=0
+check() {
+  local desc="$1" result="$2" expected="$3"
+  if [[ "$result" == "$expected" ]]; then
+    echo "  PASS: $desc"; PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc (got '$result', expected '$expected')"; FAIL=$((FAIL + 1))
+  fi
+}
 check_contains() {
   local desc="$1" haystack="$2" needle="$3"
   if [[ "$haystack" == *"$needle"* ]]; then
@@ -52,8 +60,8 @@ fi
 case "$*" in
   *"/reviews --paginate"*) cat "$FIXTURE" ;;
   *"/dismissals --method PUT"*) echo '{"id": 1}' ;;
-  *"api graphql"*) echo '{"data":{"minimizeComment":{"minimizedComment":{"isMinimized":true}}}}' ;;
-  *"--method PUT"*) echo '{}' ;;
+  *"minimizeComment"*) echo '{"data":{"minimizeComment":{"minimizedComment":{"isMinimized":true}}}}' ;;
+  *"isMinimized"*) printf '%s\n' "${GH_MOCK_MINIMIZED:-[]}" ;;
   *) echo '{}' ;;
 esac
 MOCK
@@ -78,26 +86,27 @@ jq -n '[
   {id: 104, node_id: "PRR_node104", state: "COMMENTED", user: {login: "another-human"},
    body: "I noticed the bot marker <!-- ai-pr-reviewer --> appears mid-body here."},
   {id: 105, node_id: "PRR_node105", state: "DISMISSED", user: {login: "its-saffron[bot]"},
-   body: "<!-- ai-pr-reviewer -->\n_Outdated: superseded by a newer automated review._"},
+   body: "<!-- ai-pr-reviewer -->\nOld review, already minimized in a previous run."},
   {id: 106, node_id: "PRR_node106", state: "APPROVED", user: {login: "its-saffron[bot]"},
-   body: "<!-- ai-pr-reviewer -->\n_Outdated: superseded by a newer automated review._"}
+   body: "<!-- ai-pr-reviewer -->\nMinimized previously but the dismissal failed."}
 ]' > "$FIXTURE"
 
 echo "=== Managed reviews are dismissed and stubbed regardless of author ==="
 : > "$CALLS_LOG"
-OUT="$(cleanup_native_reviews "true" 2>&1)"
+OUT="$(GH_MOCK_MINIMIZED="[105,106]" cleanup_native_reviews "true" 2>&1)"
 CALLS="$(cat "$CALLS_LOG")"
 check_contains "app-bot APPROVED review 101 dismissed" "$CALLS" "reviews/101/dismissals --method PUT"
 check_contains "default-bot CHANGES_REQUESTED review 102 dismissed" "$CALLS" "reviews/102/dismissals --method PUT"
-check_contains "review 101 body stubbed via PUT" "$CALLS" "reviews/101 --method PUT"
 check_contains "review 101 minimized (hidden)" "$CALLS" "PRR_node101"
-check_contains "review 102 body stubbed via PUT" "$CALLS" "reviews/102 --method PUT"
 check_contains "review 102 minimized (hidden)" "$CALLS" "PRR_node102"
+PUT_BODY_CALLS="$(grep -cE 'reviews/[0-9]+ --method PUT' "$CALLS_LOG" || true)"
+check "review bodies are never rewritten" "$PUT_BODY_CALLS" "0"
 check_not_contains "human review 103 untouched" "$CALLS" "reviews/103"
 check_not_contains "mid-body marker mention 104 untouched" "$CALLS" "reviews/104"
-check_not_contains "already-dismissed stub 105 skipped" "$CALLS" "reviews/105"
-check_not_contains "already-dismissed stub 105 not re-minimized" "$CALLS" "PRR_node105"
-check_contains "stubbed-but-still-APPROVED 106 re-dismissed" "$CALLS" "reviews/106/dismissals --method PUT"
+check_not_contains "already-minimized dismissed review 105 fully skipped" "$CALLS" "reviews/105"
+check_not_contains "review 105 not re-minimized" "$CALLS" "PRR_node105"
+check_contains "minimized-but-still-APPROVED 106 re-dismissed" "$CALLS" "reviews/106/dismissals --method PUT"
+check_not_contains "review 106 not re-minimized" "$CALLS" "PRR_node106"
 check_contains "dismissals logged" "$OUT" "Dismissed outdated managed review #101"
 check_contains "minimize logged" "$OUT" "Minimized (hidden as outdated) review #101"
 check_not_contains "no actor lookup performed" "$CALLS" "api user"


### PR DESCRIPTION
Per review feedback on the v1.2.2 behavior (e.g. misospace/KubeTix#94): superseded reviews are minimized — hidden in the timeline — so overwriting their body with an `_Outdated_` stub only destroys the record for anyone who deliberately expands them.

## Changes

- **No more body rewrites.** Cleanup now does exactly two things to a superseded managed review: dismiss the stale verdict, minimize (hide) it. The content stays intact behind the collapsed block.
- **Skip logic moved to `isMinimized`.** Previously the body stub doubled as the already-processed marker. That state now comes from the review's real minimized state via one GraphQL query (REST lists don't expose it). Minimized-but-still-APPROVED reviews (earlier dismissal failure) are still re-dismissed; if the query fails, minimization is retried — idempotent, no harm.

Reviews stubbed by v1.2.1/v1.2.2 in the interim keep their stub (already overwritten); they're minimized, so they're skipped like everything else.

## Tests

Behavior suite reworked for hide-without-rewrite: asserts zero body-update calls, no re-minimizing of already-minimized reviews, re-dismissal of minimized-but-live verdicts, and the GraphQL state-map plumbing (mock distinguishes the query from the mutation). Full suite green: 575 pytest + all shell suites.
