### PR TITLE
docs: restructure README for readability and refresh AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,62 +1,110 @@
 # Agents Guide: pr-reviewer-action
 
-This is a GitHub Action that analyzes pull requests using OpenAI-compatible or Anthropic-compatible models (cloud or self-hosted) and optionally publishes a sticky PR comment with the review.
+This is a GitHub Action that analyzes pull requests using OpenAI-compatible or Anthropic-compatible models (cloud or self-hosted) and publishes the review as a sticky PR comment or a native GitHub review.
 
 ## What it does
 
-The action collects rich PR context (diff, files, linked issues, version hints, image digests, repo impact/history, standards files), assembles a review corpus, sends it to an LLM via OpenAI `POST /chat/completions` or Anthropic `POST /messages`, parses the JSON verdict + markdown body, and optionally publishes or updates a managed PR comment.
+The action collects rich PR context (diff, files, linked issues, version hints, image digests, repo impact/history, standards files), runs a deterministic rule-based classification (PR kind, risk flags, required checks), assembles a review corpus, routes the review to a fast or smart model (optional), sends it to an LLM via OpenAI `POST /chat/completions` or Anthropic `POST /messages`, parses the JSON verdict + markdown body + optional structured findings, validates/enforces the result (required checks, findings severity gating, carried-forward findings, evidence/tool enforcement), and publishes via one of three modes (`comment`, `review_comment`, `review_verdict`).
 
 ## Key files
 
