### PR TITLE
fix: stop escalating trivial PRs to the smart model on planning failures and short reviews

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,8 +227,9 @@ Only three inputs are required: `github_token`, `ai_base_url`, and `ai_model`. E
 | `escalate_on_risk_flags` | Comma-separated `pr_kind`/`risk_flag` names that route to the smart model in `auto` mode | No | security/priority/auth/route/file-serving/path/secret/db list |
 | `escalate_on_incomplete_required_checks` | Escalate fast reviews with unaddressed required checks to the smart model (`auto` mode) | No | `true` |
 | `escalate_on_fast_request_changes` | Escalate fast reviews whose verdict is `request_changes` (`auto` mode) | No | `true` |
-| `escalate_on_fast_low_confidence` | Escalate low-confidence fast reviews (very short, or populated Unknowns section) (`auto` mode) | No | `true` |
-| `escalate_on_tool_or_evidence_blockers` | Escalate when evidence blockers or tool-harness failures exist (`auto` mode) | No | `true` |
+| `escalate_on_fast_low_confidence` | Escalate low-confidence fast reviews (short relative to the diff, or populated Unknowns section) (`auto` mode) | No | `true` |
+| `escalate_on_tool_or_evidence_blockers` | Escalate when evidence blockers exist or every executed tool request failed (`auto` mode) | No | `true` |
+| `escalate_on_tool_planning_failure` | Escalate when the tool-harness planning call failed (`auto` mode). Off by default: a planning failure degrades the review to no-tools, it does not signal risk | No | `false` |
 | `escalate_on_dirty_baseline` | Escalate incremental reviews whose baseline review found issues (`auto` mode) | No | `true` |
 
 </details>
@@ -806,8 +807,9 @@ In `auto` mode, a fast review can also be **escalated after the fact**: the acti
 
 - `escalate_on_fast_request_changes` — the fast model wants changes; let the smart model confirm or overturn before a human is summoned.
 - `escalate_on_incomplete_required_checks` — the fast review never discussed one of the classifier's required checks.
-- `escalate_on_fast_low_confidence` — the review is very short or carries a populated "Unknowns or Needs Verification" section.
-- `escalate_on_tool_or_evidence_blockers` — evidence providers reported a blocker or the tool harness failed.
+- `escalate_on_fast_low_confidence` — the review is very short or carries a populated "Unknowns or Needs Verification" section. The length floor is diff-aware: a diff of ≤10 changed lines only needs an 80-char review (a correct review of a one-line renovate bump is short — escalating it wastes a smart-model run on exactly the PRs least worth one), while larger diffs keep the 200-char floor.
+- `escalate_on_tool_or_evidence_blockers` — evidence providers reported a blocker, or tool requests executed and every one failed.
+- `escalate_on_tool_planning_failure` (default **false**) — the harness planning call failed before any tools ran. Off by default because a planning failure means the review proceeded with less evidence (the same situation as `tool_mode: off`), not that the PR is risky; the failure is still recorded in the step summary.
 - `escalate_on_dirty_baseline` — this is an incremental review and the previous review found issues; judging whether the delta resolves them is run on the smart model.
 
 Only the **final** review is published. The fast result is kept on the runner as `ai-output.fast.json` for debugging; if the smart model fails, the fast review is published instead (never a failed run because of escalation). `review_route` reports `escalated` and `escalation_reason` lists the trigger names; both also land in the step summary and the managed metadata marker. Worst case is two model calls per review — the unchanged-diff skip and incremental scope keep that bounded.

--- a/action.yml
+++ b/action.yml
@@ -184,9 +184,19 @@ inputs:
     required: false
     default: "true"
   escalate_on_tool_or_evidence_blockers:
-    description: Escalate when evidence providers report blocker severity or the tool harness failed (review_routing_mode=auto only).
+    description: >-
+      Escalate when evidence providers report blocker severity or every executed tool
+      request failed (review_routing_mode=auto only).
     required: false
     default: "true"
