### PR TITLE
feat: annotate the published analysis-engine line with the routing story

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ Only three inputs are required: `github_token`, `ai_base_url`, and `ai_model`. E
 | `escalation_reason` | Comma-separated escalation trigger names when `review_route` is `escalated` (empty otherwise) |
 | `findings` | Normalized structured findings as a JSON array (`[]` when the model produced none) |
 | `review_markdown` | Full markdown review body |
-| `analysis_engine` | Model and endpoint that produced the final result |
+| `analysis_engine` | Model and endpoint that produced the final result, annotated with how it was chosen: `— fast route`, `— routed smart (risk match: …)`, `— escalated (…)`, or `— fallback (primary failed)`. Unannotated when routing is off |
 | `should_review` | `true` when a new LLM review was run |
 | `skip_reason` | Skip reason such as `diff-unchanged` |
 | `diff_fingerprint` | Stable fingerprint of the current PR patch |
@@ -812,7 +812,7 @@ In `auto` mode, a fast review can also be **escalated after the fact**: the acti
 - `escalate_on_tool_planning_failure` (default **false**) — the harness planning call failed before any tools ran. Off by default because a planning failure means the review proceeded with less evidence (the same situation as `tool_mode: off`), not that the PR is risky; the failure is still recorded in the step summary.
 - `escalate_on_dirty_baseline` — this is an incremental review and the previous review found issues; judging whether the delta resolves them is run on the smart model.
 
-Only the **final** review is published. The fast result is kept on the runner as `ai-output.fast.json` for debugging; if the smart model fails, the fast review is published instead (never a failed run because of escalation). `review_route` reports `escalated` and `escalation_reason` lists the trigger names; both also land in the step summary and the managed metadata marker. Worst case is two model calls per review — the unchanged-diff skip and incremental scope keep that bounded.
+Only the **final** review is published. The fast result is kept on the runner as `ai-output.fast.json` for debugging; if the smart model fails, the fast review is published instead (never a failed run because of escalation). `review_route` reports `escalated` and `escalation_reason` lists the trigger names; both also land in the step summary and the managed metadata marker, and the published review's `_Analysis engine:_` line carries the same story in human-readable form (`— routed smart (risk match: …)` vs `— escalated (…)` vs `— fallback (primary failed)`), so you can tell a deliberate smart review from an escalation or an availability fallback at a glance. Worst case is two model calls per review — the unchanged-diff skip and incremental scope keep that bounded.
 
 ## 💾 Token-saving with incremental reviews
 

--- a/scripts/run_review.sh
+++ b/scripts/run_review.sh
@@ -1365,8 +1365,35 @@ print(json.dumps({"verdict": "request_changes", "review_markdown": md}))
 PY
 }
 
+# Append the routing/fallback story to the analysis-engine string, so the
+# published "_Analysis engine: …_" line says not just WHICH model produced
+# the review but WHY it was chosen: deliberate smart routing, post-review
+# escalation, and primary-failure fallback read very differently on cost and
+# health. Legacy (routing off) primary success stays unannotated so the
+# output is byte-identical for routing-off users.
+# Args: $1 = base "model@url (format)" string, $2 = origin: primary|fallback|escalated
+# Uses env: REVIEW_ROUTE, ROUTE_REASON, ESCALATION_REASONS
+annotate_analysis_engine() {
+  local engine="$1" origin="$2"
+  case "$origin" in
+    fallback)
+      engine="$engine — fallback (primary failed)"
+      ;;
+    escalated)
+      engine="$engine — escalated (${ESCALATION_REASONS:-unknown})"
+      ;;
+    primary)
+      case "${REVIEW_ROUTE:-legacy}" in
+        fast) engine="$engine — fast route" ;;
+        smart) engine="$engine — routed smart (${ROUTE_REASON:-risk match})" ;;
+      esac
+      ;;
+  esac
+  printf '%s' "$engine"
+}
+
 if [ "$PRIMARY_OK" -eq 1 ]; then
-  ANALYSIS_ENGINE="$AI_MODEL@$AI_BASE_URL ($AI_API_FORMAT)"
+  ANALYSIS_ENGINE="$(annotate_analysis_engine "$AI_MODEL@$AI_BASE_URL ($AI_API_FORMAT)" primary)"
   echo "Primary model succeeded"
 else
   TRY_FALLBACK=1
@@ -1397,7 +1424,7 @@ else
   if curl_model "$AI_FALLBACK_BASE_URL" "$AI_FALLBACK_API_KEY" "$AI_FALLBACK_API_FORMAT" ai-request.fallback.json ai-response.fallback.json "$FALLBACK_STREAM_BOOL" "$AI_FALLBACK_REQUEST_TIMEOUT_SEC" "$AI_FALLBACK_CONNECT_TIMEOUT_SEC" && \
     { [[ "$FALLBACK_STREAM_BOOL" != "true" ]] || reassemble_sse_response ai-response.fallback.json "$AI_FALLBACK_API_FORMAT"; } && \
     parse_and_validate ai-response.fallback.json; then
