### PR TITLE
ci: bump self-review to v1.2.3 and dogfood the full feature set

### DIFF
--- a/.github/workflows/ai-pr-review.yaml
+++ b/.github/workflows/ai-pr-review.yaml
@@ -29,27 +29,34 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          client-id: ${{ secrets.BOT_APP_ID }}
+          client-id: ${{ secrets.BOT_CLIENT_ID }}
           private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
 
       - name: Review PR with reusable AI reviewer
         if: github.event_name == 'pull_request'
         id: review
-        uses: misospace/pr-reviewer-action@e891235e8e3e75824b88fb696b1f7b4816122737 # v1.2.2
+        uses: misospace/pr-reviewer-action@59c7a0596b0d0b515ef9137f7acb985115f4c1d8 # v1.2.3
         with:
           github_token: ${{ steps.app-token.outputs.token }}
-          ai_primary_retries: "8"
+          ai_primary_retries: "3"
           ai_primary_retry_delay_sec: "15"
           ai_base_url: ${{ vars.LITELLM_URL }}
           ai_api_format: ${{ vars.PRIMARY_FORMAT }}
           ai_model: ${{ vars.PRIMARY_MODEL }}
           ai_api_key: ${{ secrets.LITELLM_API_KEY }}
+          ai_response_format: json_object
           ai_fallback_base_url: ${{ vars.LITELLM_URL }}
           ai_fallback_api_format: ${{ vars.FALLBACK_FORMAT }}
           ai_fallback_model: ${{ vars.FALLBACK_MODEL }}
           ai_fallback_api_key: ${{ secrets.LITELLM_API_KEY }}
+          review_routing_mode: auto
+          ai_smart_base_url: ${{ vars.LITELLM_URL }}
+          ai_smart_api_format: ${{ vars.SMART_FORMAT || vars.FALLBACK_FORMAT }}
+          ai_smart_model: ${{ vars.SMART_MODEL || vars.FALLBACK_MODEL }}
+          ai_smart_api_key: ${{ secrets.LITELLM_API_KEY }}
           context_limit_mode: normal
-          tool_mode: plan_execute_once
+          tool_mode: plan_execute_loop
+          tool_max_rounds: "2"
           tool_max_requests: "4"
           tool_planning_timeout_sec: "45"
           tool_planning_max_context_bytes: "15000"
@@ -58,5 +65,8 @@ jobs:
           tool_allowed_gh_api_repos: misospace/pr-reviewer-action
           tool_request_timeout_sec: "15"
           tool_enable_for_forks: "false"
+          on_model_failure: notice
+          inline_findings: "true"
+          verdict_policy: findings_severity_gated
           publish_mode: review_verdict
           allow_approve: "true"


### PR DESCRIPTION
Pre-bump config audit results applied alongside the pin update to [v1.2.3](https://github.com/misospace/pr-reviewer-action/releases/tag/v1.2.3) (`59c7a05`):

- **`BOT_CLIENT_ID`** — this repo was the last `BOT_APP_ID` holdout after the fleet migration.
- **`ai_primary_retries` 8 → 3 + `on_model_failure: notice`** — fleet-standard homelab profile: fail fast, post a visible notice instead of a bare red check.
- **Dogfood the shipped features**: `review_routing_mode: auto` with smart wiring (`vars.SMART_MODEL || vars.FALLBACK_MODEL`), `ai_response_format: json_object`, `verdict_policy: findings_severity_gated`, `inline_findings` — this repo's own PRs are the best continuous test bed, and with carry-forward (#195) + the loop (#198) just landed, self-review now exercises both daily.
- **`tool_mode: plan_execute_loop` + `tool_max_rounds: "2"`** — first deployment of the new loop, rounds capped at 2 to bound planning latency on the single-parallel `review` endpoint.

Kept as-is (deliberately): `tool_allowed_gh_api_repos` pinned to this repo, `context_limit_mode: normal` (200k window), tool planning caps, concurrency/draft gating.

⚠️ Depends on org vars being consistent: `FALLBACK_FORMAT` must match `cheap-coder` (openai) and `SMART_FORMAT` must match `SMART_MODEL` — flagged separately since org vars aren't readable from here.
