### PR TITLE
ci: wire smart model vars explicitly

### DIFF
--- a/.github/workflows/ai-pr-review.yaml
+++ b/.github/workflows/ai-pr-review.yaml
@@ -51,8 +51,8 @@ jobs:
           ai_fallback_api_key: ${{ secrets.LITELLM_API_KEY }}
           review_routing_mode: auto
           ai_smart_base_url: ${{ vars.LITELLM_URL }}
-          ai_smart_api_format: ${{ vars.SMART_FORMAT || vars.FALLBACK_FORMAT }}
-          ai_smart_model: ${{ vars.SMART_MODEL || vars.FALLBACK_MODEL }}
+          ai_smart_api_format: ${{ vars.SMART_FORMAT }}
+          ai_smart_model: ${{ vars.SMART_MODEL }}
           ai_smart_api_key: ${{ secrets.LITELLM_API_KEY }}
           context_limit_mode: normal
           tool_mode: plan_execute_loop


### PR DESCRIPTION
Follow-up to #199: `SMART_MODEL`/`SMART_FORMAT` are now explicitly set at the org level as a distinct quality tier, so the `|| FALLBACK_*` coalescing is no longer needed — and removing it makes it unambiguous which model serves smart-routed and escalated reviews.