+  escalate_on_tool_planning_failure:
+    description: >-
+      Escalate when the tool harness planning call failed (review_routing_mode=auto only).
+      Off by default: a planning failure means the review ran with less evidence — the same
+      situation as tool_mode 'off' — not that the PR is risky. The failure is still recorded
+      in tool-harness.json and the step summary.
+    required: false
+    default: "false"
   escalate_on_dirty_baseline:
     description: >-
       Escalate incremental reviews whose baseline review found issues (review_routing_mode=auto
@@ -493,6 +503,7 @@ runs:
         ESCALATE_ON_FAST_REQUEST_CHANGES: ${{ inputs.escalate_on_fast_request_changes }}
         ESCALATE_ON_FAST_LOW_CONFIDENCE: ${{ inputs.escalate_on_fast_low_confidence }}
         ESCALATE_ON_TOOL_OR_EVIDENCE_BLOCKERS: ${{ inputs.escalate_on_tool_or_evidence_blockers }}
+        ESCALATE_ON_TOOL_PLANNING_FAILURE: ${{ inputs.escalate_on_tool_planning_failure }}
         ESCALATE_ON_DIRTY_BASELINE: ${{ inputs.escalate_on_dirty_baseline }}
         ANTHROPIC_VERSION: ${{ inputs.anthropic_version }}
         SYSTEM_PROMPT: ${{ inputs.system_prompt }}
@@ -581,6 +592,7 @@ runs:
         ESCALATE_ON_FAST_REQUEST_CHANGES: ${{ inputs.escalate_on_fast_request_changes }}
         ESCALATE_ON_FAST_LOW_CONFIDENCE: ${{ inputs.escalate_on_fast_low_confidence }}
         ESCALATE_ON_TOOL_OR_EVIDENCE_BLOCKERS: ${{ inputs.escalate_on_tool_or_evidence_blockers }}
+        ESCALATE_ON_TOOL_PLANNING_FAILURE: ${{ inputs.escalate_on_tool_planning_failure }}
         ESCALATE_ON_DIRTY_BASELINE: ${{ inputs.escalate_on_dirty_baseline }}
         BASELINE_CLEAN: ${{ steps.precheck.outputs.baseline_clean }}
         AI_STREAM: ${{ inputs.ai_stream }}

--- a/pr_reviewer/escalation.py
+++ b/pr_reviewer/escalation.py
@@ -19,6 +19,13 @@ from pr_reviewer.completeness import validate_review
 # content — a fast model that produced two sentences did not review anything.
 LOW_CONFIDENCE_MIN_CHARS = 200
 
+# For trivial diffs the expected review is legitimately short: a correct
+# review of a one-line renovate bump should not escalate as "low confidence"
+# (#215). At or below this many changed lines, the minimum drops to a floor
+# that still catches bare "LGTM"-style non-reviews.
+TRIVIAL_DIFF_MAX_CHANGED_LINES = 10
+TRIVIAL_DIFF_MIN_CHARS = 80
+
 # Header of the section the default prompt asks for "when evidence is
 # incomplete" — its presence with real content is the model saying it is
 # unsure.
@@ -37,9 +44,28 @@ def _load(path: str) -> dict:
         return {}
 
 
-def is_low_confidence(review_markdown: str) -> bool:
+def count_changed_lines(diff_path: str = "pr.diff") -> int | None:
+    """Count added/removed lines in a unified diff, or None when unreadable.
+
+    None (rather than 0) on a missing/unreadable diff so callers fail closed
+    to the standard low-confidence threshold instead of the trivial one.
+    """
+    try:
+        text = Path(diff_path).read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None
+    count = 0
+    for line in text.splitlines():
+        if line.startswith("+") and not line.startswith("+++"):
+            count += 1
+        elif line.startswith("-") and not line.startswith("---"):
+            count += 1
+    return count
+
+
+def is_low_confidence(review_markdown: str, min_chars: int = LOW_CONFIDENCE_MIN_CHARS) -> bool:
     text = (review_markdown or "").strip()
-    if len(text) < LOW_CONFIDENCE_MIN_CHARS:
+    if len(text) < min_chars:
         return True
     match = _UNKNOWNS_HEADER_RE.search(text)
     if match:
@@ -53,13 +79,21 @@ def is_low_confidence(review_markdown: str) -> bool:
 def _has_blocker_signals(evidence: dict, harness: dict) -> bool:
     if evidence.get("has_blocker"):
         return True
-    if harness.get("planning_error") is not None or harness.get("error") is not None:
-        return True
     executed = harness.get("executed_request_count", 0)
     results = [t for t in harness.get("tool_results", []) if isinstance(t, dict)]
     if executed and results and not any(t.get("status") == "ok" for t in results):
         return True
     return False
+
+
+def _has_planning_failure(harness: dict) -> bool:
+    """The harness planning call failed before any tools ran (#215).
+
+    Kept separate from blocker signals: a planning failure means the review
+    proceeded with LESS evidence — the same situation as tool_mode 'off' —
+    not that the PR carries elevated risk. Escalating on it is opt-in.
+    """
+    return harness.get("planning_error") is not None or harness.get("error") is not None
 
 
 def should_escalate(
@@ -68,11 +102,13 @@ def should_escalate(
     on_low_confidence: bool = True,
     on_blockers: bool = True,
     on_dirty_baseline: bool = True,
+    on_planning_failure: bool = False,
     dirty_baseline: bool = False,
     output_path: str = "ai-output.json",
     classification_path: str = "classification.json",
     evidence_path: str = "evidence-providers.json",
     tool_harness_path: str = "tool-harness.json",
+    diff_path: str = "pr.diff",
 ) -> tuple[bool, list[str]]:
     """Return (escalate, reasons) for the fast review in *output_path*.
 
@@ -94,13 +130,24 @@ def should_escalate(
         if must_check and not validate_review(must_check, review)["validated"]:
             reasons.append("incomplete_required_checks")
 
-    if on_low_confidence and is_low_confidence(review):
-        reasons.append("fast_low_confidence")
+    if on_low_confidence:
+        # The minimum review length scales with the diff: a 2-line image bump
+        # warrants a short review, and escalating it wastes a smart-model run
+        # on exactly the PRs least worth one (#215). Unknowns-section
+        # detection inside is_low_confidence applies at any length.
+        min_chars = LOW_CONFIDENCE_MIN_CHARS
+        changed = count_changed_lines(diff_path)
+        if changed is not None and changed <= TRIVIAL_DIFF_MAX_CHANGED_LINES:
+            min_chars = TRIVIAL_DIFF_MIN_CHARS
+        if is_low_confidence(review, min_chars):
+            reasons.append("fast_low_confidence")
 
-    if on_blockers and _has_blocker_signals(
-        _load(evidence_path), _load(tool_harness_path)
-    ):
+    harness = _load(tool_harness_path)
+    if on_blockers and _has_blocker_signals(_load(evidence_path), harness):
         reasons.append("tool_or_evidence_blockers")
+
+    if on_planning_failure and _has_planning_failure(harness):
+        reasons.append("tool_planning_failed")
 
     # Incremental review against a baseline the previous review flagged: the
     # resolution judgment ("does this delta fix that blocker?") is exactly

--- a/scripts/run_review.sh
+++ b/scripts/run_review.sh
@@ -116,6 +116,7 @@ ESCALATE_ON_INCOMPLETE_REQUIRED_CHECKS="${ESCALATE_ON_INCOMPLETE_REQUIRED_CHECKS
 ESCALATE_ON_FAST_REQUEST_CHANGES="${ESCALATE_ON_FAST_REQUEST_CHANGES:-true}"
 ESCALATE_ON_FAST_LOW_CONFIDENCE="${ESCALATE_ON_FAST_LOW_CONFIDENCE:-true}"
 ESCALATE_ON_TOOL_OR_EVIDENCE_BLOCKERS="${ESCALATE_ON_TOOL_OR_EVIDENCE_BLOCKERS:-true}"
+ESCALATE_ON_TOOL_PLANNING_FAILURE="${ESCALATE_ON_TOOL_PLANNING_FAILURE:-false}"
 ESCALATE_ON_DIRTY_BASELINE="${ESCALATE_ON_DIRTY_BASELINE:-true}"
 # Default true: only the precheck can assert a dirty baseline; standalone runs
 # (smoke test, manual) have no baseline signal and must not over-escalate.
@@ -316,6 +317,7 @@ ESCALATE_ON_INCOMPLETE_REQUIRED_CHECKS="$(printf '%s' "$ESCALATE_ON_INCOMPLETE_R
 ESCALATE_ON_FAST_REQUEST_CHANGES="$(printf '%s' "$ESCALATE_ON_FAST_REQUEST_CHANGES" | tr '[:upper:]' '[:lower:]')"
 ESCALATE_ON_FAST_LOW_CONFIDENCE="$(printf '%s' "$ESCALATE_ON_FAST_LOW_CONFIDENCE" | tr '[:upper:]' '[:lower:]')"
 ESCALATE_ON_TOOL_OR_EVIDENCE_BLOCKERS="$(printf '%s' "$ESCALATE_ON_TOOL_OR_EVIDENCE_BLOCKERS" | tr '[:upper:]' '[:lower:]')"
+ESCALATE_ON_TOOL_PLANNING_FAILURE="$(printf '%s' "$ESCALATE_ON_TOOL_PLANNING_FAILURE" | tr '[:upper:]' '[:lower:]')"
 ESCALATE_ON_DIRTY_BASELINE="$(printf '%s' "$ESCALATE_ON_DIRTY_BASELINE" | tr '[:upper:]' '[:lower:]')"
 BASELINE_CLEAN="$(printf '%s' "$BASELINE_CLEAN" | tr '[:upper:]' '[:lower:]')"
 
@@ -1436,6 +1438,7 @@ escalate, reasons = should_escalate(
     on_low_confidence=('$ESCALATE_ON_FAST_LOW_CONFIDENCE' == 'true'),
     on_blockers=('$ESCALATE_ON_TOOL_OR_EVIDENCE_BLOCKERS' == 'true'),
     on_dirty_baseline=('$ESCALATE_ON_DIRTY_BASELINE' == 'true'),
+    on_planning_failure=('$ESCALATE_ON_TOOL_PLANNING_FAILURE' == 'true'),
     dirty_baseline=('$DIRTY_BASELINE' == 'true'),
 )
 print('yes ' + ','.join(reasons) if escalate else 'no')

--- a/tests/test_escalation.py
+++ b/tests/test_escalation.py
@@ -12,7 +12,11 @@ sys.path.insert(0, str(_REPO_ROOT))
 
 import pytest
 
-from pr_reviewer.escalation import is_low_confidence, should_escalate
+from pr_reviewer.escalation import (
+    count_changed_lines,
+    is_low_confidence,
+    should_escalate,
+)
 
 
 GOOD_REVIEW = (
@@ -116,7 +120,9 @@ class TestShouldEscalate:
         escalate, reasons = should_escalate()
         assert reasons == ["tool_or_evidence_blockers"]
 
-    def test_tool_harness_failure_trigger(self, tmp_path, monkeypatch):
+    def test_planning_failure_does_not_escalate_by_default(self, tmp_path, monkeypatch):
+        """A failed planning call means the review ran with less evidence —
+        the same situation as tool_mode 'off' — not elevated risk (#215)."""
         monkeypatch.chdir(tmp_path)
         _write_fast_output(tmp_path)
         _write_classification(tmp_path)
@@ -124,7 +130,29 @@ class TestShouldEscalate:
             json.dumps({"planning_error": "planner timed out", "tool_results": []})
         )
         escalate, reasons = should_escalate()
-        assert reasons == ["tool_or_evidence_blockers"]
+        assert escalate is False and reasons == []
+
+    def test_planning_failure_escalates_when_opted_in(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _write_fast_output(tmp_path)
+        _write_classification(tmp_path)
+        (tmp_path / "tool-harness.json").write_text(
+            json.dumps({"planning_error": "planner timed out", "tool_results": []})
+        )
+        escalate, reasons = should_escalate(on_planning_failure=True)
+        assert reasons == ["tool_planning_failed"]
+
+    def test_harness_hard_error_does_not_escalate_by_default(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _write_fast_output(tmp_path)
+        _write_classification(tmp_path)
+        (tmp_path / "tool-harness.json").write_text(
+            json.dumps({"error": "harness crashed", "tool_results": []})
+        )
+        escalate, reasons = should_escalate()
+        assert escalate is False
+        escalate, reasons = should_escalate(on_planning_failure=True)
+        assert reasons == ["tool_planning_failed"]
 
     def test_all_tool_requests_failed_trigger(self, tmp_path, monkeypatch):
         monkeypatch.chdir(tmp_path)
@@ -164,6 +192,87 @@ class TestShouldEscalate:
         _write_fast_output(tmp_path)
         escalate, reasons = should_escalate()
         assert escalate is False
+
+
+TRIVIAL_DIFF = """\
+diff --git a/kubernetes/apps/base/flux-system/konflate/helmrelease.yaml b/kubernetes/apps/base/flux-system/konflate/helmrelease.yaml
+--- a/kubernetes/apps/base/flux-system/konflate/helmrelease.yaml
++++ b/kubernetes/apps/base/flux-system/konflate/helmrelease.yaml
+@@ -10,7 +10,7 @@ spec:
+     operation: copy
+   ref:
+-    tag: 0.2.7
++    tag: 0.2.8
+   url: oci://ghcr.io/home-operations/charts/konflate
+"""
+
+# Short but real: a correct review of a one-line bump (#215).
+SHORT_BUMP_REVIEW = (
+    "Approve. Renovate patch bump of the konflate chart, 0.2.7 to 0.2.8; "
+    "no functional manifest changes."
+)
+
+
+class TestCountChangedLines:
+    def test_counts_only_change_lines(self, tmp_path):
+        path = tmp_path / "pr.diff"
+        path.write_text(TRIVIAL_DIFF)
+        assert count_changed_lines(str(path)) == 2
+
+    def test_missing_diff_is_none(self, tmp_path):
+        assert count_changed_lines(str(tmp_path / "absent.diff")) is None
+
+    def test_empty_diff_is_zero(self, tmp_path):
+        path = tmp_path / "pr.diff"
+        path.write_text("")
+        assert count_changed_lines(str(path)) == 0
+
+
+class TestTrivialDiffLowConfidence:
+    def test_short_review_of_trivial_diff_does_not_escalate(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _write_fast_output(tmp_path, review=SHORT_BUMP_REVIEW)
+        _write_classification(tmp_path)
+        (tmp_path / "pr.diff").write_text(TRIVIAL_DIFF)
+        escalate, reasons = should_escalate()
+        assert escalate is False and reasons == []
+
+    def test_bare_lgtm_still_escalates_on_trivial_diff(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _write_fast_output(tmp_path, review="LGTM.")
+        _write_classification(tmp_path)
+        (tmp_path / "pr.diff").write_text(TRIVIAL_DIFF)
+        escalate, reasons = should_escalate()
+        assert "fast_low_confidence" in reasons
+
+    def test_short_review_of_large_diff_still_escalates(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _write_fast_output(tmp_path, review=SHORT_BUMP_REVIEW)
+        _write_classification(tmp_path)
+        big = TRIVIAL_DIFF + "".join(f"+added line {i}\n" for i in range(40))
+        (tmp_path / "pr.diff").write_text(big)
+        escalate, reasons = should_escalate()
+        assert "fast_low_confidence" in reasons
+
+    def test_missing_diff_fails_closed_to_standard_threshold(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _write_fast_output(tmp_path, review=SHORT_BUMP_REVIEW)
+        _write_classification(tmp_path)
+        escalate, reasons = should_escalate()
+        assert "fast_low_confidence" in reasons
+
+    def test_unknowns_section_escalates_even_on_trivial_diff(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        review = SHORT_BUMP_REVIEW + (
+            "\n\n## Unknowns or Needs Verification\n"
+            "Could not verify the upstream changelog; the release fetch failed "
+            "and the compare endpoint returned an error."
+        )
+        _write_fast_output(tmp_path, review=review)
+        _write_classification(tmp_path)
+        (tmp_path / "pr.diff").write_text(TRIVIAL_DIFF)
+        escalate, reasons = should_escalate()
+        assert "fast_low_confidence" in reasons
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #215

## Diagnosis (joryirving/home-ops, 6 recent renovate runs)

5/6 correctly routed `fast` and then escalated to MiniMax anyway: 3× `tool_or_evidence_blockers` (round-1 planning call failed → `planning_error` → treated as a blocker), 2× `fast_low_confidence` (correct-but-short review of a 1-line bump under the 200-char floor). Example: home-ops PR 7412, a one-line chart tag bump — the local review was produced and then discarded for a smart re-review.

## Changes

1. **Planning failures no longer escalate by default.** `planning_error`/`error` moved out of `_has_blocker_signals` into a separate `tool_planning_failed` reason behind a new input `escalate_on_tool_planning_failure` (default `false`). Rationale: a failed planning call means the review ran with *less* evidence — identical to `tool_mode: off`, which nobody escalates on. Evidence `has_blocker` and executed-with-zero-ok-results still escalate under the existing trigger.
2. **Diff-aware low-confidence floor.** `should_escalate` counts changed lines in `pr.diff` (already in cwd at the call site): ≤10 changed lines drops the minimum review length from 200 to 80 chars — still catching bare "LGTM." non-reviews — while larger diffs keep the 200-char floor. Missing/unreadable diff fails closed to 200. The populated-Unknowns-section heuristic applies unchanged at any length.

Master switches (`escalate_on_fast_low_confidence`, `escalate_on_tool_or_evidence_blockers`) are untouched; no breaking input changes.

## Behavior change note

Repos relying on planning failures escalating must now opt in via `escalate_on_tool_planning_failure: "true"`. The failure remains visible in `tool-harness.json` and the step summary either way.

## Tests

- `tests/test_escalation.py`: 26 cases (was 17) — planning-failure default/opt-in/hard-error, `count_changed_lines`, and a trivial-diff suite (short-real-review no-escalate, bare-LGTM escalates, large-diff escalates, missing-diff fails closed, Unknowns escalates at any length) using the home-ops 7412 diff shape as the fixture.
- Full suite: 635 python tests pass; `test_review_escalation.sh` (27) and `test_review_routing.sh` (21) pass.
