### PR TITLE
feat: resolve inline finding threads when carry-forward verifies the fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -622,6 +622,8 @@ With `inline_findings: "true"` and a native publish mode, findings that carry a 
 
 Anchors are validated against the diff before submission (GitHub only accepts comments on lines present in the diff); findings without a valid anchor stay in the review body. Comment bodies are secret-masked and @-mention-neutralized like all published output, and capped by `inline_findings_max` (default 20).
 
+**Thread resolution on re-review.** Each inline comment carries a hidden content fingerprint of its finding. When a later incremental review's carry-forward concludes a carried finding is fixed (the model answers it with `resolution: resolved` — the same fail-closed rule that drives the verdict), the action resolves the matching open review thread via the GraphQL `resolveReviewThread` mutation, so authors see live thread state instead of stale open conversations. Best-effort: API failures (e.g. read-only tokens on fork PRs) warn and never fail the publish; findings answered `still_open` or `not_verifiable_from_delta` keep their threads open.
+
 ```yaml
 - uses: misospace/pr-reviewer-action@v1
   with:

--- a/action.yml
+++ b/action.yml
@@ -790,6 +790,9 @@ runs:
           fi
         fi
 
+        # Resolve threads of carried findings this review verified as fixed (#208).
+        resolve_finding_threads
+
     - name: Publish review verdict (native PR review)
       if: inputs.publish_mode == 'review_verdict' && steps.precheck.outputs.should_review == 'true'
       shell: bash
@@ -960,3 +963,6 @@ runs:
             submit_native_review REQUEST_CHANGES "$BODY_FILE"
           fi
         fi
+
+        # Resolve threads of carried findings this review verified as fixed (#208).
+        resolve_finding_threads

--- a/scripts/build_review_comments.py
+++ b/scripts/build_review_comments.py
@@ -12,6 +12,7 @@ Environment:
   INLINE_FINDINGS_MAX  maximum comments to emit (default 20)
 """
 
+import hashlib
 import json
 import os
 import re
@@ -34,6 +35,44 @@ _SEVERITY_LABELS = {
     "minor": "Minor",
     "info": "Info",
 }
+
+# Hidden marker correlating an inline comment with its finding across runs
+# (#208). The fingerprint is content-based because carried finding ids are
+# positional (P1..Pn, assigned per-run by carry_forward.load_carried_findings)
+# and therefore not stable between runs.
+FINDING_MARKER_PREFIX = "<!-- ai-pr-review-finding:"
+
+# Must match the truncation build_metadata_marker applies when persisting
+# open_findings (message[0:200]), so a finding fingerprinted here at comment
+# time equals the fingerprint of the same finding after a marker round-trip.
+_FINGERPRINT_MESSAGE_CHARS = 200
+
+
+def finding_fingerprint(finding: dict) -> str:
+    """Stable content fingerprint for correlating a finding across runs.
+
+    Computed from the fields the metadata marker persists (severity,
+    category, file, line, message truncated to 200 chars), normalized the
+    way carry_forward.load_carried_findings re-reads them. The trailing
+    strip mirrors the load-side strip-after-truncate so a cut that lands on
+    whitespace fingerprints identically on both sides.
+    """
+    severity = finding.get("severity") or "info"
+    category = finding.get("category") or "other"
+    file_path = finding.get("file") or ""
+    line = finding.get("line")
+    line_part = (
+        str(line)
+        if isinstance(line, int) and not isinstance(line, bool) and line > 0
+        else ""
+    )
+    message = str(finding.get("message") or "").strip()[:_FINGERPRINT_MESSAGE_CHARS].strip()
+    canon = "\x1f".join([str(severity), str(category), str(file_path), line_part, message])
+    return hashlib.sha256(canon.encode("utf-8")).hexdigest()[:16]
+
+
+def finding_marker(finding: dict) -> str:
+    return f"{FINDING_MARKER_PREFIX}{finding_fingerprint(finding)} -->"
 
 
 def commentable_lines(diff_text: str) -> dict:
@@ -123,12 +162,15 @@ def build_comments(findings, diff_text: str, max_comments: int = 20):
         ):
             skipped += 1
             continue
+        # The marker is appended after sanitization: it is generated locally
+        # from hex digits and must survive verbatim for the next run's
+        # thread-resolution matching.
         comments.append(
             {
                 "path": path,
                 "line": line,
                 "side": "RIGHT",
-                "body": finding_to_body(finding),
+                "body": finding_to_body(finding) + "\n\n" + finding_marker(finding),
             }
         )
         if len(comments) >= max_comments:

--- a/scripts/publish_helpers.sh
+++ b/scripts/publish_helpers.sh
@@ -120,6 +120,27 @@ cleanup_native_reviews() {
   fi
 }
 
+# Resolve inline finding threads for carried findings this run verified as
+# fixed (#208). Requires env: GH_TOKEN, REPO, PR_NUMBER, GITHUB_ACTION_PATH;
+# optional FINDINGS, INLINE_FINDINGS. Best-effort: never fails the publish —
+# the python script exits 0 on API errors and this wrapper swallows the rest.
+# Gated on inline_findings because without it no marker-bearing threads can
+# exist, and on a non-empty previous-findings.json because resolution only
+# makes sense when this run carried findings forward.
+resolve_finding_threads() {
+  if [ "$(printf '%s' "${INLINE_FINDINGS:-false}" | tr '[:upper:]' '[:lower:]')" != "true" ]; then
+    return 0
+  fi
+  if [ ! -s previous-findings.json ]; then
+    return 0
+  fi
+  printf '%s' "${FINDINGS:-[]}" > resolve-findings.json
+  if ! python3 "${GITHUB_ACTION_PATH}/scripts/resolve_finding_threads.py" previous-findings.json resolve-findings.json; then
+    echo "  WARN: finding-thread resolution failed; continuing" >&2
+  fi
+  return 0
+}
+
 # Build metadata marker JSON string.
 # Requires env: HEAD_SHA, EFFECTIVE_SCOPE, REVIEW_RESULT; optional FINDINGS
 # (JSON array — persisted as open_findings when the review found issues, so

--- a/scripts/resolve_finding_threads.py
+++ b/scripts/resolve_finding_threads.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""Resolve inline finding threads whose findings this run verified as fixed (#208).
+
+A previous run posted line-anchored inline comments carrying a content
+fingerprint marker (see build_review_comments.finding_marker). When the
+current incremental review's carry-forward concludes a carried finding is
+resolved, this script locates the matching unresolved review thread by that
+marker and resolves it via the GraphQL resolveReviewThread mutation, so
+authors see live thread state instead of stale open conversations.
+
+Best-effort by design: any API failure warns and exits 0 — thread resolution
+must never fail the publish step. Fork PRs with a read-only token simply
+leave threads unresolved.
+
+Threads are matched by the marker their first comment carries, never by
+author: /user returns 403 for installation tokens (#190).
+
+Usage: resolve_finding_threads.py PREVIOUS_FINDINGS_JSON FINDINGS_JSON_FILE
+
+Environment:
+  REPO        owner/repo of the pull request
+  PR_NUMBER   pull request number
+  GH_TOKEN    used implicitly by gh
+"""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent
+_ACTION_ROOT = _SCRIPTS_DIR.parent
+for _p in (str(_SCRIPTS_DIR), str(_ACTION_ROOT)):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from build_review_comments import FINDING_MARKER_PREFIX, finding_fingerprint  # noqa: E402
+from pr_reviewer.carry_forward import load_carried_findings  # noqa: E402
+
+_THREADS_QUERY = (
+    "query($owner: String!, $name: String!, $number: Int!) {"
+    " repository(owner: $owner, name: $name) {"
+    " pullRequest(number: $number) {"
+    " reviewThreads(first: 100) {"
+    " nodes { id isResolved comments(first: 1) { nodes { body } } }"
+    " } } } }"
+)
+
+_RESOLVE_MUTATION = (
+    "mutation($id: ID!) {"
+    " resolveReviewThread(input: {threadId: $id}) { thread { isResolved } } }"
+)
+
+_MAX_THREADS_PAGE = 100
+
+
+def _gh_graphql(fields: list, timeout: int = 60):
+    """Run ``gh api graphql`` and return the parsed JSON dict, or None.
+
+    On HTTP errors gh prints the JSON error body to STDOUT (#190), so a
+    non-zero exit discards stdout entirely instead of trying to parse it.
+    Anything that is not a JSON object is treated as a failure.
+    """
+    cmd = ["gh", "api", "graphql", *fields]
+    try:
+        completed = subprocess.run(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=timeout,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if completed.returncode != 0:
+        return None
+    try:
+        parsed = json.loads(completed.stdout.decode("utf-8", errors="replace"))
+    except (ValueError, UnicodeDecodeError):
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def resolved_fingerprints(carried: list, findings) -> set:
+    """Fingerprints of carried findings the model marked resolved.
+
+    Mirrors carry_forward.apply_carry_forward: only an explicit "resolved"
+    resolution counts; everything else stays open (fail-closed), so its
+    thread stays open too.
+    """
+    if not isinstance(findings, list):
+        return set()
+    resolutions = {
+        f["id"]: f.get("resolution")
+        for f in findings
+        if isinstance(f, dict) and isinstance(f.get("id"), str)
+    }
+    return {
+        finding_fingerprint(item)
+        for item in carried
+        if resolutions.get(item.get("id")) == "resolved"
+    }
+
+
+def extract_marker_fingerprint(body):
+    """Pull the finding fingerprint out of a comment body, if present."""
+    if not isinstance(body, str):
+        return None
+    start = body.find(FINDING_MARKER_PREFIX)
+    if start == -1:
+        return None
+    rest = body[start + len(FINDING_MARKER_PREFIX):]
+    end = rest.find("-->")
+    if end == -1:
+        return None
+    fingerprint = rest[:end].strip()
+    return fingerprint or None
+
+
+def threads_to_resolve(thread_nodes, fingerprints: set) -> list:
+    """Thread node ids whose first comment matches a resolved fingerprint.
+
+    Only the first comment is checked — that is the thread starter the
+    previous run posted; replies never carry the marker.
+    """
+    matched = []
+    for node in thread_nodes or []:
+        if not isinstance(node, dict) or node.get("isResolved"):
+            continue
+        thread_id = node.get("id")
+        if not isinstance(thread_id, str) or not thread_id:
+            continue
+        comments = (node.get("comments") or {}).get("nodes") or []
+        first = comments[0] if comments and isinstance(comments[0], dict) else {}
+        fingerprint = extract_marker_fingerprint(first.get("body"))
+        if fingerprint and fingerprint in fingerprints:
+            matched.append(thread_id)
+    return matched
+
+
+def main(argv) -> int:
+    previous_path = argv[1] if len(argv) > 1 else "previous-findings.json"
+    findings_path = argv[2] if len(argv) > 2 else "findings.json"
+
+    repo = os.getenv("REPO", "")
+    pr_number = os.getenv("PR_NUMBER", "")
+    if "/" not in repo or not pr_number.isdigit():
+        print("resolve_finding_threads: missing REPO/PR_NUMBER; skipping", file=sys.stderr)
+        return 0
+
+    carried = load_carried_findings(previous_path)
+    if not carried:
+        return 0
+
+    try:
+        findings = json.loads(Path(findings_path).read_text(encoding="utf-8", errors="replace"))
+    except (OSError, ValueError):
+        findings = []
+
+    fingerprints = resolved_fingerprints(carried, findings)
+    if not fingerprints:
+        print("resolve_finding_threads: no resolved carried findings; nothing to resolve")
+        return 0
+
+    owner, name = repo.split("/", 1)
+    data = _gh_graphql(
+        [
+            "-f", f"query={_THREADS_QUERY}",
+            "-f", f"owner={owner}",
+            "-f", f"name={name}",
+            "-F", f"number={pr_number}",
+        ]
+    )
+    if data is None:
+        print("  WARN: could not list review threads; skipping thread resolution", file=sys.stderr)
+        return 0
+    try:
+        thread_nodes = data["data"]["repository"]["pullRequest"]["reviewThreads"]["nodes"]
+    except (KeyError, TypeError):
+        thread_nodes = []
+    if not isinstance(thread_nodes, list):
+        thread_nodes = []
+    if len(thread_nodes) >= _MAX_THREADS_PAGE:
+        print(
+            f"  NOTE: PR has {_MAX_THREADS_PAGE}+ review threads; only the first "
+            f"{_MAX_THREADS_PAGE} were checked for resolution",
+            file=sys.stderr,
+        )
+
+    thread_ids = threads_to_resolve(thread_nodes, fingerprints)
+    resolved = 0
+    for thread_id in thread_ids:
+        result = _gh_graphql(
+            ["-f", f"query={_RESOLVE_MUTATION}", "-f", f"id={thread_id}"]
+        )
+        if result is not None:
+            resolved += 1
+        else:
+            print(
+                f"  WARN: could not resolve review thread {thread_id} "
+                "(may require additional permissions)",
+                file=sys.stderr,
+            )
+    print(
+        f"resolve_finding_threads: resolved {resolved}/{len(thread_ids)} matching "
+        f"thread(s) for {len(fingerprints)} fixed finding(s)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/tests/test_build_review_comments.py
+++ b/tests/test_build_review_comments.py
@@ -14,8 +14,11 @@ if str(_SCRIPTS_DIR) not in sys.path:
 import pytest
 
 from build_review_comments import (
+    FINDING_MARKER_PREFIX,
     build_comments,
     commentable_lines,
+    finding_fingerprint,
+    finding_marker,
     finding_to_body,
     main,
 )
@@ -144,6 +147,55 @@ class TestFindingBody:
     def test_other_category_omitted(self):
         body = finding_to_body(_finding(category="other"))
         assert "(other)" not in body
+
+
+class TestFindingFingerprint:
+    def test_comment_body_carries_marker(self):
+        finding = _finding(line=12)
+        comments, _ = build_comments([finding], DIFF)
+        assert len(comments) == 1
+        assert comments[0]["body"].endswith(finding_marker(finding))
+        assert FINDING_MARKER_PREFIX in comments[0]["body"]
+
+    def test_deterministic_and_content_sensitive(self):
+        assert finding_fingerprint(_finding()) == finding_fingerprint(_finding())
+        assert finding_fingerprint(_finding()) != finding_fingerprint(_finding(line=13))
+        assert finding_fingerprint(_finding()) != finding_fingerprint(_finding(message="other"))
+
+    def test_none_file_and_line_fingerprint(self):
+        # Carried findings can have file/line of None; must not raise.
+        fp = finding_fingerprint(_finding(file=None, line=None))
+        assert len(fp) == 16
+
+    def test_marker_roundtrip_preserves_fingerprint(self, tmp_path):
+        """A finding fingerprinted at comment time must fingerprint
+        identically after the metadata-marker persist/load round-trip
+        (jq message[0:200] persist, load_carried_findings re-sanitize)."""
+        if str(_REPO_ROOT) not in sys.path:
+            sys.path.insert(0, str(_REPO_ROOT))
+        from pr_reviewer.carry_forward import load_carried_findings
+
+        # Message long enough that the cut lands on whitespace — the
+        # strip-after-truncate edge case.
+        long_message = ("a" * 199) + " trailing tail that gets cut off " + ("b" * 50)
+        for original in (
+            _finding(),
+            _finding(message=long_message),
+            _finding(file=None, line=None, severity="major", category="bug"),
+        ):
+            # Simulate build_metadata_marker's open_findings projection.
+            persisted = {
+                "severity": original["severity"],
+                "category": original["category"],
+                "file": original["file"],
+                "line": original["line"],
+                "message": str(original["message"])[:200],
+            }
+            path = tmp_path / "previous-findings.json"
+            path.write_text(json.dumps([persisted]), encoding="utf-8")
+            carried = load_carried_findings(str(path))
+            assert len(carried) == 1
+            assert finding_fingerprint(carried[0]) == finding_fingerprint(original)
 
 
 class TestMainCli:

--- a/tests/test_resolve_finding_threads.py
+++ b/tests/test_resolve_finding_threads.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+"""Tests for scripts/resolve_finding_threads.py — fingerprint matching,
+fail-closed resolution selection, and gh interaction against a mocked gh
+that mimics the real CLI's stdout-on-error behavior (#190)."""
+
+import json
+import os
+import stat
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SCRIPTS_DIR = _REPO_ROOT / "scripts"
+for _p in (str(_SCRIPTS_DIR), str(_REPO_ROOT)):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+import pytest
+
+from build_review_comments import finding_fingerprint, finding_marker
+from resolve_finding_threads import (
+    extract_marker_fingerprint,
+    main,
+    resolved_fingerprints,
+    threads_to_resolve,
+)
+
+
+def _finding(file="app/serve.py", line=12, severity="blocker", message="bad", category="security"):
+    return {"severity": severity, "category": category, "file": file, "line": line, "message": message}
+
+
+def _carried(finding, index=0):
+    """The form load_carried_findings returns: positional id + sanitized fields."""
+    return {
+        "id": f"P{index + 1}",
+        "severity": finding["severity"],
+        "category": finding["category"],
+        "file": finding["file"],
+        "line": finding["line"],
+        "message": finding["message"][:200],
+    }
+
+
+class TestExtractMarkerFingerprint:
+    def test_extracts_from_comment_body(self):
+        finding = _finding()
+        body = f"**Blocker:** bad\n\n{finding_marker(finding)}"
+        assert extract_marker_fingerprint(body) == finding_fingerprint(finding)
+
+    def test_no_marker(self):
+        assert extract_marker_fingerprint("a plain comment") is None
+
+    def test_unterminated_marker(self):
+        assert extract_marker_fingerprint("<!-- ai-pr-review-finding:abc123") is None
+
+    def test_empty_fingerprint(self):
+        assert extract_marker_fingerprint("<!-- ai-pr-review-finding: -->") is None
+
+    def test_non_string(self):
+        assert extract_marker_fingerprint(None) is None
+        assert extract_marker_fingerprint(42) is None
+
+
+class TestResolvedFingerprints:
+    def test_only_explicit_resolved_counts(self):
+        carried = [
+            _carried(_finding(message="one"), 0),
+            _carried(_finding(message="two"), 1),
+            _carried(_finding(message="three"), 2),
+        ]
+        findings = [
+            {"id": "P1", "resolution": "resolved", "message": "one"},
+            {"id": "P2", "resolution": "still_open", "message": "two"},
+            # P3 unanswered — fail-closed: stays open.
+        ]
+        fps = resolved_fingerprints(carried, findings)
+        assert fps == {finding_fingerprint(carried[0])}
+
+    def test_non_list_findings(self):
+        assert resolved_fingerprints([_carried(_finding())], "garbage") == set()
+        assert resolved_fingerprints([_carried(_finding())], None) == set()
+
+    def test_empty_when_nothing_resolved(self):
+        carried = [_carried(_finding())]
+        assert resolved_fingerprints(carried, []) == set()
+
+
+class TestThreadsToResolve:
+    def _thread(self, thread_id, body, is_resolved=False):
+        return {
+            "id": thread_id,
+            "isResolved": is_resolved,
+            "comments": {"nodes": [{"body": body}]},
+        }
+
+    def test_matches_unresolved_marker_threads(self):
+        finding = _finding()
+        fp = finding_fingerprint(finding)
+        threads = [
+            self._thread("T1", f"text\n\n{finding_marker(finding)}"),
+            self._thread("T2", f"text\n\n{finding_marker(finding)}", is_resolved=True),
+            self._thread("T3", "no marker here"),
+            self._thread("T4", "<!-- ai-pr-review-finding:ffffffffffffffff -->"),
+        ]
+        assert threads_to_resolve(threads, {fp}) == ["T1"]
+
+    def test_only_first_comment_checked(self):
+        finding = _finding()
+        thread = {
+            "id": "T1",
+            "isResolved": False,
+            "comments": {"nodes": [{"body": "starter, no marker"}, {"body": finding_marker(finding)}]},
+        }
+        assert threads_to_resolve([thread], {finding_fingerprint(finding)}) == []
+
+    def test_malformed_nodes_skipped(self):
+        assert threads_to_resolve(None, {"x"}) == []
+        assert threads_to_resolve(["junk", {}, {"id": 7, "comments": {}}], {"x"}) == []
+
+
+def _install_fake_gh(tmp_path, monkeypatch, threads_response, list_exit=0, mutation_exit=0):
+    """Drop a fake gh on PATH that logs calls and replays canned responses.
+
+    On non-zero exit the fake still prints a JSON error body to stdout,
+    mimicking the real gh behavior that broke #190.
+    """
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(exist_ok=True)
+    log = tmp_path / "gh-calls.log"
+    response_file = tmp_path / "threads-response.json"
+    response_file.write_text(json.dumps(threads_response), encoding="utf-8")
+    gh = bin_dir / "gh"
+    gh.write_text(
+        "#!/usr/bin/env bash\n"
+        f"echo \"$*\" >> '{log}'\n"
+        "if [[ \"$*\" == *resolveReviewThread* ]]; then\n"
+        f"  if [ {mutation_exit} -ne 0 ]; then\n"
+        "    echo '{\"message\":\"Resource not accessible by integration\"}'\n"
+        f"    exit {mutation_exit}\n"
+        "  fi\n"
+        "  echo '{\"data\":{\"resolveReviewThread\":{\"thread\":{\"isResolved\":true}}}}'\n"
+        "  exit 0\n"
+        "fi\n"
+        f"if [ {list_exit} -ne 0 ]; then\n"
+        "  echo '{\"message\":\"API rate limit exceeded\",\"documentation_url\":\"https://docs.github.com\"}'\n"
+        f"  exit {list_exit}\n"
+        "fi\n"
+        f"cat '{response_file}'\n",
+        encoding="utf-8",
+    )
+    gh.chmod(gh.stat().st_mode | stat.S_IEXEC)
+    monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ['PATH']}")
+    return log
+
+
+def _threads_payload(nodes):
+    return {
+        "data": {
+            "repository": {"pullRequest": {"reviewThreads": {"nodes": nodes}}}
+        }
+    }
+
+
+def _write_inputs(tmp_path, carried_persisted, findings):
+    prev = tmp_path / "previous-findings.json"
+    prev.write_text(json.dumps(carried_persisted), encoding="utf-8")
+    found = tmp_path / "findings.json"
+    found.write_text(json.dumps(findings), encoding="utf-8")
+    return str(prev), str(found)
+
+
+class TestMainEndToEnd:
+    @pytest.fixture(autouse=True)
+    def _env(self, monkeypatch):
+        monkeypatch.setenv("REPO", "owner/repo")
+        monkeypatch.setenv("PR_NUMBER", "42")
+
+    def test_resolves_matching_thread(self, tmp_path, monkeypatch):
+        finding = _finding()
+        # Persisted (marker) projection of the finding from the previous run.
+        persisted = {k: finding[k] for k in ("severity", "category", "file", "line")}
+        persisted["message"] = finding["message"][:200]
+        prev, found = _write_inputs(
+            tmp_path,
+            [persisted],
+            [{"id": "P1", "resolution": "resolved", "message": finding["message"]}],
+        )
+        log = _install_fake_gh(
+            tmp_path,
+            monkeypatch,
+            _threads_payload(
+                [
+                    {
+                        "id": "T_match",
+                        "isResolved": False,
+                        "comments": {"nodes": [{"body": f"x\n\n{finding_marker(finding)}"}]},
+                    },
+                    {
+                        "id": "T_unrelated",
+                        "isResolved": False,
+                        "comments": {"nodes": [{"body": "human comment"}]},
+                    },
+                ]
+            ),
+        )
+        assert main(["prog", prev, found]) == 0
+        calls = log.read_text()
+        assert "T_match" in calls
+        assert "T_unrelated" not in calls
+        assert calls.count("resolveReviewThread") == 1
+
+    def test_still_open_thread_left_alone(self, tmp_path, monkeypatch):
+        finding = _finding()
+        persisted = {k: finding[k] for k in ("severity", "category", "file", "line")}
+        persisted["message"] = finding["message"][:200]
+        prev, found = _write_inputs(
+            tmp_path,
+            [persisted],
+            [{"id": "P1", "resolution": "still_open", "message": finding["message"]}],
+        )
+        log = _install_fake_gh(tmp_path, monkeypatch, _threads_payload([]))
+        assert main(["prog", prev, found]) == 0
+        # Nothing resolved → not even the thread list is fetched.
+        assert not log.exists()
+
+    def test_gh_list_failure_is_swallowed(self, tmp_path, monkeypatch, capsys):
+        """gh exits non-zero and prints a JSON error body to stdout (#190);
+        the script must warn, skip resolution, and still exit 0."""
+        finding = _finding()
+        persisted = {k: finding[k] for k in ("severity", "category", "file", "line")}
+        persisted["message"] = finding["message"][:200]
+        prev, found = _write_inputs(
+            tmp_path,
+            [persisted],
+            [{"id": "P1", "resolution": "resolved", "message": finding["message"]}],
+        )
+        log = _install_fake_gh(tmp_path, monkeypatch, _threads_payload([]), list_exit=1)
+        assert main(["prog", prev, found]) == 0
+        assert "could not list review threads" in capsys.readouterr().err
+        assert "resolveReviewThread" not in log.read_text()
+
+    def test_mutation_failure_is_swallowed(self, tmp_path, monkeypatch, capsys):
+        finding = _finding()
+        persisted = {k: finding[k] for k in ("severity", "category", "file", "line")}
+        persisted["message"] = finding["message"][:200]
+        prev, found = _write_inputs(
+            tmp_path,
+            [persisted],
+            [{"id": "P1", "resolution": "resolved", "message": finding["message"]}],
+        )
+        _install_fake_gh(
+            tmp_path,
+            monkeypatch,
+            _threads_payload(
+                [
+                    {
+                        "id": "T_match",
+                        "isResolved": False,
+                        "comments": {"nodes": [{"body": finding_marker(finding)}]},
+                    }
+                ]
+            ),
+            mutation_exit=1,
+        )
+        assert main(["prog", prev, found]) == 0
+        assert "could not resolve review thread" in capsys.readouterr().err
+
+    def test_missing_env_skips(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("PR_NUMBER")
+        prev, found = _write_inputs(tmp_path, [], [])
+        assert main(["prog", prev, found]) == 0
+
+    def test_no_carried_findings_is_quiet_noop(self, tmp_path, monkeypatch):
+        prev, found = _write_inputs(tmp_path, [], [])
+        log = _install_fake_gh(tmp_path, monkeypatch, _threads_payload([]))
+        assert main(["prog", prev, found]) == 0
+        assert not log.exists()
+
+
+class TestActionWiring:
+    ACTION = (_REPO_ROOT / "action.yml").read_text()
+    HELPERS = (_REPO_ROOT / "scripts" / "publish_helpers.sh").read_text()
+
+    def test_both_publish_steps_resolve_threads(self):
+        assert self.ACTION.count("resolve_finding_threads") == 2
+
+    def test_helper_gates_on_inline_findings_and_carryover(self):
+        assert "resolve_finding_threads()" in self.HELPERS
+        assert "previous-findings.json" in self.HELPERS
+        assert "INLINE_FINDINGS" in self.HELPERS
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Closes #208

## What

- `build_review_comments.py` appends a hidden marker `<!-- ai-pr-review-finding:<fp> -->` to every inline comment, where `<fp>` is a 16-hex content fingerprint of the finding (severity, category, file, line, message truncated to 200 chars — the exact projection the metadata marker persists as `open_findings`).
- New `scripts/resolve_finding_threads.py`: on incremental reviews, computes which carried findings the model answered `resolution: resolved` (same fail-closed rule as `apply_carry_forward`), lists the PR's review threads via GraphQL, matches unresolved threads by the marker in their first comment, and resolves them with `resolveReviewThread`.
- `publish_helpers.sh` gains a `resolve_finding_threads` wrapper, called from both native publish steps after the new review is posted. Gated on `inline_findings: true` and a non-empty `previous-findings.json`.
- README: thread-resolution paragraph in the inline review comments section.

## Design notes

- **Content fingerprint, not ids** — carried finding ids (`P1..Pn`) are positional per-run, so correlation is by content. The fingerprint normalization mirrors the marker persist/load round-trip exactly (incl. the strip-after-truncate edge when the 200-char cut lands on whitespace); a dedicated round-trip test locks this in.
- **Marker matching, never author matching** (#190) — threads are matched by the fingerprint marker their first comment carries.
- **stdout discarded on gh failure** (#190) — gh prints JSON error bodies to stdout on HTTP errors; the subprocess wrapper only parses stdout on exit 0, and the test's fake `gh` reproduces the error-body-on-stdout behavior.
- **Best-effort end to end** — the script always exits 0; fork PRs with read-only tokens just leave threads unresolved with a warning.

## Tests

- 13 new cases in `tests/test_resolve_finding_threads.py` (pure matching logic + end-to-end against a mocked `gh`, including list/mutation failure modes and action.yml wiring).
- 4 new cases in `tests/test_build_review_comments.py` (marker presence, fingerprint determinism, None file/line, marker round-trip property).
- Full suite: 611 python tests pass; `test_cleanup_native_reviews_behavior.sh` (20) and `test_carry_forward_roundtrip.sh` (13) pass.

## Not verified here

Live GraphQL behavior (`resolveReviewThread` against a real PR) — unit-tested against mocks only; worth watching on the first dogfood PR after release.
