### PR TITLE
fix: pass FINDINGS to comment-mode publish step so carry-forward engages

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -638,6 +638,7 @@ runs:
         REVIEW_ROUTE: ${{ steps.review.outputs.review_route }}
         ESCALATION_REASON: ${{ steps.review.outputs.escalation_reason }}
         REVIEW_MARKDOWN: ${{ steps.review.outputs.review_markdown }}
+        FINDINGS: ${{ steps.review.outputs.findings }}
         ANALYSIS_ENGINE: ${{ steps.review.outputs.analysis_engine }}
         COMMENT_MARKER: ${{ inputs.comment_marker }}
         GITHUB_ACTION_PATH: ${{ github.action_path }}

--- a/tests/test_build_review_comments.py
+++ b/tests/test_build_review_comments.py
@@ -281,8 +281,11 @@ class TestActionWiring:
         assert "inline_findings:" in self.ACTION
         assert "inline_findings_max:" in self.ACTION
 
-    def test_native_steps_receive_findings(self):
-        assert self.ACTION.count("FINDINGS: ${{ steps.review.outputs.findings }}") == 2
+    def test_all_publish_steps_receive_findings(self):
+        # All three publish steps (comment, review_comment, review_verdict)
+        # must receive FINDINGS so build_metadata_marker persists
+        # open_findings — without it, carry-forward never engages.
+        assert self.ACTION.count("FINDINGS: ${{ steps.review.outputs.findings }}") == 3
         assert self.ACTION.count("INLINE_FINDINGS: ${{ inputs.inline_findings }}") == 2
 
     def test_review_verdict_falls_back_on_failure(self):


### PR DESCRIPTION
## What changed

- Added `FINDINGS: ${{ steps.review.outputs.findings }}` to the env block of the comment-mode **Publish review comment** step in `action.yml`, matching the `review_comment` and `review_verdict` publish steps.
- Updated `TestActionWiring` in `tests/test_build_review_comments.py`: renamed `test_native_steps_receive_findings` to `test_all_publish_steps_receive_findings` and tightened the assertion to require all three publish steps receive `FINDINGS` (count == 3). `INLINE_FINDINGS` stays at 2 since comment mode doesn't post inline findings.

## Why

`build_metadata_marker` in `scripts/publish_helpers.sh` reads `${FINDINGS:-[]}` to persist `open_findings` into the managed metadata marker. The comment-mode publish step never passed `FINDINGS`, so it always persisted an empty array. Incremental scope and skip-on-unchanged still worked, but finding carry-forward (#193) — the fail-closed mechanism where unresolved blockers survive into the next incremental review and force `request_changes` — silently never engaged in comment mode, because the next run's `previous-findings.json` was always empty.

## Reviewer notes

- The prior wiring test asserted the buggy state (`count == 2`), so it doubles as proof the regression test catches this: it fails without the one-line `action.yml` change.
- Verified with `pytest tests/` — 625 passed.