-    ANALYSIS_ENGINE="$AI_FALLBACK_MODEL@$AI_FALLBACK_BASE_URL ($AI_FALLBACK_API_FORMAT)"
+    ANALYSIS_ENGINE="$(annotate_analysis_engine "$AI_FALLBACK_MODEL@$AI_FALLBACK_BASE_URL ($AI_FALLBACK_API_FORMAT)" fallback)"
     echo "Fallback model succeeded" >&2
   else
     handle_model_failure "Fallback model failed"
@@ -1481,7 +1508,7 @@ This is an ESCALATED review: a faster preliminary review was judged insufficient
   if [[ "$smart_ok" -eq 1 ]]; then
     REVIEW_ROUTE="escalated"
     ROUTE_REASON="escalated: ${ESCALATION_REASONS}"
-    ANALYSIS_ENGINE="$SMART_MODEL@$SMART_BASE_URL ($SMART_API_FORMAT)"
+    ANALYSIS_ENGINE="$(annotate_analysis_engine "$SMART_MODEL@$SMART_BASE_URL ($SMART_API_FORMAT)" escalated)"
     log "Smart model succeeded; publishing the escalated review"
   else
     # parse_and_validate only rewrites ai-output.json on success, but restore

--- a/tests/test_review_routing.sh
+++ b/tests/test_review_routing.sh
@@ -117,5 +117,41 @@ check "publish steps receive REVIEW_ROUTE" \
 check_contains "marker carries review_route" "$(cat "$ROOT_DIR/scripts/publish_helpers.sh")" "review_route"
 
 echo ""
+echo "=== Test: annotate_analysis_engine ==="
+# Extract annotate_analysis_engine the same way as resolve_review_route.
+AAE_FUNCS="$(mktemp)"
+python3 - "$ROOT_DIR/scripts/run_review.sh" "$AAE_FUNCS" <<'PY'
+import re, sys
+src = open(sys.argv[1]).read()
+m = re.search(r"^annotate_analysis_engine\(\) \{\n(.*?)\n\}", src, re.S | re.M)
+if not m:
+    sys.exit("could not extract annotate_analysis_engine")
+open(sys.argv[2], "w").write("annotate_analysis_engine() {\n%s\n}\n" % m.group(1))
+PY
+# shellcheck source=/dev/null
+source "$AAE_FUNCS"
+rm -f "$AAE_FUNCS"
+
+BASE="review@http://llm:8080/v1 (openai)"
+check "legacy primary stays unannotated" \
+  "$(REVIEW_ROUTE=legacy annotate_analysis_engine "$BASE" primary)" "$BASE"
+check "routing-off default stays unannotated" \
+  "$(REVIEW_ROUTE= annotate_analysis_engine "$BASE" primary)" "$BASE"
+check "fast route annotated" \
+  "$(REVIEW_ROUTE=fast annotate_analysis_engine "$BASE" primary)" "$BASE — fast route"
+check "smart route carries the risk reason" \
+  "$(REVIEW_ROUTE=smart ROUTE_REASON="risk match: auth_changes" annotate_analysis_engine "$BASE" primary)" \
+  "$BASE — routed smart (risk match: auth_changes)"
+check "fallback annotated" \
+  "$(annotate_analysis_engine "$BASE" fallback)" "$BASE — fallback (primary failed)"
+check "escalated carries trigger names" \
+  "$(ESCALATION_REASONS="fast_low_confidence" annotate_analysis_engine "$BASE" escalated)" \
+  "$BASE — escalated (fast_low_confidence)"
+# The step-summary usage-file branch greps the engine string for "fallback";
+# only the fallback origin may introduce that word.
+check "fast annotation does not claim fallback" \
+  "$(case "$(REVIEW_ROUTE=fast annotate_analysis_engine "$BASE" primary)" in *fallback*) echo yes;; *) echo no;; esac)" "no"
+
+echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
The visible `_Analysis engine: …_` line in published reviews showed *which* model produced the review but not *why* — a deliberate smart-route, a post-review escalation, and a primary-failure fallback were indistinguishable apart from the model name, despite meaning very different things for cost and endpoint health. The information existed (`review_route`/`escalation_reason` outputs, step summary, metadata marker) but nowhere a human reads the PR.

## What

New `annotate_analysis_engine()` in `run_review.sh`, called at the three success sites, so every publish mode gets the annotated line for free:

- `review@… (openai) — fast route`
- `MiniMax-M2.7@… (anthropic) — routed smart (risk match: auth_changes)`
- `MiniMax-M2.7@… (anthropic) — escalated (fast_low_confidence)`
- `cheap-coder@… (openai) — fallback (primary failed)`

Legacy (routing off) primary output stays **byte-identical** — no churn for routing-off users. The `analysis_engine` action output carries the same annotated string.

## Safety note

The step summary's token-usage file selection greps the engine string for the word `fallback`; only the fallback origin introduces it (asserted by a test).

## Tests

- 7 new cases in `test_review_routing.sh` (function extracted the same way as `resolve_review_route`): unannotated legacy/default, fast, smart-with-reason, fallback, escalated-with-triggers, and the no-false-`fallback`-claim guard.
- Full sweep: 635 python, routing (28), escalation (27), smoke (25), step-summary (4) all pass.