-- **`action.yml`** - Action definition with all inputs/outputs and composite run steps
-- **`scripts/run_review.sh`** - Main review orchestration script (collects context, builds corpus, calls model, enforces verdicts)
-- **`scripts/check_review_needed.sh`** - Precheck: computes `git patch-id --stable` fingerprint and skips if unchanged since last managed comment
-- **`scripts/default_system_prompt.txt`** - Bundled system prompt used when no override is provided
-- **`scripts/run_evidence_providers.py`** - Runs user-defined evidence provider commands from a JSON config, parses severity/findings output
-- **`scripts/run_tool_harness.py`** - Tool harness in `plan_execute_once` mode: model plans read-only tool requests (gh_api, read_file, web_fetch, git_grep), action executes them, appends results to corpus
-- **`scripts/strip_metadata_markers.py`** - Strips internal metadata markers from model output before publishing (fixed in PR #47 / issue #33)
-- **`scripts/image_digest_analysis.py`** - Analyzes image digests from the diff for provenance context
-- **`tests/smoke_test.sh`** - Local smoke test against a real PR with mock OpenAI server
-- **`tests/mock_openai_server.py`** - Mock API server used by the smoke test
+### Action definition and orchestration
+
+- **`action.yml`** — Action definition with all inputs/outputs and composite run steps (precheck → CI wait → review → publish). The publish steps live inline in this file using helpers from `scripts/publish_helpers.sh`.
+- **`scripts/check_review_needed.sh`** — Precheck: computes `git patch-id --stable` fingerprint, decides full vs. incremental scope, and skips if unchanged since last managed comment
+- **`scripts/wait_for_ci.sh`** — Optional CI gating: polls commit status until checks reach a terminal state (`ci_status_check=true`)
+- **`scripts/run_review.sh`** — Main review orchestration script (collects context, builds corpus, classifies, routes, calls model, validates and enforces verdicts)
+- **`scripts/model_call.sh`** — Shared model-call layer: request building, streaming/SSE handling, retries, error-body preservation for both API formats
+- **`scripts/default_system_prompt.txt`** — Bundled system prompt used when no override is provided
+
+### Python package (`pr_reviewer/`)
+
+- **`classifier.py`** — Deterministic PR classification: `pr_kind`, `risk_flags`, `must_check` checklist (no model calls)
+- **`completeness.py`** — Required-check completeness validation: keyword-matches `review_markdown` against `must_check` items
+- **`enforcement.py`** — Verdict policy (`model` / `findings_severity_gated`), findings normalization, evidence/tool enforcement; records `verdict_source`
+- **`escalation.py`** — Post-hoc escalation triggers for fast reviews (request_changes, low confidence, incomplete checks, blockers, dirty baseline)
+- **`carry_forward.py`** — Carried-forward open findings for incremental reviews; surviving blockers force `request_changes` (`verdict_source: carry_forward`)
+- **`metadata.py`** — Managed metadata marker (fingerprint, scope, open findings) embedded in published comments
+- **`github_context.py`** — PR metadata/linked-issue context helpers
+- **`response_parser.py`** — Tolerant model-output parsing (JSON in fences/prose, verdict + findings extraction)
+- **`sse_reassembler.py`** — Reassembles streamed SSE responses into complete bodies
+
+### Publishing and output hygiene
+
+- **`scripts/publish_helpers.sh`** — Shared publish functions: sanitize, metadata marker build, native review cleanup, finding-thread resolution
+- **`scripts/sanitize_review_markdown.py`** — Neutralizes upstream GitHub auto-links (PR/issue/commit URLs, `owner/repo#123`, bare `#123`) in review output
+- **`scripts/strip_metadata_markers.py`** — Strips reserved `<!-- ai-pr-review-*:... -->` markers from model output before publishing
+- **`scripts/redact.py`** — Shared secret-redaction pipeline applied to tool and evidence-provider output
+- **`scripts/build_review_comments.py`** — Builds line-anchored inline review comments from structured findings, validated against the PR diff
+- **`scripts/resolve_finding_threads.py`** — Resolves/replies on existing finding threads by content fingerprint on re-review
+- **`scripts/strip_source_text.py`** — Strips fetched source text where needed for corpus hygiene
+
+### Enrichment
+
+- **`scripts/run_evidence_providers.py`** — Runs user-defined evidence provider commands from a JSON config, parses severity/findings output
+- **`scripts/run_tool_harness.py`** — Tool harness (`plan_execute_once` and `plan_execute_loop`): model plans read-only tool requests (`gh_api`, `read_file`, `web_fetch`, `git_grep`, named-only `run_command`), action executes them, appends results to corpus
+- **`scripts/image_digest_analysis.py`** — Analyzes image digests from the diff for provenance context
+
+### Tests
+
+- **`tests/smoke_test.sh`** — Local smoke test against a real PR with a mock OpenAI/Anthropic server
+- **`tests/mock_openai_server.py`** — Mock API server used by the smoke test
+- **`tests/test_*.py`** — pytest suite (run in CI via `pytest tests/`)
+- **`tests/test_*.sh`** — shell-based behavior tests for action scripts
 
 ## Architecture
 
 ```
-check_review_needed.sh          → should_review + diff_fingerprint
-run_review.sh                   → collects context → builds corpus → calls model → enforces verdicts
+check_review_needed.sh          → should_review + diff_fingerprint + effective scope (full/incremental)
+wait_for_ci.sh (optional)       → block until CI checks are terminal
+run_review.sh                   → collects context → classifies → builds corpus → routes → calls model → validates/enforces
   ├─ gh pr view/diff/api        → PR metadata, files, linked issues
+  ├─ pr_reviewer.classifier     → pr_kind, risk_flags, must_check (rule-based, no model)
   ├─ URL fetching               → Linked sources from PR body (allowlisted hosts)
   ├─ image_digest_analysis.py   → Image digest provenance
   ├─ run_evidence_providers.py  → User-defined provider commands
-  ├─ run_tool_harness.py        → Tool harness planning + execution
-  └─ Model call with retries    → Primary model, fallback if needed
-publish_review_comment         → sanitizes markdown → builds managed comment → publishes
-  ├─ strip_metadata_markers.py  → Strips <!-- ai-pr-review-*:... --> from model output
-  └─ gh pr comment              → Edit-last or create-if-none with metadata + review body
+  ├─ run_tool_harness.py        → Tool harness planning + execution (once or loop)
+  ├─ model_call.sh              → Fast/smart routing, retries, streaming, fallback
+  └─ pr_reviewer.{completeness,enforcement,escalation,carry_forward}
+                                 → required-check validation, verdict policy, escalation, carried findings
+publish (action.yml steps)      → sanitize markdown → strip markers → build managed body → publish
+  ├─ publish_mode=comment        → gh pr comment --edit-last --create-if-none (sticky)
+  ├─ publish_mode=review_comment → sticky comment + optional inline-findings COMMENT review
+  └─ publish_mode=review_verdict → native approve/request_changes (guardrailed) + inline comments
+     ├─ cleanup_native_reviews   → dismiss/stub previous managed reviews
+     └─ resolve_finding_threads  → resolve or reply on existing finding threads
 ```
 
 ## Review corpus sections (in order)
 
-1. Repository Standards and Conventions (from CLAUDE.md, AGENTS.md, etc.) — always included in full
-2. Changed Manifest Context (Helm/K8s manifests)
-3. PR Metadata (JSON from `gh pr view`)
-4. Linked Issue Context (from Fixes/Closes references in PR body)
-5. PR Files (truncated JSON with patches)
-6. Version Hints from Diff
-7. PR Diff (truncated)
-8. Linked Sources (fetched URLs, GitHub releases/compare metadata)
-9. Evidence Providers (user-defined command output)
-10. Tool Harness Findings (planned + executed tool results)
+1. Changed Manifest Context (Helm/K8s manifests)
+2. PR Metadata (JSON from `gh pr view`)
+3. PR Classification (deterministic classifier output)
+4. Incremental Review Delta + Carried-Forward Open Findings (incremental scope only)
+5. Linked Issue Context (from Fixes/Closes references in PR body)
+6. PR Files (truncated JSON with patches)
+7. Version Hints from Diff
+8. PR Diff (truncated)
+9. Tool Harness Findings (planned + executed tool results)
+10. Evidence Providers (user-defined command output)
 11. Image Digest Provenance
-12. Repository Impact Scan (git grep hits for extracted terms)
-13. Repository History (git log context for extracted terms)
+12. Linked Sources (fetched URLs, GitHub releases/compare metadata)
+13. Repository Impact Scan (git grep hits for extracted terms)
+14. Repository History (git log context for extracted terms)
+15. Repository Standards and Conventions (from AGENTS.md, CLAUDE.md, etc.)
 
-Note: `MAX_CORPUS` truncation applies only to sections 2-13; the standards section (1) is always preserved in full.
+Note: `MAX_CORPUS` truncation applies to sections 1–14; the standards section is always preserved in full.
 
 ## Running tests
 
 ```bash
-# Run smoke test against a specific PR
+# Python unit tests (what CI runs)
+pytest tests/ -v --tb=short
+
+# Shell behavior tests are standalone, e.g.
+tests/test_check_review_needed.sh
+
+# Smoke test against a specific PR
 PR_NUMBER=6757 tests/smoke_test.sh
 
 # Let it pick the most recent open PR in misospace/pr-reviewer-action
@@ -68,23 +116,33 @@ The smoke test validates: GitHub PR data collection, corpus assembly, OpenAI/Ant
 ## Important conventions
 
 - All model calls use `curl -q` to avoid `.curlrc` timeouts interfering with local models
-- Model responses are parsed by extracting JSON from markdown code blocks or scanning for the first valid JSON object
-- Verdict must be `"approve"` or `"request_changes"` with a non-empty `review_markdown` string
-- Context limit modes: `normal` (140k/70k/220k), `low` (80k/40k/120k), `minimal` (40k/20k/60k) — controls MAX_DIFF, MAX_FILES, MAX_CORPUS byte limits
+- Model responses are parsed by extracting JSON from markdown code blocks or scanning for the first valid JSON object (`pr_reviewer/response_parser.py`)
+- Verdict must be `"approve"` or `"request_changes"` with a non-empty `review_markdown` string; an optional `findings` array is normalized (severities mapped to `blocker`/`major`/`minor`/`info`, malformed entries dropped)
+- Context limit modes: `normal` (140k/70k/220k), `low` (80k/40k/120k), `minimal` (40k/20k/60k) — controls MAX_DIFF, MAX_FILES, MAX_CORPUS byte limits. `model_context_tokens` overrides these by deriving budgets from the real context window
 - Evidence providers and tool harness are disabled by default on cross-repository PRs (`*_enable_for_forks=false`)
+- Native approvals are off by default (`allow_approve=false`); fork approvals additionally require `approve_forks=true`
 - Standards file resolution: explicit `standards_file` → first found from `standards_file_candidates` list (default: AGENTS.md, agents.md, CLAUDE.md, claude.md, .github/ai-review-rules.md, .github/ai-review-rules.txt). Candidates support glob patterns (e.g. `.agents/*.md`); first match wins.
 - System prompt priority: inline `system_prompt` > file `system_prompt_file` > bundled default
+- Reserved metadata markers (`<!-- ai-pr-review-fingerprint:... -->`, `<!-- ai-pr-review-sha:... -->`) are stripped from model output before publishing; the precheck reads only the first occurrence of each
+- The `run_command` tool never executes model-supplied shell text — only named argv definitions from a fixed read-only catalog (`git_status_short`, `git_diff_stat`, `git_diff_name_only`)
+- Versioning: `v1.x.y` semver tags; feature releases stay on `1.2.x` (`v1.3.0` is reserved for the tool-calling milestone, issue #197)
 
 ## Inputs summary
 
 Required: `github_token`, `ai_base_url`, `ai_model`
-Optional but common: `ai_api_key`, `publish_review_comment`, `standards_file`, `context_limit_mode`, `evidence_providers_file`, `tool_mode`
+Optional but common: `ai_api_key`, `publish_review_comment`, `publish_mode`, `standards_file`, `model_context_tokens`, `ai_response_format`, `review_routing_mode`, `evidence_providers_file`, `tool_mode`
+
+See `action.yml` (the source of truth) or the README's grouped input tables for the full list.
 
 ## Outputs summary
 
 - `verdict`: `"approve"` or `"request_changes"`
+- `verdict_source`: `"model"`, `"findings"`, or `"carry_forward"`
+- `required_checks`: `"complete"`, `"incomplete"`, or `"none"`
+- `review_route` / `escalation_reason`: routing outcome (`legacy`/`fast`/`smart`/`escalated`) and trigger names
+- `findings`: normalized structured findings as a JSON array
 - `review_markdown`: Full markdown review body
 - `analysis_engine`: Model and endpoint string (e.g. `qwen3-32b@http://llama-server.internal:8080/v1`)
-- `should_review`: Whether a new LLM review was run
-- `skip_reason`: Skip reason if skipped (e.g. `"diff-unchanged"`)
-- `diff_fingerprint`: Stable fingerprint of the PR patch
+- `should_review` / `skip_reason` / `diff_fingerprint`: precheck results
+- `ci_status_skipped` / `ci_status_final`: CI gating results
+- `effective_review_scope` / `previous_head_sha` / `baseline_clean`: incremental-review state

--- a/README.md
+++ b/README.md
@@ -1,193 +1,34 @@
-# pr-reviewer-action
+<div align="center">
 
-Analyze pull requests with a self-hosted or cloud OpenAI-compatible or Anthropic-compatible model.
+# 🤖 pr-reviewer-action
+
+**AI pull request reviews with any OpenAI- or Anthropic-compatible model — cloud or self-hosted.**
+
+*Point it at your llama.cpp box or your Anthropic key. Either way, every PR gets a real review.*
 
 [![CI](https://github.com/misospace/pr-reviewer-action/actions/workflows/ci.yaml/badge.svg)](https://github.com/misospace/pr-reviewer-action/actions/workflows/ci.yaml)
+[![Latest release](https://img.shields.io/github/v/release/misospace/pr-reviewer-action)](https://github.com/misospace/pr-reviewer-action/releases)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
-The action gathers PR metadata, diff context, linked issue context from PR-closing references, linked sources, optional evidence provider output, optional tool harness output, image digest provenance, basic repository impact/history, and an optional standards file such as `CLAUDE.md`. It returns a structured verdict and markdown review body, and it can also publish or update a sticky PR comment.
+**[Quick start](#-quick-start)** · **[How it works](#%EF%B8%8F-how-it-works)** · **[Inputs](#%EF%B8%8F-inputs)** · **[Recipes](#-usage-recipes)** · **[Troubleshooting](#-local-model-troubleshooting)**
 
-## What it supports
+</div>
 
-- self-hosted OpenAI-compatible endpoints
-- native Anthropic-compatible `/messages` endpoints
-- cloud OpenAI-compatible or Anthropic-compatible subscriptions
-- optional fallback model/endpoint
-- optional evidence providers for repo-specific checks
-- optional read-only tool harness for one planning round
-- optional managed PR comment publishing
-- automatic skip when the effective PR diff is unchanged since the last managed review
-- linked issue body ingestion from `Fixes #123`, `Closes owner/repo#456`, and similar PR-body references
-- repo-provided rules via `CLAUDE.md`, `AGENTS.md`, or a custom file
-- upstream link sanitizer to neutralize auto-linked PR/issue/commit references in published reviews
+---
 
-### Upstream Link Sanitizer
+The action gathers PR metadata, diff context, linked issue context from PR-closing references, linked sources, optional evidence provider output, optional tool harness output, image digest provenance, basic repository impact/history, and an optional standards file such as `CLAUDE.md`. It returns a structured verdict and markdown review body, and it can publish the result as a sticky comment or a native GitHub review.
 
-Before publishing, the action runs `scripts/sanitize_review_markdown.py` on the review markdown to neutralize upstream GitHub references (PR URLs, issue URLs, commit URLs, compare URLs, cross-repo `owner/repo#123` references, and bare `#123` references). This prevents GitHub from auto-linking them into the reviewed repository, which would create notification noise and misleading linkbacks to unrelated projects. Sanitization is documented as P0 hygiene in [issue #132](https://github.com/misospace/pr-reviewer-action/issues/132).
+## ✨ Highlights
 
+- 🏠 **Local-model-first** — works with ollama, llama.cpp, vLLM, LiteLLM, or any OpenAI/Anthropic-compatible endpoint, with a cloud fallback if you want one
+- 🧭 **Deterministic PR classification** — rule-based risk flags and required checklists keep small models focused and honest
+- ⚡ **Fast/smart model routing** — boring PRs go to a cheap model, scary ones escalate to a smarter one automatically
+- 🔍 **Structured findings** — severity-tagged findings, optional line-anchored inline comments, and a severity-gated verdict policy
+- 💸 **Token-saving by design** — unchanged-diff skip, incremental re-reviews, and carry-forward of unresolved findings
+- 🛡️ **Safe by default** — approvals off, fork enrichment off, read-only tool allowlists, secret redaction, link sanitization
+- 🧰 **Extensible** — repo-defined evidence providers, a bounded read-only tool harness, repo-local rules (`AGENTS.md`/`CLAUDE.md`) and prompt overrides
 
-
-### Deterministic PR Classification
-
-Before invoking the AI model, the action runs a deterministic classification step that analyzes changed file paths, diff content, and linked issue context to produce structured metadata about the PR. This helps smaller/weaker reviewer models stay focused and reduces the chance of being misled by irrelevant context.
-
-**Classification output (injected into the review corpus):**
-
-| Field | Description |
-|-------|-------------|
-| `pr_kind` | One of: `renovate_digest_only`, `dependency_upgrade`, `app_code`, `k8s_manifest`, `auth_changes`, `public_route_changes`, `file_serving_changes`, `path_handling_changes`, `secret_handling_changes`, `db_or_migration_changes` |
-| `risk_flags` | Detected risk indicators such as `linked_security_issue`, `linked_audit_issue`, `linked_priority_p0`, `linked_priority_p1`, `file_serving_changes`, `path_handling_changes`, `auth_changes`, `secret_handling_changes` |
-| `changed_files_summary` | List of changed file paths (truncated to 50) |
-| `linked_issue_labels` | Labels from linked issues when available |
-| `must_check` | Explicit checklist items derived from the classification (e.g., "review auth flow for regression" for `auth_changes`) |
-
-The classification is purely rule-based — no model calls are involved. It uses pattern matching on file paths, diff content, and linked issue metadata to determine the PR type and associated risk flags.
-
-**Default required checks per risk class** (`must_check` is the union of the checks for the `pr_kind` and every detected risk flag — a PR classified as `app_code` that still trips the `auth_changes` flag gets the auth checklist):
-
-| Risk class | Required checks |
-|------------|-----------------|
-| `renovate_digest_only` | verify no functional changes beyond lockfile hashes |
-| `dependency_upgrade` | breaking API changes in updated dependencies; run full test suite after upgrade |
-| `k8s_manifest` | validate manifest against target cluster version; resource quota / limit changes |
-| `auth_changes` | review auth flow for regression; session token handling |
-| `public_route_changes` | route access controls; unintended public endpoints |
-| `file_serving_changes` | file path sanitization; directory traversal |
-| `path_handling_changes` | path traversal; edge-case paths (null bytes, symlinks) |
-| `secret_handling_changes` | secrets not logged/exposed; secret rotation impact |
-| `db_or_migration_changes` | migration data-loss risk; test on a copy of production schema |
-| `linked_security_issue` / `linked_audit_issue` / `linked_priority_p0`/`p1` | explicitly address the linked issue / verify thoroughly |
-
-These checklists exist to keep weaker local models honest on high-risk PRs: the items are injected into the model's instructions ("address EACH of these"), and the review is then **validated** against them.
-
-### Required-check completeness validation
-
-After the model returns, the action deterministically checks whether `review_markdown` actually discussed each `must_check` item (shallow keyword matching — it catches reviews that never mentioned a required check, not incorrect discussion). Controlled by `validate_required_checks` (`auto` = validate when must_check is non-empty) and `required_check_validation_mode`:
-
-- `warn` (default): an **Unaddressed required checks** section listing the missing items is appended to the published review, so a human sees exactly what the model skipped. The verdict is not changed.
-- `fail`: additionally forces a `request_changes` verdict.
-- `metadata_only`: records the result without touching the published review — for downstream automation.
-
-The result is exposed as the `required_checks` output (`complete` / `incomplete` / `none`), written to the run's step summary, and recorded in the managed metadata marker for future runs. Low-risk PRs (empty `must_check`) produce no validation noise.
-
-## Requirements
-
-- The repository under review must already be checked out.
-- The runner must have `gh`, `jq`, `curl`, `git`, and `python3`.
-- The workflow should run on `pull_request` events, or pass explicit `repo` and `pr_number` inputs.
-
-## Inputs
-
-| Input | Description | Required | Default |
-|-------|-------------|----------|---------|
-| `github_token` | GitHub token for PR and API access | Yes | - |
-| `repo` | Repository in `owner/name` format | No | current repository |
-| `pr_number` | Pull request number | No | current `pull_request` number |
-| `ai_base_url` | Base URL of the primary AI API | Yes | - |
-| `ai_api_format` | Primary API request/response format: `openai` or `anthropic` | No | `openai` |
-| `ai_model` | Model name for the primary analysis pass | Yes | - |
-| `ai_api_key` | Optional API key for the primary AI endpoint. OpenAI format sends `Authorization: Bearer`; Anthropic format sends `x-api-key` | No | `""` |
-| `ai_max_tokens` | Maximum completion tokens for primary and fallback final review calls. Required by Anthropic-compatible APIs | No | `4096` |
-| `ai_temperature` | Sampling temperature for the review model. Empty string omits the field (some newer cloud models reject non-default temperature) | No | `0.1` |
-| `ai_response_format` | Structured-output mode for OpenAI-compatible endpoints (incl. LiteLLM): `off`, `json_object`, or `json_schema` (enforces the verdict/review_markdown schema). Ignored for `anthropic`. Improves reliability with smaller local models | No | `off` |
-| `ai_tokens_param` | Token-limit field name for OpenAI-compatible requests: `max_tokens` or `max_completion_tokens` (newer OpenAI reasoning models). Ignored for `anthropic` | No | `max_tokens` |
-| `anthropic_version` | `anthropic-version` header used for Anthropic-compatible requests | No | `2023-06-01` |
-| `ai_fallback_base_url` | Optional fallback AI API base URL | No | `""` |
-| `ai_fallback_api_format` | Fallback API request/response format; defaults to `ai_api_format` when blank | No | `""` |
-| `ai_fallback_model` | Optional fallback model name | No | `""` |
-| `ai_fallback_api_key` | Optional API key for the fallback AI endpoint | No | `""` |
-| `ai_primary_retries` | Number of retries for the primary model | No | `8` |
-| `on_model_failure` | Behavior when primary **and** fallback models fail: `fail` (fail the step) or `notice` (post a visible `request_changes` notice explaining the review could not run — never auto-approves) | No | `fail` |
-| `verdict_policy` | How the final verdict is decided: `model` (the model's own verdict) or `findings_severity_gated` (derived from structured findings: `request_changes` iff any blocker finding; falls back to the model verdict when no findings). Enforcement settings still apply afterwards | No | `model` |
-| `inline_findings` | Attach diff-anchorable structured findings as native line-anchored review comments in `review_comment`/`review_verdict` modes. Ignored for `comment` mode | No | `false` |
-| `inline_findings_max` | Maximum inline review comments per review when `inline_findings=true` | No | `20` |
-| `validate_required_checks` | Validate the final review against the classifier's `must_check` items: `auto` (when must_check is non-empty), `true`, or `false` | No | `auto` |
-| `required_check_validation_mode` | Action on unaddressed required checks: `warn` (append a section to the review), `fail` (also force `request_changes`), or `metadata_only` | No | `warn` |
-| `review_routing_mode` | Route reviews between fast and smart models from the classification: `off` (existing primary/fallback behavior) or `auto` | No | `off` |
-| `ai_fast_model` | Fast model for low-risk reviews in `auto` mode; defaults to `ai_model` | No | `""` |
-| `ai_fast_base_url` | Base URL for the fast model; defaults to `ai_base_url` | No | `""` |
-| `ai_fast_api_format` | API format for the fast model; defaults to `ai_api_format` | No | `""` |
-| `ai_fast_api_key` | API key for the fast model; defaults to `ai_api_key` | No | `""` |
-| `ai_smart_model` | Smart model for high-risk reviews in `auto` mode; defaults to `ai_fallback_model` | No | `""` |
-| `ai_smart_base_url` | Base URL for the smart model; defaults to `ai_fallback_base_url` | No | `""` |
-| `ai_smart_api_format` | API format for the smart model; defaults to `ai_fallback_api_format`, then `ai_api_format` | No | `""` |
-| `ai_smart_api_key` | API key for the smart model; defaults to `ai_fallback_api_key` | No | `""` |
-| `escalate_on_risk_flags` | Comma-separated `pr_kind`/`risk_flag` names that route to the smart model in `auto` mode | No | security/priority/auth/route/file-serving/path/secret/db list |
-| `escalate_on_incomplete_required_checks` | Escalate fast reviews with unaddressed required checks to the smart model (`auto` mode) | No | `true` |
-| `escalate_on_fast_request_changes` | Escalate fast reviews whose verdict is `request_changes` (`auto` mode) | No | `true` |
-| `escalate_on_fast_low_confidence` | Escalate low-confidence fast reviews (very short, or populated Unknowns section) (`auto` mode) | No | `true` |
-| `escalate_on_tool_or_evidence_blockers` | Escalate when evidence blockers or tool-harness failures exist (`auto` mode) | No | `true` |
-| `escalate_on_dirty_baseline` | Escalate incremental reviews whose baseline review found issues (`auto` mode) | No | `true` |
-| `ai_primary_retry_delay_sec` | Delay between retries in seconds | No | `15` |
-| `allowed_source_hosts` | Comma-separated allowlist for linked URL fetching | No | `github.com,api.github.com,gitlab.com,registry.terraform.io,artifacthub.io` |
-| `system_prompt` | Optional system prompt override | No | bundled prompt |
-| `system_prompt_file` | File in the reviewed repo to use as the full system prompt | No | `""` |
-| `standards_file` | Explicit standards file path; takes priority over candidates | No | `""` |
-| `standards_file_candidates` | Candidate files checked in order; first found is used | No | `AGENTS.md,agents.md,CLAUDE.md,claude.md,.github/ai-review-rules.md,.github/ai-review-rules.txt` |
-| `publish_review_comment` | Publish or update a managed PR comment | No | `false` |
-| `publish_mode` | Publish mode for the review verdict: `comment` (sticky PR comment, default), `review_comment` (non-blocking native PR review comment), `review_verdict` (native approve/request_changes). Requires `pull-requests: write` for review_comment and review_verdict | No | `comment` |
-| `allow_approve` | If true and publish_mode=review_verdict, the model's approve verdict can be submitted as a native approval. Defaults to false — approval is blocked unless explicitly enabled. WARNING: native approvals can affect branch protection rules and automerge pipelines. | No | `false` |
-| `approve_forks` | If true and publish_mode=review_verdict with allow_approve=true, native approvals are also allowed for cross-repository (fork) PRs. Defaults to false — fork PRs are blocked from approval even when allow_approve is set. | No | `false` |
-| `cleanup_previous_native_reviews` | Mark previous managed native PR reviews as outdated/superseded before publishing a new native review. Accepted values: `auto` (default, enables cleanup for review_comment and review_verdict modes), `true`, or `false`. Cleanup only targets reviews created by this action carrying the managed marker. Dismissal of old approval/request-changes reviews is attempted when permissions allow but is secondary to visual cleanup. | No | `auto` |
-| `context_limit_mode` | Context budget mode: `normal` (140k/70k/220k), `low` (80k/40k/120k), `minimal` (40k/20k/60k) | No | `normal` |
-| `model_context_tokens` | The model's real context window in tokens (e.g. `8192`, `32768`). When set, corpus/diff/file byte budgets are derived from it (reserving `ai_max_tokens` for output) instead of `context_limit_mode`. Recommended for local models. Empty uses `context_limit_mode` | No | `""` |
-| `enrichment_budget_sec` | Maximum seconds to spend on enrichment (linked source fetching, release metadata, ghcr.io lookups). Exceeding the budget stops further enrichment. | No | `60` |
-| `image_digest_budget_sec` | Maximum seconds to spend on image digest provenance lookups (registry tokens, manifests, revision compares). 0 disables the budget. | No | `60` |
-| `evidence_providers_file` | Optional JSON file in the reviewed repo defining evidence provider commands | No | `""` |
-| `evidence_provider_timeout_sec` | Default timeout in seconds for each evidence provider command | No | `30` |
-| `evidence_provider_max_output_bytes` | Max stdout or stderr bytes captured per provider command | No | `20000` |
-| `evidence_provider_parallelism` | Max evidence provider commands run concurrently (set `1` to force serial execution) | No | `4` |
-| `evidence_blocker_enforcement` | Force `request_changes` when any provider reports blocker severity | No | `false` |
-| `evidence_enable_for_forks` | Allow evidence providers on cross-repository PRs | No | `false` |
-| `tool_mode` | Tool harness mode: `off`, `plan_execute_once`, or `plan_execute_loop` | No | `off` |
-| `tool_max_requests` | Maximum tool requests executed in one harness run (total across rounds in loop mode) | No | `4` |
-| `tool_max_rounds` | Maximum planning rounds for `tool_mode=plan_execute_loop` | No | `3` |
-| `tool_planning_timeout_sec` | Timeout in seconds for tool harness planning model call | No | `60` |
-| `tool_planning_max_context_bytes` | Maximum corpus bytes passed to planning | No | `50000` |
-| `tool_planning_max_tokens` | Maximum completion tokens for tool harness planning call | No | `400` |
-| `tool_max_response_bytes` | Maximum bytes captured from each tool response | No | `12000` |
-| `tool_allowed_gh_api_repos` | Comma-separated owner/repo allowlist for `gh_api`; use `*` to allow any repo endpoint still permitted by the tool path allowlist (empty = current repo only) | No | `""` |
-| `tool_request_timeout_sec` | Timeout in seconds for each tool execution request | No | `20` |
-| `tool_failure_enforcement` | Force `request_changes` when tool harness planning fails | No | `false` |
-| `tool_min_successful_requests` | Minimum successful tool requests required when `tool_failure_enforcement=true` | No | `0` |
-| `tool_enable_for_forks` | Allow tool harness on cross-repository PRs | No | `false` |
-| `ai_request_timeout_sec` | Timeout in seconds for the primary model API request (`curl --max-time`) | No | `300` |
-| `ai_connect_timeout_sec` | Timeout in seconds for the primary model API connection (`curl --connect-timeout`) | No | `30` |
-| `ai_fallback_request_timeout_sec` | Timeout in seconds for the fallback model API request (`curl --max-time`). Defaults to `ai_request_timeout_sec` when blank. | No | `""` |
-| `ai_fallback_connect_timeout_sec` | Timeout in seconds for the fallback model API connection (`curl --connect-timeout`). Defaults to `ai_connect_timeout_sec` when blank. | No | `""` |
-| `ai_stream` | If true, use streaming responses to avoid timeouts behind proxies with short read timeouts (e.g. Cloudflare 100s edge timer) | No | `"true"` |
-| `ai_fallback_stream` | If set, overrides ai_stream for the fallback model; defaults to ai_stream value when blank | No | `""` |
-| `skip_if_diff_unchanged` | Skip the LLM review when the current PR patch matches the last managed review fingerprint | No | `true` |
-| `comment_marker` | HTML marker for the managed PR comment | No | `<!-- ai-pr-reviewer -->` |
-| `review_scope` | Controls whether the action reviews the full PR or only changes since the last managed review. Accepted values: `auto` (default, full on first run, incremental on later safe updates), `full` (always full review), `incremental` (delta review, falls back to full if prior metadata unavailable) | No | `auto` |
-| `ci_status_check` | Wait for all CI checks to reach a terminal state before starting the AI review. Default false — immediate review. | No | `false` |
-| `ci_timeout_sec` | Maximum seconds to wait for CI checks to complete when ci_status_check=true. | No | `300` |
-| `ci_interval_sec` | Seconds between CI status polls when ci_status_check=true. | No | `15` |
-| `ci_skip_on_timeout` | If true, proceed with review after timeout instead of failing. | No | `true` |
-
-## Outputs
-
-| Output | Description |
-|--------|-------------|
-| `verdict` | `approve` or `request_changes` |
-| `verdict_source` | `model` or `findings`, per `verdict_policy` |
-| `required_checks` | Required-check validation status: `complete`, `incomplete`, or `none` (validation did not run) |
-| `review_route` | Model route used: `legacy` (routing off), `fast`, `smart`, or `escalated` |
-| `escalation_reason` | Comma-separated escalation trigger names when `review_route` is `escalated` (empty otherwise) |
-| `findings` | Normalized structured findings as a JSON array (`[]` when the model produced none) |
-| `review_markdown` | Full markdown review body |
-| `analysis_engine` | Model and endpoint that produced the final result |
-| `should_review` | `true` when a new LLM review was run |
-| `skip_reason` | Skip reason such as `diff-unchanged` |
-| `diff_fingerprint` | Stable fingerprint of the current PR patch |
-| `ci_status_skipped` | `true` if CI status check was skipped, `false` if it completed |
-| `ci_status_final` | Final CI state (`success`/`failure`) when `ci_status_check` completed |
-| `effective_review_scope` | Effective scope used: `full` or `incremental` |
-| `previous_head_sha` | Previous head SHA when scope is `incremental` |
-| `baseline_clean` | Whether the full-review baseline was clean (for verdict safety) |
-
-## Usage
-
-### Self-hosted model
+## 🚀 Quick start
 
 ```yaml
 name: AI PR Review
@@ -218,7 +59,305 @@ jobs:
           publish_review_comment: "true"
 ```
 
-### Cloud model subscription
+**Requirements:** the repository under review is already checked out; the runner has `gh`, `jq`, `curl`, `git`, and `python3`; the workflow runs on `pull_request` events (or passes explicit `repo` and `pr_number` inputs).
+
+## 📚 Table of contents
+
+- [How it works](#%EF%B8%8F-how-it-works)
+- [Review pipeline features](#-review-pipeline-features)
+- [Inputs](#%EF%B8%8F-inputs)
+- [Outputs](#-outputs)
+- [Usage recipes](#-usage-recipes)
+- [Publishing & verdicts](#-publishing--verdicts)
+- [Routing & escalation](#-routing--escalation)
+- [Token-saving with incremental reviews](#-token-saving-with-incremental-reviews)
+- [Local model troubleshooting](#-local-model-troubleshooting)
+- [Notes](#-notes)
+- [Validation](#-validation)
+- [Version pinning and releases](#-version-pinning-and-releases)
+- [Security](#-security)
+
+## ⚙️ How it works
+
+```mermaid
+flowchart LR
+    A[Precheck<br/>diff fingerprint] -->|unchanged| Z[Skip review 💤]
+    A -->|changed| B[Wait for CI<br/><i>optional</i>]
+    B --> C[Collect context<br/>diff · issues · sources · evidence · tools]
+    C --> D[Classify PR<br/>rule-based risk flags]
+    D --> E[Route & call model<br/>fast / smart / fallback]
+    E --> F[Validate & enforce<br/>required checks · findings · carry-forward]
+    F --> G[Publish<br/>comment / native review]
+```
+
+What it supports:
+
+| | |
+|---|---|
+| ✅ Self-hosted OpenAI-compatible endpoints | ✅ Native Anthropic-compatible `/messages` endpoints |
+| ✅ Cloud OpenAI- or Anthropic-compatible subscriptions | ✅ Optional fallback model/endpoint |
+| ✅ Evidence providers for repo-specific checks | ✅ Read-only tool harness (single-round or iterative planning) |
+| ✅ Managed PR comment publishing | ✅ Automatic skip when the effective PR diff is unchanged |
+| ✅ Linked issue ingestion (`Fixes #123`, `Closes owner/repo#456`) | ✅ Repo-provided rules via `CLAUDE.md`, `AGENTS.md`, or a custom file |
+| ✅ Upstream link sanitizer for published reviews | ✅ Incremental re-reviews with carried-forward findings |
+
+## 🧠 Review pipeline features
+
+### 🏷️ Deterministic PR classification
+
+Before invoking the AI model, the action runs a deterministic classification step that analyzes changed file paths, diff content, and linked issue context to produce structured metadata about the PR. This helps smaller/weaker reviewer models stay focused and reduces the chance of being misled by irrelevant context.
+
+The classification is purely rule-based — no model calls are involved. It uses pattern matching on file paths, diff content, and linked issue metadata to determine the PR type and associated risk flags.
+
+**Classification output (injected into the review corpus):**
+
+| Field | Description |
+|-------|-------------|
+| `pr_kind` | One of: `renovate_digest_only`, `dependency_upgrade`, `app_code`, `k8s_manifest`, `auth_changes`, `public_route_changes`, `file_serving_changes`, `path_handling_changes`, `secret_handling_changes`, `db_or_migration_changes` |
+| `risk_flags` | Detected risk indicators such as `linked_security_issue`, `linked_audit_issue`, `linked_priority_p0`, `linked_priority_p1`, `file_serving_changes`, `path_handling_changes`, `auth_changes`, `secret_handling_changes` |
+| `changed_files_summary` | List of changed file paths (truncated to 50) |
+| `linked_issue_labels` | Labels from linked issues when available |
+| `must_check` | Explicit checklist items derived from the classification (e.g., "review auth flow for regression" for `auth_changes`) |
+
+**Default required checks per risk class** (`must_check` is the union of the checks for the `pr_kind` and every detected risk flag — a PR classified as `app_code` that still trips the `auth_changes` flag gets the auth checklist):
+
+| Risk class | Required checks |
+|------------|-----------------|
+| `renovate_digest_only` | verify no functional changes beyond lockfile hashes |
+| `dependency_upgrade` | breaking API changes in updated dependencies; run full test suite after upgrade |
+| `k8s_manifest` | validate manifest against target cluster version; resource quota / limit changes |
+| `auth_changes` | review auth flow for regression; session token handling |
+| `public_route_changes` | route access controls; unintended public endpoints |
+| `file_serving_changes` | file path sanitization; directory traversal |
+| `path_handling_changes` | path traversal; edge-case paths (null bytes, symlinks) |
+| `secret_handling_changes` | secrets not logged/exposed; secret rotation impact |
+| `db_or_migration_changes` | migration data-loss risk; test on a copy of production schema |
+| `linked_security_issue` / `linked_audit_issue` / `linked_priority_p0`/`p1` | explicitly address the linked issue / verify thoroughly |
+
+These checklists exist to keep weaker local models honest on high-risk PRs: the items are injected into the model's instructions ("address EACH of these"), and the review is then **validated** against them.
+
+### 📋 Required-check completeness validation
+
+After the model returns, the action deterministically checks whether `review_markdown` actually discussed each `must_check` item (shallow keyword matching — it catches reviews that never mentioned a required check, not incorrect discussion). Controlled by `validate_required_checks` (`auto` = validate when must_check is non-empty) and `required_check_validation_mode`:
+
+- `warn` (default): an **Unaddressed required checks** section listing the missing items is appended to the published review, so a human sees exactly what the model skipped. The verdict is not changed.
+- `fail`: additionally forces a `request_changes` verdict.
+- `metadata_only`: records the result without touching the published review — for downstream automation.
+
+The result is exposed as the `required_checks` output (`complete` / `incomplete` / `none`), written to the run's step summary, and recorded in the managed metadata marker for future runs. Low-risk PRs (empty `must_check`) produce no validation noise.
+
+### 🧼 Upstream link sanitizer
+
+Before publishing, the action runs `scripts/sanitize_review_markdown.py` on the review markdown to neutralize upstream GitHub references (PR URLs, issue URLs, commit URLs, compare URLs, cross-repo `owner/repo#123` references, and bare `#123` references). This prevents GitHub from auto-linking them into the reviewed repository, which would create notification noise and misleading linkbacks to unrelated projects. Sanitization is documented as P0 hygiene in [issue #132](https://github.com/misospace/pr-reviewer-action/issues/132).
+
+## 🎛️ Inputs
+
+Only three inputs are required: `github_token`, `ai_base_url`, and `ai_model`. Everything else has a sensible default. Inputs are grouped by topic below — expand the sections you need.
+
+<details>
+<summary><b>Core</b> — token, repo, PR targeting</summary>
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `github_token` | GitHub token for PR and API access | Yes | - |
+| `repo` | Repository in `owner/name` format | No | current repository |
+| `pr_number` | Pull request number | No | current `pull_request` number |
+
+</details>
+
+<details>
+<summary><b>Primary model</b> — endpoint, format, sampling, structured output</summary>
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `ai_base_url` | Base URL of the primary AI API | Yes | - |
+| `ai_api_format` | Primary API request/response format: `openai` or `anthropic` | No | `openai` |
+| `ai_model` | Model name for the primary analysis pass | Yes | - |
+| `ai_api_key` | Optional API key for the primary AI endpoint. OpenAI format sends `Authorization: Bearer`; Anthropic format sends `x-api-key` | No | `""` |
+| `ai_max_tokens` | Maximum completion tokens for primary and fallback final review calls. Required by Anthropic-compatible APIs | No | `4096` |
+| `ai_temperature` | Sampling temperature for the review model. Empty string omits the field (some newer cloud models reject non-default temperature) | No | `0.1` |
+| `ai_response_format` | Structured-output mode for OpenAI-compatible endpoints (incl. LiteLLM): `off`, `json_object`, or `json_schema` (enforces the verdict/review_markdown schema). Ignored for `anthropic`. Improves reliability with smaller local models | No | `off` |
+| `ai_tokens_param` | Token-limit field name for OpenAI-compatible requests: `max_tokens` or `max_completion_tokens` (newer OpenAI reasoning models). Ignored for `anthropic` | No | `max_tokens` |
+| `anthropic_version` | `anthropic-version` header used for Anthropic-compatible requests | No | `2023-06-01` |
+
+</details>
+
+<details>
+<summary><b>Fallback & failure handling</b> — fallback endpoint, retries, failure behavior</summary>
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `ai_fallback_base_url` | Optional fallback AI API base URL | No | `""` |
+| `ai_fallback_api_format` | Fallback API request/response format; defaults to `ai_api_format` when blank | No | `""` |
+| `ai_fallback_model` | Optional fallback model name | No | `""` |
+| `ai_fallback_api_key` | Optional API key for the fallback AI endpoint | No | `""` |
+| `ai_primary_retries` | Number of retries for the primary model | No | `8` |
+| `ai_primary_retry_delay_sec` | Delay between retries in seconds | No | `15` |
+| `on_model_failure` | Behavior when primary **and** fallback models fail: `fail` (fail the step) or `notice` (post a visible `request_changes` notice explaining the review could not run — never auto-approves) | No | `fail` |
+
+</details>
+
+<details>
+<summary><b>Verdicts & findings</b> — verdict policy, inline comments, required-check validation</summary>
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `verdict_policy` | How the final verdict is decided: `model` (the model's own verdict) or `findings_severity_gated` (derived from structured findings: `request_changes` iff any blocker finding; falls back to the model verdict when no findings). Enforcement settings still apply afterwards | No | `model` |
+| `inline_findings` | Attach diff-anchorable structured findings as native line-anchored review comments in `review_comment`/`review_verdict` modes. Ignored for `comment` mode | No | `false` |
+| `inline_findings_max` | Maximum inline review comments per review when `inline_findings=true` | No | `20` |
+| `validate_required_checks` | Validate the final review against the classifier's `must_check` items: `auto` (when must_check is non-empty), `true`, or `false` | No | `auto` |
+| `required_check_validation_mode` | Action on unaddressed required checks: `warn` (append a section to the review), `fail` (also force `request_changes`), or `metadata_only` | No | `warn` |
+
+</details>
+
+<details>
+<summary><b>Routing & escalation</b> — fast/smart model split and escalation triggers</summary>
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `review_routing_mode` | Route reviews between fast and smart models from the classification: `off` (existing primary/fallback behavior) or `auto` | No | `off` |
+| `ai_fast_model` | Fast model for low-risk reviews in `auto` mode; defaults to `ai_model` | No | `""` |
+| `ai_fast_base_url` | Base URL for the fast model; defaults to `ai_base_url` | No | `""` |
+| `ai_fast_api_format` | API format for the fast model; defaults to `ai_api_format` | No | `""` |
+| `ai_fast_api_key` | API key for the fast model; defaults to `ai_api_key` | No | `""` |
+| `ai_smart_model` | Smart model for high-risk reviews in `auto` mode; defaults to `ai_fallback_model` | No | `""` |
+| `ai_smart_base_url` | Base URL for the smart model; defaults to `ai_fallback_base_url` | No | `""` |
+| `ai_smart_api_format` | API format for the smart model; defaults to `ai_fallback_api_format`, then `ai_api_format` | No | `""` |
+| `ai_smart_api_key` | API key for the smart model; defaults to `ai_fallback_api_key` | No | `""` |
+| `escalate_on_risk_flags` | Comma-separated `pr_kind`/`risk_flag` names that route to the smart model in `auto` mode | No | security/priority/auth/route/file-serving/path/secret/db list |
+| `escalate_on_incomplete_required_checks` | Escalate fast reviews with unaddressed required checks to the smart model (`auto` mode) | No | `true` |
+| `escalate_on_fast_request_changes` | Escalate fast reviews whose verdict is `request_changes` (`auto` mode) | No | `true` |
+| `escalate_on_fast_low_confidence` | Escalate low-confidence fast reviews (very short, or populated Unknowns section) (`auto` mode) | No | `true` |
+| `escalate_on_tool_or_evidence_blockers` | Escalate when evidence blockers or tool-harness failures exist (`auto` mode) | No | `true` |
+| `escalate_on_dirty_baseline` | Escalate incremental reviews whose baseline review found issues (`auto` mode) | No | `true` |
+
+</details>
+
+<details>
+<summary><b>Publishing</b> — comment vs. native review, approval guardrails, cleanup</summary>
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `publish_review_comment` | Publish or update a managed PR comment | No | `false` |
+| `publish_mode` | Publish mode for the review verdict: `comment` (sticky PR comment, default), `review_comment` (non-blocking native PR review comment), `review_verdict` (native approve/request_changes). Requires `pull-requests: write` for review_comment and review_verdict | No | `comment` |
+| `allow_approve` | If true and publish_mode=review_verdict, the model's approve verdict can be submitted as a native approval. Defaults to false — approval is blocked unless explicitly enabled. WARNING: native approvals can affect branch protection rules and automerge pipelines. | No | `false` |
+| `approve_forks` | If true and publish_mode=review_verdict with allow_approve=true, native approvals are also allowed for cross-repository (fork) PRs. Defaults to false — fork PRs are blocked from approval even when allow_approve is set. | No | `false` |
+| `cleanup_previous_native_reviews` | Mark previous managed native PR reviews as outdated/superseded before publishing a new native review. Accepted values: `auto` (default, enables cleanup for review_comment and review_verdict modes), `true`, or `false`. Cleanup only targets reviews created by this action carrying the managed marker. Dismissal of old approval/request-changes reviews is attempted when permissions allow but is secondary to visual cleanup. | No | `auto` |
+| `comment_marker` | HTML marker for the managed PR comment | No | `<!-- ai-pr-reviewer -->` |
+
+</details>
+
+<details>
+<summary><b>Prompt & standards</b> — system prompt overrides and repo-local rules</summary>
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `system_prompt` | Optional system prompt override | No | bundled prompt |
+| `system_prompt_file` | File in the reviewed repo to use as the full system prompt | No | `""` |
+| `standards_file` | Explicit standards file path; takes priority over candidates | No | `""` |
+| `standards_file_candidates` | Candidate files checked in order; first found is used | No | `AGENTS.md,agents.md,CLAUDE.md,claude.md,.github/ai-review-rules.md,.github/ai-review-rules.txt` |
+
+</details>
+
+<details>
+<summary><b>Context & enrichment budgets</b> — context window sizing, enrichment time limits</summary>
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `context_limit_mode` | Context budget mode: `normal` (140k/70k/220k), `low` (80k/40k/120k), `minimal` (40k/20k/60k) | No | `normal` |
+| `model_context_tokens` | The model's real context window in tokens (e.g. `8192`, `32768`). When set, corpus/diff/file byte budgets are derived from it (reserving `ai_max_tokens` for output) instead of `context_limit_mode`. Recommended for local models. Empty uses `context_limit_mode` | No | `""` |
+| `enrichment_budget_sec` | Maximum seconds to spend on enrichment (linked source fetching, release metadata, ghcr.io lookups). Exceeding the budget stops further enrichment. | No | `60` |
+| `image_digest_budget_sec` | Maximum seconds to spend on image digest provenance lookups (registry tokens, manifests, revision compares). 0 disables the budget. | No | `60` |
+| `allowed_source_hosts` | Comma-separated allowlist for linked URL fetching | No | `github.com,api.github.com,gitlab.com,registry.terraform.io,artifacthub.io` |
+
+</details>
+
+<details>
+<summary><b>Evidence providers</b> — repo-defined check commands</summary>
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `evidence_providers_file` | Optional JSON file in the reviewed repo defining evidence provider commands | No | `""` |
+| `evidence_provider_timeout_sec` | Default timeout in seconds for each evidence provider command | No | `30` |
+| `evidence_provider_max_output_bytes` | Max stdout or stderr bytes captured per provider command | No | `20000` |
+| `evidence_provider_parallelism` | Max evidence provider commands run concurrently (set `1` to force serial execution) | No | `4` |
+| `evidence_blocker_enforcement` | Force `request_changes` when any provider reports blocker severity | No | `false` |
+| `evidence_enable_for_forks` | Allow evidence providers on cross-repository PRs | No | `false` |
+
+</details>
+
+<details>
+<summary><b>Tool harness</b> — read-only model-planned evidence gathering</summary>
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `tool_mode` | Tool harness mode: `off`, `plan_execute_once`, or `plan_execute_loop` | No | `off` |
+| `tool_max_requests` | Maximum tool requests executed in one harness run (total across rounds in loop mode) | No | `4` |
+| `tool_max_rounds` | Maximum planning rounds for `tool_mode=plan_execute_loop` | No | `3` |
+| `tool_planning_timeout_sec` | Timeout in seconds for tool harness planning model call | No | `60` |
+| `tool_planning_max_context_bytes` | Maximum corpus bytes passed to planning | No | `50000` |
+| `tool_planning_max_tokens` | Maximum completion tokens for tool harness planning call | No | `400` |
+| `tool_max_response_bytes` | Maximum bytes captured from each tool response | No | `12000` |
+| `tool_allowed_gh_api_repos` | Comma-separated owner/repo allowlist for `gh_api`; use `*` to allow any repo endpoint still permitted by the tool path allowlist (empty = current repo only) | No | `""` |
+| `tool_request_timeout_sec` | Timeout in seconds for each tool execution request | No | `20` |
+| `tool_failure_enforcement` | Force `request_changes` when tool harness planning fails | No | `false` |
+| `tool_min_successful_requests` | Minimum successful tool requests required when `tool_failure_enforcement=true` | No | `0` |
+| `tool_enable_for_forks` | Allow tool harness on cross-repository PRs | No | `false` |
+
+</details>
+
+<details>
+<summary><b>Timeouts & streaming</b> — request/connect timeouts, streaming toggles</summary>
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `ai_request_timeout_sec` | Timeout in seconds for the primary model API request (`curl --max-time`) | No | `300` |
+| `ai_connect_timeout_sec` | Timeout in seconds for the primary model API connection (`curl --connect-timeout`) | No | `30` |
+| `ai_fallback_request_timeout_sec` | Timeout in seconds for the fallback model API request (`curl --max-time`). Defaults to `ai_request_timeout_sec` when blank. | No | `""` |
+| `ai_fallback_connect_timeout_sec` | Timeout in seconds for the fallback model API connection (`curl --connect-timeout`). Defaults to `ai_connect_timeout_sec` when blank. | No | `""` |
+| `ai_stream` | If true, use streaming responses to avoid timeouts behind proxies with short read timeouts (e.g. Cloudflare 100s edge timer) | No | `"true"` |
+| `ai_fallback_stream` | If set, overrides ai_stream for the fallback model; defaults to ai_stream value when blank | No | `""` |
+
+</details>
+
+<details>
+<summary><b>Review scope & CI gating</b> — incremental reviews, diff skip, waiting for CI</summary>
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `review_scope` | Controls whether the action reviews the full PR or only changes since the last managed review. Accepted values: `auto` (default, full on first run, incremental on later safe updates), `full` (always full review), `incremental` (delta review, falls back to full if prior metadata unavailable) | No | `auto` |
+| `skip_if_diff_unchanged` | Skip the LLM review when the current PR patch matches the last managed review fingerprint | No | `true` |
+| `ci_status_check` | Wait for all CI checks to reach a terminal state before starting the AI review. Default false — immediate review. | No | `false` |
+| `ci_timeout_sec` | Maximum seconds to wait for CI checks to complete when ci_status_check=true. | No | `300` |
+| `ci_interval_sec` | Seconds between CI status polls when ci_status_check=true. | No | `15` |
+| `ci_skip_on_timeout` | If true, proceed with review after timeout instead of failing. | No | `true` |
+
+</details>
+
+## 📤 Outputs
+
+| Output | Description |
+|--------|-------------|
+| `verdict` | `approve` or `request_changes` |
+| `verdict_source` | `model`, `findings` (per `verdict_policy`), or `carry_forward` (a carried-forward blocker survived an incremental review) |
+| `required_checks` | Required-check validation status: `complete`, `incomplete`, or `none` (validation did not run) |
+| `review_route` | Model route used: `legacy` (routing off), `fast`, `smart`, or `escalated` |
+| `escalation_reason` | Comma-separated escalation trigger names when `review_route` is `escalated` (empty otherwise) |
+| `findings` | Normalized structured findings as a JSON array (`[]` when the model produced none) |
+| `review_markdown` | Full markdown review body |
+| `analysis_engine` | Model and endpoint that produced the final result |
+| `should_review` | `true` when a new LLM review was run |
+| `skip_reason` | Skip reason such as `diff-unchanged` |
+| `diff_fingerprint` | Stable fingerprint of the current PR patch |
+| `ci_status_skipped` | `true` if CI status check was skipped, `false` if it completed |
+| `ci_status_final` | Final CI state (`success`/`failure`) when `ci_status_check` completed |
+| `effective_review_scope` | Effective scope used: `full` or `incremental` |
+| `previous_head_sha` | Previous head SHA when scope is `incremental` |
+| `baseline_clean` | Whether the full-review baseline was clean (for verdict safety) |
+
+## 📖 Usage recipes
+
+### ☁️ Cloud model subscription
 
 ```yaml
 name: AI PR Review
@@ -251,7 +390,7 @@ jobs:
           publish_review_comment: "true"
 ```
 
-### Native Anthropic-compatible endpoint
+### 🧠 Native Anthropic-compatible endpoint
 
 ```yaml
 - uses: misospace/pr-reviewer-action@v1
@@ -267,7 +406,7 @@ jobs:
 
 When `ai_api_format: anthropic` is set, the action posts to `/messages`, sends the `x-api-key` and `anthropic-version` headers, and parses only Anthropic `text` content blocks. Non-text blocks such as `thinking` are ignored so private reasoning is not copied into PR comments.
 
-### With a fallback model
+### 🛟 With a fallback model
 
 ```yaml
 - uses: misospace/pr-reviewer-action@v1
@@ -282,7 +421,7 @@ When `ai_api_format: anthropic` is set, the action posts to `/messages`, sends t
     ai_fallback_api_key: ${{ secrets.OPENAI_API_KEY }}
 ```
 
-### Waiting for CI checks
+### 🚦 Waiting for CI checks
 
 Set `ci_status_check: true` to wait for all CI checks to reach a terminal state before starting the AI review. This ensures the review considers the final CI results rather than running against in-progress checks.
 
@@ -301,7 +440,7 @@ Set `ci_status_check: true` to wait for all CI checks to reach a terminal state 
 
 When `ci_skip_on_timeout: true` (the default), the action proceeds with the review after `ci_timeout_sec` even if checks are still running. Set it to `false` to fail the action on timeout instead. The `ci_status_skipped` and `ci_status_final` outputs indicate whether the CI wait completed and what the final state was.
 
-### With evidence providers
+### 🧾 With evidence providers
 
 ```yaml
 - uses: misospace/pr-reviewer-action@v1
@@ -346,158 +485,7 @@ Evidence providers execute in the context of the **checked-out pull request code
 
 Evidence providers are **disabled by default on cross-repository pull requests** (`evidence_enable_for_forks=false`). This prevents forked PRs from executing arbitrary scripts defined in the destination repository's config. Set `evidence_enable_for_forks: "true"` only when you trust fork contributors or run reviews in an isolated environment.
 
-### Publish modes
-
-The action supports three publish modes via the `publish_mode` input:
-
-| Mode | Behavior | Branch protection impact |
-|------|----------|------------------------|
-| `comment` | Posts a sticky PR comment with `<!-- ai-pr-reviewer -->` markers. The default mode. | None — comments are advisory only |
-| `review_comment` | Submits a non-blocking native PR review comment via `gh pr review --comment`. | None — review comments don't affect status checks |
-| `review_verdict` | Submits a native PR review verdict (`approve` or `request_changes`) via `gh pr review`. Affects branch protection and status checks. | Yes — counts as a real review |
-
-
-### Permissions per publish mode
-
-Each publish mode requires different GitHub token permissions in your workflow:
-
-| Publish mode | Required permissions | Notes |
-|---|---|---|
-| `comment` | `contents: read`, `pull-requests: write` | The action posts a managed comment using the existing sticky-comment behavior. `pull-requests: write` is needed for the token to create/edit PR comments. |
-| `review_comment` | `contents: read`, `pull-requests: write` | Submits non-blocking native review comments via `gh pr review --comment`. The token must have `pull-requests: write`. |
-| `review_verdict` | `contents: read`, `pull-requests: write` | Submits native approve or request-changes verdicts. Requires `pull-requests: write` and may additionally require the **Allow GitHub Actions to create and approve pull requests** setting (see below). |
-
-All modes require `contents: read` for the action to access repository files during review.
-
-### Native PR review verdicts
-
-When `publish_mode=review_verdict` is set, the action submits a native GitHub PR review
-(`approve` or `request_changes`) instead of posting a comment. This integrates with branch
-protection rules and status checks.
-
-**Approval guardrails:**
-
-- `allow_approve` defaults to `false`. The model's approve verdict will be blocked unless
-  this input is explicitly set to `true`.
-- `approve_forks` defaults to `false`. Even when `allow_approve=true`, native approvals are
-  blocked for cross-repository (fork) PRs unless this is also set to `true`.
-- If evidence provider enforcement or tool harness failure enforcement modified the verdict
-  to `request_changes`, approval is automatically blocked.
-- The review body must be non-empty for an approval to be submitted.
-
-⚠️ **WARNING**: Native approvals can affect branch protection rules and automerge pipelines.
-Enable `allow_approve` only when you understand the implications for your repository's
-merge policy.
-
-```yaml
-- uses: misospace/pr-reviewer-action@v1
-  with:
-    github_token: ${{ secrets.GITHUB_TOKEN }}
-    ai_base_url: https://api.openai.com/v1
-    ai_model: gpt-4.1
-    ai_api_key: ${{ secrets.OPENAI_API_KEY }}
-    publish_mode: review_verdict
-    allow_approve: "true"
-```
-
-
-#### Example: full workflow with `publish_mode=review_verdict`
-
-```yaml
-name: AI PR Review (native verdicts)
-
-on:
-  pull_request:
-    types: [opened, reopened, synchronize, ready_for_review]
-
-permissions:
-  contents: read
-  pull-requests: write
-
-jobs:
-  review:
-    if: ${{ !github.event.pull_request.draft }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
-
-      - uses: misospace/pr-reviewer-action@v1
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          ai_base_url: https://api.openai.com/v1
-          ai_model: gpt-4.1
-          ai_api_key: ${{ secrets.OPENAI_API_KEY }}
-          publish_review_comment: "true"
-          publish_mode: review_verdict
-          allow_approve: "true"
-```
-
-> **Note**: This workflow requires the **Allow GitHub Actions to create and approve pull requests** setting to be enabled for your repository or organization. Without it, native approvals will fail with a 403 error even though `pull-requests: write` is granted.
-
-This configuration allows the AI to submit native approvals when its verdict is `approve`.
-Fork PRs are still blocked from approval unless `approve_forks` is also set to `"true"`.
-
-### Why approvals may fail even with `pull-requests: write`
-
-Even when your workflow grants `pull-requests: write`, native PR review verdicts (approve/request-changes) may fail silently or error out because of **GitHub Actions repository settings**:
-
-1. **Allow GitHub Actions to create and approve pull requests** — This organization or repository setting must be enabled for Actions to submit native approvals. Without it, the `gh pr review --approve` command will fail with a 403 error from the GitHub API. You can find this setting under:
-   - **Repository**: Settings → Actions → General → "Allow GitHub Actions to create and approve pull requests"
-   - **Organization**: Settings → Actions → Organization permissions → "Allow GitHub Actions to create and approve pull requests"
-
-2. **Branch protection rules** — If branch protection requires a review from a specific user or team, the AI's approval may not satisfy that requirement. The PR will still show `request_changes` until the required reviewer approves.
-
-3. **Fork PRs without `approve_forks: true`** — Approvals from fork PRs are blocked by default unless `approve_forks` is explicitly set to `"true"`.
-
-When approval is blocked, the action always submits a `request_changes` verdict with an explanation in the review body rather than failing silently.
-
-### Non-blocking review comments
-
-When `publish_mode=review_comment` is set, the action submits a non-blocking native PR review comment via `gh pr review --comment`. This gives you a GitHub-native review entry in the PR's conversation thread without affecting branch protection or status checks.
-
-```yaml
-- uses: misospace/pr-reviewer-action@v1
-  with:
-    github_token: ${{ secrets.GITHUB_TOKEN }}
-    ai_base_url: https://api.openai.com/v1
-    ai_model: gpt-4.1
-    ai_api_key: ${{ secrets.OPENAI_API_KEY }}
-    publish_mode: review_comment
-```
-
-### Native review cleanup
-
-When `publish_mode` is set to `review_comment` or `review_verdict`, the action creates a new submitted native PR review on every run. Without cleanup, old AI reviews pile up in the PR timeline and make the conversation noisy.
-
-By default, the action automatically cleans up previous managed native reviews for `review_comment` and `review_verdict` modes. The `cleanup_previous_native_reviews` input controls this behavior:
-
-- `auto` (default): enables cleanup for `review_comment` and `review_verdict` modes, disabled for `comment` mode (which already edits one sticky comment in place).
-- `true`: always enable cleanup regardless of publish mode.
-- `false`: disable cleanup entirely.
-
-The cleanup process:
-
-1. Identifies previous managed AI reviews from the current authenticated actor that carry the `<!-- ai-pr-reviewer -->` marker.
-2. Dismisses old approval or request-changes verdict reviews when permissions allow, so stale verdicts stop counting toward branch protection.
-3. Updates the body of old managed reviews to a compact "Outdated: superseded by a newer automated review." stub.
-
-Old reviews may still exist in the PR timeline, but they are visually minimized and explicitly marked as outdated. Human reviews and unmarked bot reviews are never modified.
-
-Cleanup and dismissal failures produce warnings but do not prevent posting the new review. If you need to grant additional permissions for dismissal:
-
-```yaml
-permissions:
-  contents: read
-  pull-requests: write
-```
-
-The `pull-requests: write` permission is required for both posting reviews and dismissing them. On protected branches or stricter repositories, GitHub may require repository admin permissions or explicit review-dismissal settings to be enabled for the app/token.
-
-### With tool harness planning
-
+### 🛠️ With tool harness planning
 
 ```yaml
 - uses: misospace/pr-reviewer-action@v1
@@ -539,7 +527,7 @@ Any other command name is rejected with an error listing the catalog. Output is 
 
 By default, tool harness execution is skipped on cross-repository PRs unless `tool_enable_for_forks` is set to `true`.
 
-### Use repo-local review rules
+### 📐 Use repo-local review rules
 
 If the destination repo has a `CLAUDE.md`, `claude.md`, `AGENTS.md`, or `.github/ai-review-rules.md`, the action can use that as review policy context.
 
@@ -565,11 +553,11 @@ You can also pin a specific rules file:
     standards_file: .github/review-rules.md
 ```
 
-### Issue-first review workflows
+### 🎯 Issue-first review workflows
 
 If PRs are driven by detailed GitHub issues, include closing references such as `Fixes #40` or `Closes owner/repo#12` in the PR body. The action will fetch those issue bodies and include them in the review corpus so the model can compare the implementation against issue guidance and acceptance criteria.
 
-### Use a repo-local prompt file
+### ✍️ Use a repo-local prompt file
 
 If a repo wants more than policy context and needs to fully control the reviewer behavior, it can provide a prompt file:
 
@@ -583,7 +571,151 @@ If a repo wants more than policy context and needs to fully control the reviewer
     system_prompt_file: .github/pr-review-prompt.md
 ```
 
-### Structured findings and verdict policy
+## 📣 Publishing & verdicts
+
+### 📮 Publish modes
+
+The action supports three publish modes via the `publish_mode` input:
+
+| Mode | Behavior | Branch protection impact |
+|------|----------|------------------------|
+| 💬 `comment` | Posts a sticky PR comment with `<!-- ai-pr-reviewer -->` markers. The default mode. | 🟢 None — comments are advisory only |
+| 📝 `review_comment` | Submits a non-blocking native PR review comment via `gh pr review --comment`. | 🟢 None — review comments don't affect status checks |
+| ⚖️ `review_verdict` | Submits a native PR review verdict (`approve` or `request_changes`) via `gh pr review`. Affects branch protection and status checks. | 🔴 Yes — counts as a real review |
+
+### 🔑 Permissions per publish mode
+
+Each publish mode requires different GitHub token permissions in your workflow:
+
+| Publish mode | Required permissions | Notes |
+|---|---|---|
+| `comment` | `contents: read`, `pull-requests: write` | The action posts a managed comment using the existing sticky-comment behavior. `pull-requests: write` is needed for the token to create/edit PR comments. |
+| `review_comment` | `contents: read`, `pull-requests: write` | Submits non-blocking native review comments via `gh pr review --comment`. The token must have `pull-requests: write`. |
+| `review_verdict` | `contents: read`, `pull-requests: write` | Submits native approve or request-changes verdicts. Requires `pull-requests: write` and may additionally require the **Allow GitHub Actions to create and approve pull requests** setting (see below). |
+
+All modes require `contents: read` for the action to access repository files during review.
+
+### ✅ Native PR review verdicts
+
+When `publish_mode=review_verdict` is set, the action submits a native GitHub PR review (`approve` or `request_changes`) instead of posting a comment. This integrates with branch protection rules and status checks.
+
+**Approval guardrails:**
+
+- `allow_approve` defaults to `false`. The model's approve verdict will be blocked unless this input is explicitly set to `true`.
+- `approve_forks` defaults to `false`. Even when `allow_approve=true`, native approvals are blocked for cross-repository (fork) PRs unless this is also set to `true`.
+- If evidence provider enforcement or tool harness failure enforcement modified the verdict to `request_changes`, approval is automatically blocked.
+- The review body must be non-empty for an approval to be submitted.
+
+> [!WARNING]
+> Native approvals can affect branch protection rules and automerge pipelines. Enable `allow_approve` only when you understand the implications for your repository's merge policy.
+
+```yaml
+- uses: misospace/pr-reviewer-action@v1
+  with:
+    github_token: ${{ secrets.GITHUB_TOKEN }}
+    ai_base_url: https://api.openai.com/v1
+    ai_model: gpt-4.1
+    ai_api_key: ${{ secrets.OPENAI_API_KEY }}
+    publish_mode: review_verdict
+    allow_approve: "true"
+```
+
+#### Example: full workflow with `publish_mode=review_verdict`
+
+```yaml
+name: AI PR Review (native verdicts)
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  review:
+    if: ${{ !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - uses: misospace/pr-reviewer-action@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          ai_base_url: https://api.openai.com/v1
+          ai_model: gpt-4.1
+          ai_api_key: ${{ secrets.OPENAI_API_KEY }}
+          publish_review_comment: "true"
+          publish_mode: review_verdict
+          allow_approve: "true"
+```
+
+> [!NOTE]
+> This workflow requires the **Allow GitHub Actions to create and approve pull requests** setting to be enabled for your repository or organization. Without it, native approvals will fail with a 403 error even though `pull-requests: write` is granted.
+
+This configuration allows the AI to submit native approvals when its verdict is `approve`. Fork PRs are still blocked from approval unless `approve_forks` is also set to `"true"`.
+
+#### Why approvals may fail even with `pull-requests: write`
+
+Even when your workflow grants `pull-requests: write`, native PR review verdicts (approve/request-changes) may fail silently or error out because of **GitHub Actions repository settings**:
+
+1. **Allow GitHub Actions to create and approve pull requests** — This organization or repository setting must be enabled for Actions to submit native approvals. Without it, the `gh pr review --approve` command will fail with a 403 error from the GitHub API. You can find this setting under:
+   - **Repository**: Settings → Actions → General → "Allow GitHub Actions to create and approve pull requests"
+   - **Organization**: Settings → Actions → Organization permissions → "Allow GitHub Actions to create and approve pull requests"
+
+2. **Branch protection rules** — If branch protection requires a review from a specific user or team, the AI's approval may not satisfy that requirement. The PR will still show `request_changes` until the required reviewer approves.
+
+3. **Fork PRs without `approve_forks: true`** — Approvals from fork PRs are blocked by default unless `approve_forks` is explicitly set to `"true"`.
+
+When approval is blocked, the action always submits a `request_changes` verdict with an explanation in the review body rather than failing silently.
+
+### 💬 Non-blocking review comments
+
+When `publish_mode=review_comment` is set, the action submits a non-blocking native PR review comment via `gh pr review --comment`. This gives you a GitHub-native review entry in the PR's conversation thread without affecting branch protection or status checks.
+
+```yaml
+- uses: misospace/pr-reviewer-action@v1
+  with:
+    github_token: ${{ secrets.GITHUB_TOKEN }}
+    ai_base_url: https://api.openai.com/v1
+    ai_model: gpt-4.1
+    ai_api_key: ${{ secrets.OPENAI_API_KEY }}
+    publish_mode: review_comment
+```
+
+### 🧹 Native review cleanup
+
+When `publish_mode` is set to `review_comment` or `review_verdict`, the action creates a new submitted native PR review on every run. Without cleanup, old AI reviews pile up in the PR timeline and make the conversation noisy.
+
+By default, the action automatically cleans up previous managed native reviews for `review_comment` and `review_verdict` modes. The `cleanup_previous_native_reviews` input controls this behavior:
+
+- `auto` (default): enables cleanup for `review_comment` and `review_verdict` modes, disabled for `comment` mode (which already edits one sticky comment in place).
+- `true`: always enable cleanup regardless of publish mode.
+- `false`: disable cleanup entirely.
+
+The cleanup process:
+
+1. Identifies previous managed AI reviews from the current authenticated actor that carry the `<!-- ai-pr-reviewer -->` marker.
+2. Dismisses old approval or request-changes verdict reviews when permissions allow, so stale verdicts stop counting toward branch protection.
+3. Updates the body of old managed reviews to a compact "Outdated: superseded by a newer automated review." stub.
+
+Old reviews may still exist in the PR timeline, but they are visually minimized and explicitly marked as outdated. Human reviews and unmarked bot reviews are never modified.
+
+Cleanup and dismissal failures produce warnings but do not prevent posting the new review. If you need to grant additional permissions for dismissal:
+
+```yaml
+permissions:
+  contents: read
+  pull-requests: write
+```
+
+The `pull-requests: write` permission is required for both posting reviews and dismissing them. On protected branches or stricter repositories, GitHub may require repository admin permissions or explicit review-dismissal settings to be enabled for the app/token.
+
+### 🧩 Structured findings and verdict policy
 
 The model may return an optional `findings` array alongside the verdict — concrete, located issues:
 
@@ -612,7 +744,7 @@ With `verdict_policy: findings_severity_gated`, the verdict is derived determini
     verdict_policy: findings_severity_gated
 ```
 
-### Inline review comments from findings
+### 📍 Inline review comments from findings
 
 With `inline_findings: "true"` and a native publish mode, findings that carry a `file` + `line` anchoring to the PR diff are attached as **line-anchored review comments**:
 
@@ -641,7 +773,9 @@ Best-effort throughout: API failures (e.g. read-only tokens on fork PRs) warn an
     inline_findings: "true"
 ```
 
-### Fast/smart model routing
+## 🧭 Routing & escalation
+
+### ⚡ Fast/smart model routing
 
 With `review_routing_mode: auto`, the deterministic classification decides which model reviews the PR — boring PRs go to a fast/local model, scary ones go straight to a smarter model:
 
@@ -659,13 +793,14 @@ With `review_routing_mode: auto`, the deterministic classification decides which
 ```
 
 Routing rules:
+
 - A PR whose `pr_kind` **or** any `risk_flags` entry matches `escalate_on_risk_flags` routes to the **smart** model; everything else routes to the **fast** model.
 - The fast config defaults to the primary `ai_*` inputs; the smart config defaults to the `ai_fallback_*` inputs. If a risky PR is detected but no smart/fallback model is configured, the review stays on the fast model (logged, never fails).
 - `off` (the default) preserves the existing primary/fallback behavior exactly (`review_route` output reports `legacy`).
 - The retry and failure-fallback machinery is unchanged — routing only picks which model it talks to.
 - The chosen route appears in the `review_route` output, the step summary, and the managed metadata marker; routing config is part of the precheck fingerprint, so changing it forces a fresh review.
 
-#### Escalation of insufficient fast reviews
+### 🪜 Escalation of insufficient fast reviews
 
 In `auto` mode, a fast review can also be **escalated after the fact**: the action evaluates the raw fast output and re-runs the review on the smart model when any enabled trigger fires:
 
@@ -677,11 +812,12 @@ In `auto` mode, a fast review can also be **escalated after the fact**: the acti
 
 Only the **final** review is published. The fast result is kept on the runner as `ai-output.fast.json` for debugging; if the smart model fails, the fast review is published instead (never a failed run because of escalation). `review_route` reports `escalated` and `escalation_reason` lists the trigger names; both also land in the step summary and the managed metadata marker. Worst case is two model calls per review — the unchanged-diff skip and incremental scope keep that bounded.
 
-### Token-saving with incremental reviews
+## 💾 Token-saving with incremental reviews
 
 When `review_scope: auto` (the default), the action performs a full PR review on the first run. On subsequent pushes to the same PR, it attempts an **incremental review** that only analyzes the delta since the last managed review. This can significantly reduce token usage for large PRs with multiple commits.
 
 Key behaviors:
+
 - **First run**: Full PR review (same as before).
 - **Later pushes**: Incremental review of only new changes.
 - **Fallback**: Automatically falls back to full review when incremental comparison is unsafe (force-push, rebase, base branch change, missing metadata, etc.).
@@ -690,6 +826,7 @@ Key behaviors:
 - **Header**: incremental reviews are titled `# AI Automated Review (incremental)`.
 
 You can force specific behavior:
+
 ```yaml
 # Always do full reviews (original behavior)
 - uses: misospace/pr-reviewer-action@vX.Y.Z
@@ -702,11 +839,11 @@ You can force specific behavior:
     review_scope: incremental
 ```
 
-## Local model troubleshooting
+## 🔧 Local model troubleshooting
 
 The action is designed local-model-first (ollama, llama.cpp, vLLM, or anything behind an OpenAI/Anthropic-compatible proxy like LiteLLM). The settings below cover the failure modes that come up most often with self-hosted endpoints.
 
-### Base URL examples
+### 🌐 Base URL examples
 
 `ai_base_url` must point at the **OpenAI-compatible base** (the action appends `/chat/completions`, or `/messages` for `ai_api_format: anthropic`):
 
@@ -729,7 +866,7 @@ ai_base_url: http://litellm.internal:4000/v1
 
 Self-hosted runners must be able to reach the endpoint — GitHub-hosted runners cannot reach `localhost` or LAN addresses on your network. Leave `ai_api_key` unset if the endpoint is unauthenticated; nothing is sent in that case.
 
-### Right-size the context budget with `model_context_tokens`
+### 📏 Right-size the context budget with `model_context_tokens`
 
 The named `context_limit_mode` budgets assume large cloud-model windows (`normal` is roughly 55–70k tokens of corpus). Local models commonly run 8k–32k windows, and an overflowing prompt fails in confusing ways: the server returns `context length exceeded` (visible in the action log thanks to error-body preservation), or worse, silently truncates the prompt and the model returns malformed or irrelevant JSON.
 
@@ -742,7 +879,7 @@ ai_max_tokens: "2048"           # reserved for the model's reply within that win
 
 The action reserves `ai_max_tokens` plus prompt headroom and converts the rest to byte budgets conservatively (~3 bytes/token). Check the run's step summary: it shows the active budget and whether the diff/corpus were truncated.
 
-### Get reliable JSON out of small models with `ai_response_format`
+### 🧱 Get reliable JSON out of small models with `ai_response_format`
 
 Small models often wrap their JSON in prose or markdown fences. The parser tolerates a lot, but structured output is more reliable when the server supports it:
 
@@ -754,7 +891,7 @@ ai_response_format: json_schema   # vLLM guided decoding, llama.cpp grammars, ne
 
 If the endpoint rejects the request after enabling this (HTTP 400 mentioning `response_format`), the server does not support that mode — drop back to `json_object` or `off`. Ignored entirely for `ai_api_format: anthropic`.
 
-### Timeouts, streaming, and retries
+### ⏱️ Timeouts, streaming, and retries
 
 - **Slow prompt eval** (big corpus, CPU offload): raise `ai_request_timeout_sec` (default 300). The tool-planning call is non-streaming and has its own `tool_planning_timeout_sec` — raise it too if planning times out.
 - **Proxies with idle-read timeouts** (e.g. Cloudflare's ~100s edge timer): keep `ai_stream: "true"` (the default) so bytes flow before the timer fires.
@@ -769,7 +906,7 @@ ai_connect_timeout_sec: "10"
 on_model_failure: notice   # visible explanation instead of a long red check
 ```
 
-### Quick symptom table
+### 🩺 Quick symptom table
 
 | Symptom | Likely cause | Fix |
 | --- | --- | --- |
@@ -780,13 +917,13 @@ on_model_failure: notice   # visible explanation instead of a long red check
 | Reviews time out behind a proxy | idle-read timer on non-streamed response | keep `ai_stream: "true"` |
 | HTTP 400 mentioning `temperature` | model rejects non-default sampling | `ai_temperature: ""` |
 
-## Notes
+## 📝 Notes
+
 - **Reserved comment markers**: The managed PR comment uses HTML comment markers for internal metadata. These are reserved and must not appear in model-generated review markdown:
   - `<!-- ai-pr-review-fingerprint:<value> -->` — stable patch + config fingerprint used by the precheck to skip unchanged diffs.
   - `<!-- ai-pr-review-sha:<sha> -->` — PR head SHA used to detect out-of-date reviews.
+
   The action strips any matching markers from model output before publishing (see `scripts/strip_metadata_markers.py`). The precheck parser reads only the **first** occurrence of each marker for defense in depth.
-
-
 - `ai_api_format=openai` posts to `/chat/completions` and parses `choices[0].message.content`.
 - `ai_api_format=anthropic` posts to `/messages` and parses only `content[]` blocks where `type == "text"`.
 - The tool harness planner uses the primary `ai_api_format`; fallback settings apply only to the final review call.
@@ -809,7 +946,7 @@ on_model_failure: notice   # visible explanation instead of a long red check
 - Use `tool_min_successful_requests` (for example `1`) to enforce a minimum successful tool-evidence threshold when the planner attempted tool requests.
 - Model requests use `curl -q` so user-level `.curlrc` timeouts do not unexpectedly cancel long-running local model calls.
 
-## Validation
+## ✅ Validation
 
 This repo includes a local smoke test that exercises the action logic against a real GitHub pull request while using a mock OpenAI/Anthropic-compatible API server.
 
@@ -832,42 +969,51 @@ The smoke test validates:
 - OpenAI-compatible `chat/completions` and Anthropic-compatible `messages` response parsing
 - output parsing and action output generation
 
-## Examples
+Copyable workflows are included in [`examples/`](examples):
 
-Copyable workflows are included here:
+- [`examples/workflow-self-hosted.yml`](examples/workflow-self-hosted.yml)
+- [`examples/workflow-cloud.yml`](examples/workflow-cloud.yml)
 
-- `examples/workflow-self-hosted.yml`
-- `examples/workflow-cloud.yml`
+## 📌 Version pinning and releases
 
-## Version pinning and releases
-
-The action is versioned via Git tags (e.g., `v1.0.18`). The examples in this README use `@v1` as a shorthand; in production workflows, pin to a specific version tag or commit SHA for reproducible runs:
+The action is versioned via Git tags (e.g., `v1.2.4`). The examples in this README use `@v1` as a shorthand; in production workflows, pin to a specific version tag or commit SHA for reproducible runs:
 
 ```yaml
 # Pin to a specific release tag (recommended)
-- uses: misospace/pr-reviewer-action@v1.0.18
+- uses: misospace/pr-reviewer-action@v1.2.4
 
 # Pin to a specific commit (most stable during development)
-- uses: misospace/pr-reviewer-action@f838c5b49d72d11dd33cfee6e29b85a28b5aa8df # v1.0.18
+- uses: misospace/pr-reviewer-action@d1a7753252a7d9d1e999ae53824e5e43587c8130 # v1.2.4
 ```
 
-### Self-review version pinning
+### 🔒 Self-review version pinning
 
 This repository's own self-review workflow (`.github/workflows/ai-pr-review.yaml`) pins the action to a specific commit SHA rather than `@v1` or `@main`. This ensures the self-review process uses a known-good, tested version while new changes are developed on `main`. After a release is cut and tagged, the self-review workflow is updated to pin the new tag.
 
-### Release cadence
+### 🗓️ Release cadence
 
 Releases are cut when features or fixes are ready. The `v1.x.y` scheme follows semver:
+
 - **Patch** (`y`): bug fixes and minor improvements
 - **Minor** (`x`): new features, backward-compatible changes
 - **Major** (`v1` → `v2`): breaking changes to inputs/outputs or behavior
 
 To stay current, subscribe to [GitHub Releases](https://github.com/misospace/pr-reviewer-action/releases) or enable Renovate to track the `misospace/pr-reviewer-action` dependency.
 
-## License
+## 🔐 Security
 
-MIT
+See [SECURITY.md](SECURITY.md) for the threat model, controls, and operational guidance.
 
-## Security
+## 📄 License
 
-See `SECURITY.md` for threat model, controls, and operational guidance.
+[MIT](LICENSE)
+
+---
+
+<div align="center">
+
+Built for homelabs and production alike — if this action reviews your PRs well, consider **[starring the repo ⭐](https://github.com/misospace/pr-reviewer-action)**
+
+<sub>[⬆ Back to top](#-pr-reviewer-action)</sub>
+
+</div>

--- a/action.yml
+++ b/action.yml
@@ -409,7 +409,7 @@ outputs:
     description: AI verdict, approve or request_changes
     value: ${{ steps.review.outputs.verdict }}
   verdict_source:
-    description: Where the final verdict came from ('model' or 'findings', per verdict_policy)
+    description: Where the final verdict came from ('model' or 'findings' per verdict_policy, or 'carry_forward' when a carried-forward blocker survived an incremental review)
     value: ${{ steps.review.outputs.verdict_source }}
   required_checks:
     description: Required-check validation status ('complete', 'incomplete', or 'none' when validation did not run)

--- a/tests/test_action_inputs.py
+++ b/tests/test_action_inputs.py
@@ -32,22 +32,28 @@ def parse_action_inputs():
 
 
 def parse_readme_inputs():
-    """Parse documented input names from the README inputs table."""
+    """Parse documented input names from the README inputs tables.
+
+    The README groups inputs into multiple tables (one per category,
+    inside <details> blocks), so every table with an `| Input |` header
+    is scanned.
+    """
     readme = _REPO_ROOT / "README.md"
     content = readme.read_text()
 
     inputs = set()
     in_table = False
     for line in content.splitlines():
-        # Detect start of inputs table (first pipe row with Input header)
+        # Detect start of an inputs table (pipe row with Input header)
         if "| Input |" in line:
             in_table = True
             continue
-        # Detect end of table (next section header or non-table line)
+        # Detect end of the current table (non-table line); keep scanning
+        # for further tables.
         if in_table:
-            if line.startswith("## ") or (line.strip() and not line.startswith("|")):
+            if line.strip() and not line.startswith("|"):
                 in_table = False
-                break
+                continue
             # Match input name in backticks: | `input_name` |
             m = re.search(r"\| \s*`(\w+)`\s*\|", line)
             if m:


### PR DESCRIPTION
## Summary

- **README**: restructured for scannability — centered hero with badges, tagline, and quick-nav links; quick start moved to the top; mermaid pipeline diagram; the 85-row flat inputs table split into 11 collapsible category groups; emoji section/subsection headers; two-column ✅ feature grid; `> [!WARNING]`/`> [!NOTE]` alerts; footer with back-to-top. No content removed.
- **AGENTS.md**: brought current with the codebase — documents the `pr_reviewer/` Python package, previously missing scripts (model_call.sh, publish_helpers.sh, redact.py, resolve_finding_threads.py, build_review_comments.py, wait_for_ci.sh, …), corrected review-corpus section order, `plan_execute_loop` + `git_grep` + named `run_command` tools, routing/escalation, publish modes, and the full outputs list.
- **Accuracy fixes**: `verdict_source` now documents the `carry_forward` value (set in `pr_reviewer/carry_forward.py` but undocumented in README/action.yml); stale `v1.0.18` version-pinning example updated to `v1.2.4` with its real commit SHA.
- **Tests**: `parse_readme_inputs()` in `tests/test_action_inputs.py` now scans all grouped input tables instead of stopping after the first, so the README↔action.yml consistency guarantee survives the new layout.

## Notes for reviewers

- Emoji in headers change GitHub's auto-generated anchor slugs, so deep links into old README sections (e.g. from issues) will need updating.
- SECURITY.md and the example workflows were audited and found accurate — left unchanged.

## Test plan

- [x] `pytest tests/` — 556 passed locally (test_evidence_providers.py skipped only because local system Python is 3.9; CI runs it)
- [x] README↔action.yml input-consistency test passes with the grouped tables
