### PR TITLE
feat: reply on still-open finding threads instead of re-posting duplicates

### DIFF
--- a/README.md
+++ b/README.md
@@ -622,7 +622,13 @@ With `inline_findings: "true"` and a native publish mode, findings that carry a 
 
 Anchors are validated against the diff before submission (GitHub only accepts comments on lines present in the diff); findings without a valid anchor stay in the review body. Comment bodies are secret-masked and @-mention-neutralized like all published output, and capped by `inline_findings_max` (default 20).
 
-**Thread resolution on re-review.** Each inline comment carries a hidden content fingerprint of its finding. When a later incremental review's carry-forward concludes a carried finding is fixed (the model answers it with `resolution: resolved` — the same fail-closed rule that drives the verdict), the action resolves the matching open review thread via the GraphQL `resolveReviewThread` mutation, so authors see live thread state instead of stale open conversations. Best-effort: API failures (e.g. read-only tokens on fork PRs) warn and never fail the publish; findings answered `still_open` or `not_verifiable_from_delta` keep their threads open.
+**Thread lifecycle on re-review.** Each inline comment carries a hidden content fingerprint of its finding. On a later incremental review, the action matches existing review threads by that fingerprint and keeps them alive instead of stacking duplicates:
+
+- A carried finding the model answered with `resolution: resolved` (the same fail-closed rule that drives the verdict) gets its thread **resolved** via the GraphQL `resolveReviewThread` mutation.
+- A carried finding that survives (`still_open`, `not_verifiable_from_delta`, or unanswered) gets a short **reply on its existing thread** ("Still open after this push…") instead of a fresh duplicate anchored comment. Replies are stamped with the head SHA, so a re-run on the same push never posts the same follow-up twice, and are capped by `inline_findings_max`.
+- A still-open carried finding whose thread no longer exists falls back to a fresh anchored comment as before.
+
+Best-effort throughout: API failures (e.g. read-only tokens on fork PRs) warn and never fail the publish.
 
 ```yaml
 - uses: misospace/pr-reviewer-action@v1

--- a/action.yml
+++ b/action.yml
@@ -765,6 +765,11 @@ runs:
         # Use gh pr comment instead for visibility, with --edit-last/--create-if-none for sticky behavior.
         gh pr comment "$PR_NUMBER" --repo "$REPO" --edit-last --create-if-none --body-file "$BODY_FILE"
 
+        # Resolve threads of carried findings this review verified as fixed,
+        # and reply on threads still open (#208, #209). Must precede the
+        # comment build so finding-threads.json suppresses duplicates.
+        resolve_finding_threads
+
         # Optionally attach line-anchored inline comments from the structured
         # findings as a separate native COMMENT review. It carries the managed
         # marker so the next run's cleanup marks it superseded. Best-effort:
@@ -772,7 +777,7 @@ runs:
         if [ "$(printf '%s' "${INLINE_FINDINGS:-false}" | tr '[:upper:]' '[:lower:]')" = "true" ] && [ -n "${FINDINGS:-}" ]; then
           printf '%s' "$FINDINGS" > findings.json
           COMMENTS_JSON="[]"
-          if INLINE_FINDINGS_MAX="${INLINE_FINDINGS_MAX:-20}" python3 "${GITHUB_ACTION_PATH}/scripts/build_review_comments.py" findings.json pr.diff review-comments.json; then
+          if SUPPRESS_FINDINGS_FILE=finding-threads.json INLINE_FINDINGS_MAX="${INLINE_FINDINGS_MAX:-20}" python3 "${GITHUB_ACTION_PATH}/scripts/build_review_comments.py" findings.json pr.diff review-comments.json; then
             COMMENTS_JSON="$(cat review-comments.json)"
           fi
           if [ -n "$COMMENTS_JSON" ] && [ "$COMMENTS_JSON" != "[]" ]; then
@@ -789,9 +794,6 @@ runs:
             fi
           fi
         fi
-
-        # Resolve threads of carried findings this review verified as fixed (#208).
-        resolve_finding_threads
 
     - name: Publish review verdict (native PR review)
       if: inputs.publish_mode == 'review_verdict' && steps.precheck.outputs.should_review == 'true'
@@ -898,13 +900,18 @@ runs:
           cat review-verdict-markdown.raw.md
         } > "$BODY_FILE"
 
+        # Resolve threads of carried findings this review verified as fixed,
+        # and reply on threads still open (#208, #209). Must precede the
+        # comment build so finding-threads.json suppresses duplicates.
+        resolve_finding_threads
+
         # Build line-anchored inline comments from the structured findings
         # when enabled. Anchors are validated against pr.diff (written by the
         # review step); non-anchorable findings stay in the body only.
         COMMENTS_JSON="[]"
         if [ "$(printf '%s' "${INLINE_FINDINGS:-false}" | tr '[:upper:]' '[:lower:]')" = "true" ] && [ -n "${FINDINGS:-}" ]; then
           printf '%s' "$FINDINGS" > findings.json
-          if INLINE_FINDINGS_MAX="${INLINE_FINDINGS_MAX:-20}" python3 "${GITHUB_ACTION_PATH}/scripts/build_review_comments.py" findings.json pr.diff review-comments.json; then
+          if SUPPRESS_FINDINGS_FILE=finding-threads.json INLINE_FINDINGS_MAX="${INLINE_FINDINGS_MAX:-20}" python3 "${GITHUB_ACTION_PATH}/scripts/build_review_comments.py" findings.json pr.diff review-comments.json; then
             COMMENTS_JSON="$(cat review-comments.json)"
           fi
         fi
@@ -963,6 +970,3 @@ runs:
             submit_native_review REQUEST_CHANGES "$BODY_FILE"
           fi
         fi
-
-        # Resolve threads of carried findings this review verified as fixed (#208).
-        resolve_finding_threads

--- a/scripts/build_review_comments.py
+++ b/scripts/build_review_comments.py
@@ -9,7 +9,12 @@ payload for POST /repos/{owner}/{repo}/pulls/{n}/reviews.
 Usage: build_review_comments.py FINDINGS_JSON_FILE DIFF_FILE OUTPUT_FILE
 
 Environment:
-  INLINE_FINDINGS_MAX  maximum comments to emit (default 20)
+  INLINE_FINDINGS_MAX     maximum comments to emit (default 20)
+  SUPPRESS_FINDINGS_FILE  optional JSON array of finding fingerprints that
+                          already have a live review thread (written by
+                          resolve_finding_threads.py); matching findings are
+                          skipped so a carried-forward finding gets a thread
+                          reply instead of a duplicate anchored comment (#209)
 """
 
 import hashlib
@@ -138,10 +143,30 @@ def finding_to_body(finding: dict) -> str:
     return sanitize_markdown(mask_secrets(body))
 
 
-def build_comments(findings, diff_text: str, max_comments: int = 20):
-    """Return (comments, skipped_count) for the anchorable findings."""
+def load_suppressed_fingerprints(path) -> set:
+    """Read the fingerprint set resolve_finding_threads.py emitted, if any."""
+    if not path:
+        return set()
+    try:
+        data = json.loads(Path(path).read_text(encoding="utf-8", errors="replace"))
+    except (OSError, ValueError):
+        return set()
+    if not isinstance(data, list):
+        return set()
+    return {item for item in data if isinstance(item, str) and item}
+
+
+def build_comments(findings, diff_text: str, max_comments: int = 20, suppressed=None):
+    """Return (comments, skipped_count) for the anchorable findings.
+
+    Skipped findings include the non-anchorable ones, findings the model
+    marked resolved (a fixed finding needs no fresh comment — its thread is
+    resolved separately), and findings whose fingerprint already has a live
+    review thread (those get a thread reply instead, #209).
+    """
     if not isinstance(findings, list):
         return [], 0
+    suppressed = suppressed or set()
 
     anchors = commentable_lines(diff_text)
     comments = []
@@ -149,6 +174,12 @@ def build_comments(findings, diff_text: str, max_comments: int = 20):
 
     for finding in findings:
         if not isinstance(finding, dict):
+            skipped += 1
+            continue
+        if finding.get("resolution") == "resolved":
+            skipped += 1
+            continue
+        if suppressed and finding_fingerprint(finding) in suppressed:
             skipped += 1
             continue
         path = finding.get("file")
@@ -196,12 +227,15 @@ def main(argv) -> int:
     except ValueError:
         max_comments = 20
 
-    comments, skipped = build_comments(findings, diff_text, max_comments)
+    suppressed = load_suppressed_fingerprints(os.getenv("SUPPRESS_FINDINGS_FILE"))
+
+    comments, skipped = build_comments(findings, diff_text, max_comments, suppressed)
     Path(output_path).write_text(
         json.dumps(comments, ensure_ascii=False) + "\n", encoding="utf-8"
     )
     print(
-        f"inline findings: {len(comments)} anchored comment(s), {skipped} finding(s) not anchorable",
+        f"inline findings: {len(comments)} anchored comment(s), "
+        f"{skipped} finding(s) skipped (not anchorable, resolved, or already threaded)",
         file=sys.stderr,
     )
     return 0

--- a/scripts/publish_helpers.sh
+++ b/scripts/publish_helpers.sh
@@ -120,14 +120,19 @@ cleanup_native_reviews() {
   fi
 }
 
-# Resolve inline finding threads for carried findings this run verified as
-# fixed (#208). Requires env: GH_TOKEN, REPO, PR_NUMBER, GITHUB_ACTION_PATH;
-# optional FINDINGS, INLINE_FINDINGS. Best-effort: never fails the publish —
-# the python script exits 0 on API errors and this wrapper swallows the rest.
-# Gated on inline_findings because without it no marker-bearing threads can
-# exist, and on a non-empty previous-findings.json because resolution only
-# makes sense when this run carried findings forward.
+# Manage inline finding threads for carried findings (#208, #209): resolve
+# threads this run verified as fixed, reply on threads still open, and write
+# finding-threads.json so the comment builder suppresses duplicates.
+# Requires env: GH_TOKEN, REPO, PR_NUMBER, GITHUB_ACTION_PATH; optional
+# FINDINGS, INLINE_FINDINGS, HEAD_SHA, INLINE_FINDINGS_MAX. Best-effort:
+# never fails the publish — the python script exits 0 on API errors and this
+# wrapper swallows the rest. Gated on inline_findings because without it no
+# marker-bearing threads can exist, and on a non-empty previous-findings.json
+# because thread management only makes sense when this run carried findings
+# forward. Must run BEFORE build_review_comments.py so the suppression file
+# exists when comments are built.
 resolve_finding_threads() {
+  rm -f finding-threads.json
   if [ "$(printf '%s' "${INLINE_FINDINGS:-false}" | tr '[:upper:]' '[:lower:]')" != "true" ]; then
     return 0
   fi
@@ -135,8 +140,8 @@ resolve_finding_threads() {
     return 0
   fi
   printf '%s' "${FINDINGS:-[]}" > resolve-findings.json
-  if ! python3 "${GITHUB_ACTION_PATH}/scripts/resolve_finding_threads.py" previous-findings.json resolve-findings.json; then
-    echo "  WARN: finding-thread resolution failed; continuing" >&2
+  if ! python3 "${GITHUB_ACTION_PATH}/scripts/resolve_finding_threads.py" previous-findings.json resolve-findings.json finding-threads.json; then
+    echo "  WARN: finding-thread management failed; continuing" >&2
   fi
   return 0
 }

--- a/scripts/resolve_finding_threads.py
+++ b/scripts/resolve_finding_threads.py
@@ -1,26 +1,38 @@
 #!/usr/bin/env python3
-"""Resolve inline finding threads whose findings this run verified as fixed (#208).
+"""Manage inline finding threads across incremental reviews (#208, #209).
 
 A previous run posted line-anchored inline comments carrying a content
-fingerprint marker (see build_review_comments.finding_marker). When the
-current incremental review's carry-forward concludes a carried finding is
-resolved, this script locates the matching unresolved review thread by that
-marker and resolves it via the GraphQL resolveReviewThread mutation, so
-authors see live thread state instead of stale open conversations.
+fingerprint marker (see build_review_comments.finding_marker). On an
+incremental review this script matches the PR's open review threads by that
+marker and, for each carried finding:
 
-Best-effort by design: any API failure warns and exits 0 — thread resolution
+- resolution "resolved" (carry-forward's fail-closed rule): the thread is
+  resolved via the GraphQL resolveReviewThread mutation, so authors see live
+  thread state instead of stale open conversations (#208);
+- still open (still_open / not_verifiable_from_delta / unanswered): a short
+  reply is posted on the existing thread instead of letting the publish step
+  duplicate the finding as a fresh inline comment (#209).
+
+It also writes the fingerprints of threads that remain open to an output
+file; build_review_comments.py uses it to suppress duplicate anchored
+comments for findings that already have a live thread.
+
+Best-effort by design: any API failure warns and exits 0 — thread management
 must never fail the publish step. Fork PRs with a read-only token simply
-leave threads unresolved.
+leave threads untouched.
 
 Threads are matched by the marker their first comment carries, never by
 author: /user returns 403 for installation tokens (#190).
 
-Usage: resolve_finding_threads.py PREVIOUS_FINDINGS_JSON FINDINGS_JSON_FILE
+Usage: resolve_finding_threads.py PREVIOUS_FINDINGS_JSON FINDINGS_JSON_FILE [OPEN_THREADS_OUT]
 
 Environment:
-  REPO        owner/repo of the pull request
-  PR_NUMBER   pull request number
-  GH_TOKEN    used implicitly by gh
+  REPO                 owner/repo of the pull request
+  PR_NUMBER            pull request number
+  HEAD_SHA             current head SHA, stamped into follow-up replies for
+                       idempotency (optional)
+  INLINE_FINDINGS_MAX  cap on follow-up replies per run (default 20)
+  GH_TOKEN             used implicitly by gh
 """
 
 import json
@@ -43,8 +55,10 @@ _THREADS_QUERY = (
     " repository(owner: $owner, name: $name) {"
     " pullRequest(number: $number) {"
     " reviewThreads(first: 100) {"
-    " nodes { id isResolved comments(first: 1) { nodes { body } } }"
-    " } } } }"
+    " nodes { id isResolved"
+    " first: comments(first: 1) { nodes { body databaseId } }"
+    " last: comments(last: 1) { nodes { body } }"
+    " } } } } }"
 )
 
 _RESOLVE_MUTATION = (
@@ -54,18 +68,21 @@ _RESOLVE_MUTATION = (
 
 _MAX_THREADS_PAGE = 100
 
+# Hidden idempotency stamp on follow-up replies: a re-run on the same head
+# must not stack identical "still open" replies on the thread.
+FOLLOWUP_MARKER_PREFIX = "<!-- ai-pr-review-followup:"
 
-def _gh_graphql(fields: list, timeout: int = 60):
-    """Run ``gh api graphql`` and return the parsed JSON dict, or None.
+
+def _run_gh(args: list, timeout: int = 60):
+    """Run gh and return the parsed JSON dict from stdout, or None.
 
     On HTTP errors gh prints the JSON error body to STDOUT (#190), so a
     non-zero exit discards stdout entirely instead of trying to parse it.
     Anything that is not a JSON object is treated as a failure.
     """
-    cmd = ["gh", "api", "graphql", *fields]
     try:
         completed = subprocess.run(
-            cmd,
+            ["gh", *args],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             timeout=timeout,
@@ -79,6 +96,10 @@ def _gh_graphql(fields: list, timeout: int = 60):
     except (ValueError, UnicodeDecodeError):
         return None
     return parsed if isinstance(parsed, dict) else None
+
+
+def _gh_graphql(fields: list):
+    return _run_gh(["api", "graphql", *fields])
 
 
 def resolved_fingerprints(carried: list, findings) -> set:
@@ -117,36 +138,69 @@ def extract_marker_fingerprint(body):
     return fingerprint or None
 
 
-def threads_to_resolve(thread_nodes, fingerprints: set) -> list:
-    """Thread node ids whose first comment matches a resolved fingerprint.
+def match_threads(thread_nodes) -> dict:
+    """Map fingerprint -> thread info for unresolved marker-bearing threads.
 
-    Only the first comment is checked — that is the thread starter the
-    previous run posted; replies never carry the marker.
+    Only the first comment is checked for the marker — that is the thread
+    starter the previous run posted; replies never carry it. The last
+    comment's body is kept for follow-up idempotency checks.
     """
-    matched = []
+    matched = {}
     for node in thread_nodes or []:
         if not isinstance(node, dict) or node.get("isResolved"):
             continue
         thread_id = node.get("id")
         if not isinstance(thread_id, str) or not thread_id:
             continue
-        comments = (node.get("comments") or {}).get("nodes") or []
-        first = comments[0] if comments and isinstance(comments[0], dict) else {}
+        first_nodes = (node.get("first") or {}).get("nodes") or []
+        first = first_nodes[0] if first_nodes and isinstance(first_nodes[0], dict) else {}
         fingerprint = extract_marker_fingerprint(first.get("body"))
-        if fingerprint and fingerprint in fingerprints:
-            matched.append(thread_id)
+        if not fingerprint or fingerprint in matched:
+            continue
+        last_nodes = (node.get("last") or {}).get("nodes") or []
+        last = last_nodes[0] if last_nodes and isinstance(last_nodes[0], dict) else {}
+        comment_id = first.get("databaseId")
+        matched[fingerprint] = {
+            "thread_id": thread_id,
+            "first_comment_id": comment_id if isinstance(comment_id, int) else None,
+            "last_body": last.get("body") if isinstance(last.get("body"), str) else "",
+        }
     return matched
+
+
+def threads_to_resolve(thread_nodes, fingerprints: set) -> list:
+    """Thread node ids whose first comment matches a resolved fingerprint."""
+    matched = match_threads(thread_nodes)
+    return [info["thread_id"] for fp, info in matched.items() if fp in fingerprints]
+
+
+def followup_body(item: dict, head_sha: str) -> str:
+    """Reply text for a carried finding that survived this review."""
+    if item.get("resolution") == "not_verifiable_from_delta":
+        text = "Not verifiable from this push's delta; carried forward as open."
+    else:
+        text = "Still open after this push; carried forward."
+    if head_sha:
+        text = f"{text} (as of {head_sha[:12]})"
+        return f"_{text}_\n\n{FOLLOWUP_MARKER_PREFIX}{head_sha} -->"
+    return f"_{text}_"
 
 
 def main(argv) -> int:
     previous_path = argv[1] if len(argv) > 1 else "previous-findings.json"
     findings_path = argv[2] if len(argv) > 2 else "findings.json"
+    open_threads_out = argv[3] if len(argv) > 3 else None
 
     repo = os.getenv("REPO", "")
     pr_number = os.getenv("PR_NUMBER", "")
+    head_sha = os.getenv("HEAD_SHA", "").strip()
     if "/" not in repo or not pr_number.isdigit():
         print("resolve_finding_threads: missing REPO/PR_NUMBER; skipping", file=sys.stderr)
         return 0
+    try:
+        max_replies = max(1, int(os.getenv("INLINE_FINDINGS_MAX", "20")))
+    except ValueError:
+        max_replies = 20
 
     carried = load_carried_findings(previous_path)
     if not carried:
@@ -157,10 +211,18 @@ def main(argv) -> int:
     except (OSError, ValueError):
         findings = []
 
-    fingerprints = resolved_fingerprints(carried, findings)
-    if not fingerprints:
-        print("resolve_finding_threads: no resolved carried findings; nothing to resolve")
-        return 0
+    resolved_fps = resolved_fingerprints(carried, findings)
+    resolutions = {
+        f["id"]: f.get("resolution")
+        for f in findings
+        if isinstance(f, dict) and isinstance(f.get("id"), str)
+    }
+    open_by_fp = {}
+    for item in carried:
+        if resolutions.get(item.get("id")) != "resolved":
+            entry = dict(item)
+            entry["resolution"] = resolutions.get(item.get("id")) or "still_open"
+            open_by_fp[finding_fingerprint(item)] = entry
 
     owner, name = repo.split("/", 1)
     data = _gh_graphql(
@@ -172,7 +234,7 @@ def main(argv) -> int:
         ]
     )
     if data is None:
-        print("  WARN: could not list review threads; skipping thread resolution", file=sys.stderr)
+        print("  WARN: could not list review threads; skipping thread management", file=sys.stderr)
         return 0
     try:
         thread_nodes = data["data"]["repository"]["pullRequest"]["reviewThreads"]["nodes"]
@@ -183,27 +245,82 @@ def main(argv) -> int:
     if len(thread_nodes) >= _MAX_THREADS_PAGE:
         print(
             f"  NOTE: PR has {_MAX_THREADS_PAGE}+ review threads; only the first "
-            f"{_MAX_THREADS_PAGE} were checked for resolution",
+            f"{_MAX_THREADS_PAGE} were checked",
             file=sys.stderr,
         )
 
-    thread_ids = threads_to_resolve(thread_nodes, fingerprints)
+    matched = match_threads(thread_nodes)
+
+    # Resolve threads whose carried finding this review verified as fixed (#208).
+    to_resolve = [(fp, info) for fp, info in matched.items() if fp in resolved_fps]
     resolved = 0
-    for thread_id in thread_ids:
-        result = _gh_graphql(
-            ["-f", f"query={_RESOLVE_MUTATION}", "-f", f"id={thread_id}"]
-        )
+    for _fp, info in to_resolve:
+        result = _gh_graphql(["-f", f"query={_RESOLVE_MUTATION}", "-f", f"id={info['thread_id']}"])
         if result is not None:
             resolved += 1
         else:
             print(
-                f"  WARN: could not resolve review thread {thread_id} "
+                f"  WARN: could not resolve review thread {info['thread_id']} "
                 "(may require additional permissions)",
                 file=sys.stderr,
             )
+
+    # Reply on threads whose carried finding is still open (#209), instead of
+    # letting the publish step duplicate it as a fresh anchored comment.
+    replies = 0
+    skipped_dup = 0
+    for fp, info in matched.items():
+        if fp in resolved_fps:
+            continue
+        item = open_by_fp.get(fp)
+        if item is None:
+            # Thread belongs to a finding this run did not carry (e.g. beyond
+            # the carry cap) — leave it alone.
+            continue
+        if head_sha and f"{FOLLOWUP_MARKER_PREFIX}{head_sha} -->" in info["last_body"]:
+            skipped_dup += 1
+            continue
+        if replies >= max_replies:
+            print(
+                f"  NOTE: follow-up reply cap ({max_replies}) reached; remaining "
+                "open threads left without a reply",
+                file=sys.stderr,
+            )
+            break
+        if info["first_comment_id"] is None:
+            continue
+        result = _run_gh(
+            [
+                "api", f"repos/{repo}/pulls/{pr_number}/comments",
+                "--method", "POST",
+                "-F", f"in_reply_to={info['first_comment_id']}",
+                "-f", f"body={followup_body(item, head_sha)}",
+            ]
+        )
+        if result is not None:
+            replies += 1
+        else:
+            print(
+                f"  WARN: could not reply on review thread {info['thread_id']} "
+                "(may require additional permissions)",
+                file=sys.stderr,
+            )
+
+    # Fingerprints with a surviving open thread: the comment builder uses
+    # these to suppress duplicate anchored comments (#209).
+    if open_threads_out:
+        surviving = sorted(fp for fp in matched if fp not in resolved_fps)
+        try:
+            Path(open_threads_out).write_text(
+                json.dumps(surviving) + "\n", encoding="utf-8"
+            )
+        except OSError:
+            print(f"  WARN: could not write {open_threads_out}", file=sys.stderr)
+
     print(
-        f"resolve_finding_threads: resolved {resolved}/{len(thread_ids)} matching "
-        f"thread(s) for {len(fingerprints)} fixed finding(s)"
+        f"resolve_finding_threads: resolved {resolved}/{len(to_resolve)} fixed thread(s), "
+        f"replied on {replies} still-open thread(s)"
+        + (f", {skipped_dup} already up to date" if skipped_dup else "")
     )
     return 0
 

--- a/tests/test_build_review_comments.py
+++ b/tests/test_build_review_comments.py
@@ -198,6 +198,62 @@ class TestFindingFingerprint:
             assert finding_fingerprint(carried[0]) == finding_fingerprint(original)
 
 
+class TestSuppression:
+    def test_resolved_findings_skipped(self):
+        resolved = _finding(line=12)
+        resolved["resolution"] = "resolved"
+        comments, skipped = build_comments([resolved, _finding(line=13, message="open")], DIFF)
+        assert len(comments) == 1
+        assert "open" in comments[0]["body"]
+        assert skipped == 1
+
+    def test_still_open_carried_findings_not_skipped_without_suppression(self):
+        carried = _finding(line=12)
+        carried["resolution"] = "still_open"
+        carried["carried_over"] = True
+        comments, _ = build_comments([carried], DIFF)
+        assert len(comments) == 1
+
+    def test_suppressed_fingerprints_skipped(self):
+        threaded = _finding(line=12, message="already has a thread")
+        fresh = _finding(line=13, message="brand new")
+        from build_review_comments import finding_fingerprint
+
+        comments, skipped = build_comments(
+            [threaded, fresh], DIFF, suppressed={finding_fingerprint(threaded)}
+        )
+        assert len(comments) == 1
+        assert "brand new" in comments[0]["body"]
+        assert skipped == 1
+
+    def test_main_reads_suppression_file_from_env(self, tmp_path, monkeypatch):
+        threaded = _finding(line=12, message="already threaded")
+        from build_review_comments import finding_fingerprint
+
+        findings_file = tmp_path / "findings.json"
+        findings_file.write_text(json.dumps([threaded]))
+        diff_file = tmp_path / "pr.diff"
+        diff_file.write_text(DIFF)
+        suppress_file = tmp_path / "finding-threads.json"
+        suppress_file.write_text(json.dumps([finding_fingerprint(threaded)]))
+        out_file = tmp_path / "comments.json"
+        monkeypatch.setenv("SUPPRESS_FINDINGS_FILE", str(suppress_file))
+        assert main(["prog", str(findings_file), str(diff_file), str(out_file)]) == 0
+        assert json.loads(out_file.read_text()) == []
+
+    def test_missing_or_garbage_suppression_file_ignored(self, tmp_path, monkeypatch):
+        from build_review_comments import load_suppressed_fingerprints
+
+        assert load_suppressed_fingerprints(None) == set()
+        assert load_suppressed_fingerprints(str(tmp_path / "absent.json")) == set()
+        garbage = tmp_path / "garbage.json"
+        garbage.write_text("not json")
+        assert load_suppressed_fingerprints(str(garbage)) == set()
+        not_list = tmp_path / "obj.json"
+        not_list.write_text('{"a": 1}')
+        assert load_suppressed_fingerprints(str(not_list)) == set()
+
+
 class TestMainCli:
     def test_end_to_end(self, tmp_path):
         findings_file = tmp_path / "findings.json"

--- a/tests/test_resolve_finding_threads.py
+++ b/tests/test_resolve_finding_threads.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 """Tests for scripts/resolve_finding_threads.py — fingerprint matching,
-fail-closed resolution selection, and gh interaction against a mocked gh
-that mimics the real CLI's stdout-on-error behavior (#190)."""
+fail-closed resolution selection, still-open follow-up replies, suppression
+output, and gh interaction against a mocked gh that mimics the real CLI's
+stdout-on-error behavior (#190)."""
 
 import json
 import os
@@ -19,8 +20,11 @@ import pytest
 
 from build_review_comments import finding_fingerprint, finding_marker
 from resolve_finding_threads import (
+    FOLLOWUP_MARKER_PREFIX,
     extract_marker_fingerprint,
+    followup_body,
     main,
+    match_threads,
     resolved_fingerprints,
     threads_to_resolve,
 )
@@ -39,6 +43,15 @@ def _carried(finding, index=0):
         "file": finding["file"],
         "line": finding["line"],
         "message": finding["message"][:200],
+    }
+
+
+def _thread(thread_id, body, is_resolved=False, comment_id=1001, last_body=None):
+    return {
+        "id": thread_id,
+        "isResolved": is_resolved,
+        "first": {"nodes": [{"body": body, "databaseId": comment_id}]},
+        "last": {"nodes": [{"body": last_body if last_body is not None else body}]},
     }
 
 
@@ -86,22 +99,26 @@ class TestResolvedFingerprints:
         assert resolved_fingerprints(carried, []) == set()
 
 
-class TestThreadsToResolve:
-    def _thread(self, thread_id, body, is_resolved=False):
-        return {
-            "id": thread_id,
-            "isResolved": is_resolved,
-            "comments": {"nodes": [{"body": body}]},
-        }
-
-    def test_matches_unresolved_marker_threads(self):
+class TestMatchThreads:
+    def test_maps_unresolved_marker_threads(self):
         finding = _finding()
         fp = finding_fingerprint(finding)
         threads = [
-            self._thread("T1", f"text\n\n{finding_marker(finding)}"),
-            self._thread("T2", f"text\n\n{finding_marker(finding)}", is_resolved=True),
-            self._thread("T3", "no marker here"),
-            self._thread("T4", "<!-- ai-pr-review-finding:ffffffffffffffff -->"),
+            _thread("T1", f"text\n\n{finding_marker(finding)}", comment_id=7),
+            _thread("T2", f"text\n\n{finding_marker(finding)}", is_resolved=True),
+            _thread("T3", "no marker here"),
+        ]
+        matched = match_threads(threads)
+        assert set(matched) == {fp}
+        assert matched[fp]["thread_id"] == "T1"
+        assert matched[fp]["first_comment_id"] == 7
+
+    def test_threads_to_resolve_filters_by_fingerprint(self):
+        finding = _finding()
+        fp = finding_fingerprint(finding)
+        threads = [
+            _thread("T1", f"x\n\n{finding_marker(finding)}"),
+            _thread("T4", "<!-- ai-pr-review-finding:ffffffffffffffff -->"),
         ]
         assert threads_to_resolve(threads, {fp}) == ["T1"]
 
@@ -110,16 +127,29 @@ class TestThreadsToResolve:
         thread = {
             "id": "T1",
             "isResolved": False,
-            "comments": {"nodes": [{"body": "starter, no marker"}, {"body": finding_marker(finding)}]},
+            "first": {"nodes": [{"body": "starter, no marker", "databaseId": 1}]},
+            "last": {"nodes": [{"body": finding_marker(finding)}]},
         }
-        assert threads_to_resolve([thread], {finding_fingerprint(finding)}) == []
+        assert match_threads([thread]) == {}
 
     def test_malformed_nodes_skipped(self):
-        assert threads_to_resolve(None, {"x"}) == []
-        assert threads_to_resolve(["junk", {}, {"id": 7, "comments": {}}], {"x"}) == []
+        assert match_threads(None) == {}
+        assert match_threads(["junk", {}, {"id": 7, "first": {}}]) == {}
 
 
-def _install_fake_gh(tmp_path, monkeypatch, threads_response, list_exit=0, mutation_exit=0):
+class TestFollowupBody:
+    def test_still_open_with_sha(self):
+        body = followup_body({"resolution": "still_open"}, "a" * 40)
+        assert "Still open" in body
+        assert f"{FOLLOWUP_MARKER_PREFIX}{'a' * 40} -->" in body
+
+    def test_not_verifiable(self):
+        body = followup_body({"resolution": "not_verifiable_from_delta"}, "")
+        assert "Not verifiable" in body
+        assert FOLLOWUP_MARKER_PREFIX not in body
+
+
+def _install_fake_gh(tmp_path, monkeypatch, threads_response, list_exit=0, mutation_exit=0, reply_exit=0):
     """Drop a fake gh on PATH that logs calls and replays canned responses.
 
     On non-zero exit the fake still prints a JSON error body to stdout,
@@ -142,6 +172,14 @@ def _install_fake_gh(tmp_path, monkeypatch, threads_response, list_exit=0, mutat
         "  echo '{\"data\":{\"resolveReviewThread\":{\"thread\":{\"isResolved\":true}}}}'\n"
         "  exit 0\n"
         "fi\n"
+        "if [[ \"$*\" == *in_reply_to* ]]; then\n"
+        f"  if [ {reply_exit} -ne 0 ]; then\n"
+        "    echo '{\"message\":\"Resource not accessible by integration\"}'\n"
+        f"    exit {reply_exit}\n"
+        "  fi\n"
+        "  echo '{\"id\": 4242}'\n"
+        "  exit 0\n"
+        "fi\n"
         f"if [ {list_exit} -ne 0 ]; then\n"
         "  echo '{\"message\":\"API rate limit exceeded\",\"documentation_url\":\"https://docs.github.com\"}'\n"
         f"  exit {list_exit}\n"
@@ -162,6 +200,13 @@ def _threads_payload(nodes):
     }
 
 
+def _persisted(finding):
+    """build_metadata_marker's open_findings projection of a finding."""
+    persisted = {k: finding[k] for k in ("severity", "category", "file", "line")}
+    persisted["message"] = finding["message"][:200]
+    return persisted
+
+
 def _write_inputs(tmp_path, carried_persisted, findings):
     prev = tmp_path / "previous-findings.json"
     prev.write_text(json.dumps(carried_persisted), encoding="utf-8")
@@ -171,68 +216,107 @@ def _write_inputs(tmp_path, carried_persisted, findings):
 
 
 class TestMainEndToEnd:
+    HEAD_SHA = "c0ffee" * 6 + "abcd"
+
     @pytest.fixture(autouse=True)
     def _env(self, monkeypatch):
         monkeypatch.setenv("REPO", "owner/repo")
         monkeypatch.setenv("PR_NUMBER", "42")
+        monkeypatch.setenv("HEAD_SHA", self.HEAD_SHA)
 
-    def test_resolves_matching_thread(self, tmp_path, monkeypatch):
-        finding = _finding()
-        # Persisted (marker) projection of the finding from the previous run.
-        persisted = {k: finding[k] for k in ("severity", "category", "file", "line")}
-        persisted["message"] = finding["message"][:200]
+    def test_resolves_fixed_and_replies_still_open(self, tmp_path, monkeypatch):
+        fixed = _finding(message="fixed finding")
+        still = _finding(message="still broken", line=33)
         prev, found = _write_inputs(
             tmp_path,
-            [persisted],
-            [{"id": "P1", "resolution": "resolved", "message": finding["message"]}],
+            [_persisted(fixed), _persisted(still)],
+            [
+                {"id": "P1", "resolution": "resolved", "message": fixed["message"]},
+                {"id": "P2", "resolution": "still_open", "message": still["message"]},
+            ],
         )
         log = _install_fake_gh(
             tmp_path,
             monkeypatch,
             _threads_payload(
                 [
-                    {
-                        "id": "T_match",
-                        "isResolved": False,
-                        "comments": {"nodes": [{"body": f"x\n\n{finding_marker(finding)}"}]},
-                    },
-                    {
-                        "id": "T_unrelated",
-                        "isResolved": False,
-                        "comments": {"nodes": [{"body": "human comment"}]},
-                    },
+                    _thread("T_fixed", f"x\n\n{finding_marker(fixed)}", comment_id=11),
+                    _thread("T_still", f"x\n\n{finding_marker(still)}", comment_id=22),
+                    _thread("T_unrelated", "human comment", comment_id=33),
                 ]
             ),
         )
-        assert main(["prog", prev, found]) == 0
+        out = tmp_path / "finding-threads.json"
+        assert main(["prog", prev, found, str(out)]) == 0
         calls = log.read_text()
-        assert "T_match" in calls
-        assert "T_unrelated" not in calls
         assert calls.count("resolveReviewThread") == 1
+        assert "T_fixed" in calls
+        assert "in_reply_to=22" in calls
+        assert "in_reply_to=33" not in calls
+        # Suppression file lists only the surviving open thread.
+        assert json.loads(out.read_text()) == [finding_fingerprint(still)]
 
-    def test_still_open_thread_left_alone(self, tmp_path, monkeypatch):
-        finding = _finding()
-        persisted = {k: finding[k] for k in ("severity", "category", "file", "line")}
-        persisted["message"] = finding["message"][:200]
+    def test_followup_already_posted_for_head_is_skipped(self, tmp_path, monkeypatch):
+        still = _finding(message="still broken")
         prev, found = _write_inputs(
             tmp_path,
-            [persisted],
-            [{"id": "P1", "resolution": "still_open", "message": finding["message"]}],
+            [_persisted(still)],
+            [{"id": "P1", "resolution": "still_open", "message": still["message"]}],
+        )
+        log = _install_fake_gh(
+            tmp_path,
+            monkeypatch,
+            _threads_payload(
+                [
+                    _thread(
+                        "T_still",
+                        f"x\n\n{finding_marker(still)}",
+                        last_body=f"_Still open_\n\n{FOLLOWUP_MARKER_PREFIX}{self.HEAD_SHA} -->",
+                    )
+                ]
+            ),
+        )
+        out = tmp_path / "finding-threads.json"
+        assert main(["prog", prev, found, str(out)]) == 0
+        assert "in_reply_to" not in log.read_text()
+        # Still suppressed: the thread exists and stays open.
+        assert json.loads(out.read_text()) == [finding_fingerprint(still)]
+
+    def test_unanswered_carried_finding_gets_reply(self, tmp_path, monkeypatch):
+        """Fail-closed: a carried finding the model never answered is still
+        open, so its thread gets a follow-up too."""
+        still = _finding(message="ghosted finding")
+        prev, found = _write_inputs(tmp_path, [_persisted(still)], [])
+        log = _install_fake_gh(
+            tmp_path,
+            monkeypatch,
+            _threads_payload([_thread("T_still", f"x\n\n{finding_marker(still)}", comment_id=5)]),
+        )
+        assert main(["prog", prev, found]) == 0
+        assert "in_reply_to=5" in log.read_text()
+
+    def test_no_thread_no_reply_not_suppressed(self, tmp_path, monkeypatch):
+        """A still-open carried finding without a surviving thread falls back
+        to the fresh-comment path: no reply, absent from suppression."""
+        still = _finding(message="never anchored")
+        prev, found = _write_inputs(
+            tmp_path,
+            [_persisted(still)],
+            [{"id": "P1", "resolution": "still_open", "message": still["message"]}],
         )
         log = _install_fake_gh(tmp_path, monkeypatch, _threads_payload([]))
-        assert main(["prog", prev, found]) == 0
-        # Nothing resolved → not even the thread list is fetched.
-        assert not log.exists()
+        out = tmp_path / "finding-threads.json"
+        assert main(["prog", prev, found, str(out)]) == 0
+        assert "in_reply_to" not in log.read_text()
+        assert json.loads(out.read_text()) == []
 
     def test_gh_list_failure_is_swallowed(self, tmp_path, monkeypatch, capsys):
         """gh exits non-zero and prints a JSON error body to stdout (#190);
-        the script must warn, skip resolution, and still exit 0."""
+        the script must warn, skip everything, and still exit 0."""
         finding = _finding()
-        persisted = {k: finding[k] for k in ("severity", "category", "file", "line")}
-        persisted["message"] = finding["message"][:200]
         prev, found = _write_inputs(
             tmp_path,
-            [persisted],
+            [_persisted(finding)],
             [{"id": "P1", "resolution": "resolved", "message": finding["message"]}],
         )
         log = _install_fake_gh(tmp_path, monkeypatch, _threads_payload([]), list_exit=1)
@@ -242,29 +326,53 @@ class TestMainEndToEnd:
 
     def test_mutation_failure_is_swallowed(self, tmp_path, monkeypatch, capsys):
         finding = _finding()
-        persisted = {k: finding[k] for k in ("severity", "category", "file", "line")}
-        persisted["message"] = finding["message"][:200]
         prev, found = _write_inputs(
             tmp_path,
-            [persisted],
+            [_persisted(finding)],
             [{"id": "P1", "resolution": "resolved", "message": finding["message"]}],
         )
         _install_fake_gh(
             tmp_path,
             monkeypatch,
-            _threads_payload(
-                [
-                    {
-                        "id": "T_match",
-                        "isResolved": False,
-                        "comments": {"nodes": [{"body": finding_marker(finding)}]},
-                    }
-                ]
-            ),
+            _threads_payload([_thread("T_match", finding_marker(finding))]),
             mutation_exit=1,
         )
         assert main(["prog", prev, found]) == 0
         assert "could not resolve review thread" in capsys.readouterr().err
+
+    def test_reply_failure_is_swallowed(self, tmp_path, monkeypatch, capsys):
+        still = _finding(message="still broken")
+        prev, found = _write_inputs(
+            tmp_path,
+            [_persisted(still)],
+            [{"id": "P1", "resolution": "still_open", "message": still["message"]}],
+        )
+        _install_fake_gh(
+            tmp_path,
+            monkeypatch,
+            _threads_payload([_thread("T_still", finding_marker(still))]),
+            reply_exit=1,
+        )
+        assert main(["prog", prev, found]) == 0
+        assert "could not reply on review thread" in capsys.readouterr().err
+
+    def test_reply_cap_respected(self, tmp_path, monkeypatch):
+        findings = [_finding(message=f"open finding {i}", line=10 + i) for i in range(3)]
+        prev, found = _write_inputs(
+            tmp_path,
+            [_persisted(f) for f in findings],
+            [{"id": f"P{i + 1}", "resolution": "still_open", "message": f["message"]} for i, f in enumerate(findings)],
+        )
+        monkeypatch.setenv("INLINE_FINDINGS_MAX", "1")
+        log = _install_fake_gh(
+            tmp_path,
+            monkeypatch,
+            _threads_payload(
+                [_thread(f"T{i}", finding_marker(f), comment_id=100 + i) for i, f in enumerate(findings)]
+            ),
+        )
+        assert main(["prog", prev, found]) == 0
+        assert log.read_text().count("in_reply_to") == 1
 
     def test_missing_env_skips(self, tmp_path, monkeypatch):
         monkeypatch.delenv("PR_NUMBER")
@@ -285,10 +393,26 @@ class TestActionWiring:
     def test_both_publish_steps_resolve_threads(self):
         assert self.ACTION.count("resolve_finding_threads") == 2
 
+    def test_resolution_precedes_comment_build(self):
+        # The suppression file must exist before comments are built, in both
+        # publish steps.
+        action = self.ACTION
+        first_build = action.find("build_review_comments.py")
+        first_resolve = action.find("resolve_finding_threads")
+        assert -1 < first_resolve < first_build
+        second_build = action.find("build_review_comments.py", first_build + 1)
+        second_resolve = action.find("resolve_finding_threads", first_resolve + 1)
+        assert -1 < second_resolve < second_build
+
+    def test_builders_receive_suppression_file(self):
+        assert self.ACTION.count("SUPPRESS_FINDINGS_FILE=finding-threads.json") == 2
+
     def test_helper_gates_on_inline_findings_and_carryover(self):
         assert "resolve_finding_threads()" in self.HELPERS
         assert "previous-findings.json" in self.HELPERS
         assert "INLINE_FINDINGS" in self.HELPERS
+        # Stale suppression from a previous step must not leak.
+        assert "rm -f finding-threads.json" in self.HELPERS
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #209. Builds on #210 (merged).

## What

- `resolve_finding_threads.py` becomes a thread manager. After resolving threads for fixed findings (#210), it now:
  - posts an `in_reply_to` follow-up on threads whose carried finding survives this review (`still_open`, `not_verifiable_from_delta`, or unanswered — same fail-closed rule as carry-forward): _"Still open after this push; carried forward. (as of <sha>)"_;
  - stamps each reply with a hidden `<!-- ai-pr-review-followup:<head_sha> -->` marker and checks the thread's last comment for it, so a re-run on the same push never stacks duplicate follow-ups;
  - caps replies with the existing `INLINE_FINDINGS_MAX` budget;
  - writes the fingerprints of surviving open threads to `finding-threads.json`.
- `build_review_comments.py` reads that file (`SUPPRESS_FINDINGS_FILE`) and skips findings that already have a live thread — one conversation per finding instead of N duplicates across N pushes. It also now skips findings the model marked `resolution: resolved` (a fixed finding needs no fresh anchored comment).
- A still-open carried finding whose thread no longer exists is **not** suppressed — it falls back to the fresh-comment path as before.
- Thread management moved before the comment build in both publish steps (the suppression file must exist when comments are built); the helper clears stale `finding-threads.json` on entry.

## Tests

- `tests/test_resolve_finding_threads.py` grown to 18 cases: resolve+reply partition, SHA idempotency, unanswered-finding fail-closed reply, no-thread fallback (not suppressed), reply cap, reply/list/mutation failure modes against the mocked `gh` (JSON-error-on-stdout, #190), suppression-file output, and wiring order assertions (resolve precedes build in both steps).
- `tests/test_build_review_comments.py`: suppression-by-fingerprint, resolved-finding skip, env-driven suppression file in `main`, garbage-file tolerance.
- Full suite after rebase onto main: 625 python tests pass; `test_cleanup_native_reviews_behavior.sh` (20) passes.

## Not verified here

Live REST `in_reply_to` reply behavior against a real PR — unit-tested against mocks only; worth watching alongside #210's resolution on the first dogfood PR after release.
