### PR TITLE
feat: feed CI check results into the review corpus

### DIFF
--- a/.github/workflows/ai-pr-review.yaml
+++ b/.github/workflows/ai-pr-review.yaml
@@ -55,6 +55,8 @@ jobs:
           ai_smart_model: ${{ vars.SMART_MODEL }}
           ai_smart_api_key: ${{ secrets.LITELLM_API_KEY }}
           context_limit_mode: normal
+          ci_status_check: "true"
+          ci_timeout_sec: "600"
           tool_mode: plan_execute_loop
           tool_max_rounds: "2"
           tool_max_requests: "4"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ The action collects rich PR context (diff, files, linked issues, version hints, 
 
 - **`action.yml`** — Action definition with all inputs/outputs and composite run steps (precheck → CI wait → review → publish). The publish steps live inline in this file using helpers from `scripts/publish_helpers.sh`.
 - **`scripts/check_review_needed.sh`** — Precheck: computes `git patch-id --stable` fingerprint, decides full vs. incremental scope, and skips if unchanged since last managed comment
-- **`scripts/wait_for_ci.sh`** — Optional CI gating: polls commit status until checks reach a terminal state (`ci_status_check=true`)
+- **`scripts/wait_for_ci.sh`** — Optional CI gating: polls the Checks API until checks reach a terminal state (`ci_status_check=true`), then renders the per-check outcomes to `CI_CHECKS_FILE` for the review corpus
 - **`scripts/run_review.sh`** — Main review orchestration script (collects context, builds corpus, classifies, routes, calls model, validates and enforces verdicts)
 - **`scripts/model_call.sh`** — Shared model-call layer: request building, streaming/SSE handling, retries, error-body preservation for both API formats
 - **`scripts/default_system_prompt.txt`** — Bundled system prompt used when no override is provided
@@ -56,7 +56,7 @@ The action collects rich PR context (diff, files, linked issues, version hints, 
 
 ```
 check_review_needed.sh          → should_review + diff_fingerprint + effective scope (full/incremental)
-wait_for_ci.sh (optional)       → block until CI checks are terminal
+wait_for_ci.sh (optional)       → block until CI checks are terminal + emit per-check results
 run_review.sh                   → collects context → classifies → builds corpus → routes → calls model → validates/enforces
   ├─ gh pr view/diff/api        → PR metadata, files, linked issues
   ├─ pr_reviewer.classifier     → pr_kind, risk_flags, must_check (rule-based, no model)

--- a/README.md
+++ b/README.md
@@ -426,6 +426,8 @@ When `ai_api_format: anthropic` is set, the action posts to `/messages`, sends t
 
 Set `ci_status_check: true` to wait for all CI checks to reach a terminal state before starting the AI review. This ensures the review considers the final CI results rather than running against in-progress checks.
 
+The per-check outcomes (name, status, conclusion) are also folded into the review corpus as a **CI Check Results** section, so the model cites real test/lint results instead of reporting them as "not verifiable". The reviewer never runs your test suite itself — that would mean executing untrusted PR code with the bot's token — it consumes the results your CI already produced in its own sandbox.
+
 ```yaml
 - uses: misospace/pr-reviewer-action@v1
   id: review

--- a/action.yml
+++ b/action.yml
@@ -389,7 +389,7 @@ inputs:
     required: false
     default: "<!-- ai-pr-reviewer -->"
   ci_status_check:
-    description: If true, wait for all CI checks to reach a terminal state before starting the AI review. Polls commit-status API for the PR head SHA. Default false — immediate review (original behavior).
+    description: If true, wait for all CI checks to reach a terminal state before starting the AI review, then fold the per-check outcomes into the review corpus as evidence (so the model cites real test/lint results instead of "not verifiable"). Polls the Checks API for the PR head SHA. Default false — immediate review (original behavior).
     required: false
     default: "false"
   ci_timeout_sec:
@@ -549,6 +549,7 @@ runs:
         CI_TIMEOUT_SEC: ${{ inputs.ci_timeout_sec }}
         CI_INTERVAL_SEC: ${{ inputs.ci_interval_sec }}
         CI_SKIP_ON_TIMEOUT: ${{ inputs.ci_skip_on_timeout }}
+        CI_CHECKS_FILE: ${{ runner.temp }}/ci-checks-context.md
       run: bash "${{ github.action_path }}/scripts/wait_for_ci.sh"
 
     - name: Run AI review
@@ -631,6 +632,7 @@ runs:
         CI_STATUS_CHECK: ${{ inputs.ci_status_check }}
         CI_STATUS_FINAL: ${{ steps.ci_status.outputs.ci_status_final }}
         CI_STATUS_SKIPPED: ${{ steps.ci_status.outputs.ci_status_skipped }}
+        CI_CHECKS_FILE: ${{ runner.temp }}/ci-checks-context.md
         REVIEW_SCOPE: ${{ inputs.review_scope }}
         EFFECTIVE_SCOPE: ${{ steps.precheck.outputs.effective_review_scope }}
         PREVIOUS_HEAD_SHA: ${{ steps.precheck.outputs.previous_head_sha }}

--- a/scripts/run_review.sh
+++ b/scripts/run_review.sh
@@ -124,6 +124,9 @@ BASELINE_CLEAN="${BASELINE_CLEAN:-true}"
 REVIEW_SCOPE="${REVIEW_SCOPE:-auto}"
 EFFECTIVE_SCOPE="${EFFECTIVE_SCOPE:-full}"
 PREVIOUS_HEAD_SHA="${PREVIOUS_HEAD_SHA:-}"
+# Per-check CI results written by wait_for_ci.sh when ci_status_check=true.
+# Empty/absent when CI gating is off or no external checks ran.
+CI_CHECKS_FILE="${CI_CHECKS_FILE:-}"
 ENRICHMENT_BUDGET_SEC="${ENRICHMENT_BUDGET_SEC:-60}"
 
 apply_context_limits() {
@@ -1138,6 +1141,15 @@ print(render_carried_findings_section(load_carried_findings()), end='')
     echo "# Evidence Providers"
     cat evidence-providers.md
     echo
+    # CI ran to completion in its own sandbox before this review; surface the
+    # per-check outcomes so the model cites real test/lint results instead of
+    # reporting them as "not verifiable". Only present when ci_status_check=true
+    # and external checks existed.
+    if [ -n "$CI_CHECKS_FILE" ] && [ -s "$CI_CHECKS_FILE" ]; then
+      echo "# CI Check Results"
+      cat "$CI_CHECKS_FILE"
+      echo
+    fi
     echo "# Image Digest Provenance"
     cat image-digest-context.md
     echo

--- a/scripts/wait_for_ci.sh
+++ b/scripts/wait_for_ci.sh
@@ -31,6 +31,10 @@ CI_TIMEOUT_SEC="${CI_TIMEOUT_SEC:-300}"
 CI_INTERVAL_SEC="${CI_INTERVAL_SEC:-15}"
 CI_SKIP_ON_TIMEOUT="${CI_SKIP_ON_TIMEOUT:-true}"
 OUTPUT_FILE="${GITHUB_OUTPUT:-/dev/null}"
+# When set, render a per-check markdown summary here for run_review.sh to fold
+# into the review corpus. The data is already fetched for gating; this just
+# stops it from being discarded so the model can cite real CI outcomes.
+CI_CHECKS_FILE="${CI_CHECKS_FILE:-}"
 
 if [[ "$CI_STATUS_CHECK" != "true" ]]; then
   echo "ci_status_skipped=true" >> "$OUTPUT_FILE"
@@ -59,8 +63,58 @@ get_head_sha() {
   gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.head.sha' 2>/dev/null
 }
 
+# Render the per-check results gathered this iteration into CI_CHECKS_FILE so
+# run_review.sh can surface them as review evidence. Own-workflow check runs are
+# excluded with the same rule used for gating. A no-op when CI_CHECKS_FILE is
+# unset or no external checks exist.
+render_ci_checks() {
+  local final_state="$1"
+  [[ -n "$CI_CHECKS_FILE" ]] || return 0
+  local runs="${check_runs_response:-{}}"
+  local combined="${combined_response:-{}}"
+
+  local rows
+  rows="$(printf '%s' "$runs" | jq -r --arg run "$GITHUB_RUN_ID" '
+    [.check_runs[]?
+      | select(
+          $run == ""
+          or ((((.details_url // "") | test("/runs/" + $run + "(/|$)"))
+               or ((.html_url // "") | test("/runs/" + $run + "(/|$)"))) | not)
+        )] as $ext
+    | $ext[]
+    | "| \(.name // "(unnamed)") | \(.status // "?") | \(.conclusion // "—") |"' 2>/dev/null || echo "")"
+
+  local legacy
+  legacy="$(printf '%s' "$combined" | jq -r '
+    if ((.total_count // 0) > 0) then
+      (.statuses[]? | "| \(.context // "(status)") | \(.state // "?") | \(.description // "") |")
+    else empty end' 2>/dev/null || echo "")"
+
+  # Nothing external to report — leave no file so run_review omits the section.
+  [[ -n "$rows" || -n "$legacy" ]] || return 0
+
+  {
+    echo "_CI reached a terminal state before this review began (overall: ${final_state}). These results are from the GitHub Checks API for commit ${sha} and are authoritative evidence of which checks ran and how they concluded._"
+    echo
+    if [[ -n "$rows" ]]; then
+      echo "| Check | Status | Conclusion |"
+      echo "| --- | --- | --- |"
+      printf '%s\n' "$rows"
+    fi
+    if [[ -n "$legacy" ]]; then
+      echo
+      echo "Legacy commit statuses:"
+      echo
+      echo "| Context | State | Description |"
+      echo "| --- | --- | --- |"
+      printf '%s\n' "$legacy"
+    fi
+  } > "$CI_CHECKS_FILE" 2>/dev/null || true
+}
+
 finalize() {
   local state="$1"
+  render_ci_checks "$state"
   echo "ci_status_final=$state" >> "$OUTPUT_FILE"
   echo "ci_status_skipped=false" >> "$OUTPUT_FILE"
   exit 0
@@ -87,6 +141,7 @@ while true; do
     log "Timeout reached after ${elapsed}s"
     if [[ "$(printf '%s' "$CI_SKIP_ON_TIMEOUT" | tr '[:upper:]' '[:lower:]')" == "true" ]]; then
       log "ci_skip_on_timeout=true — proceeding without CI context"
+      render_ci_checks "timeout (CI did not finish in time)"
       echo "ci_status_skipped=true" >> "$OUTPUT_FILE"
       exit 1   # non-zero so the caller can decide whether to skip or continue
     else

--- a/tests/test_ci_status_check.sh
+++ b/tests/test_ci_status_check.sh
@@ -205,9 +205,13 @@ exit 0
 SHELLEOF
 chmod +x "$CI_TMP/bin/gh"
 
+# Shared with each run_wait call so tests can inspect the rendered CI summary.
+CHECKS_OUT="$CI_TMP/ci-checks.md"
+
 run_wait() {
   local output_file="$CI_TMP/out_$RANDOM$RANDOM"
   local rc=0
+  rm -f "$CHECKS_OUT"
   (
     PATH="$CI_TMP/bin:$PATH" \
     GH_TOKEN=test REPO="test/repo" PR_NUMBER=7 \
@@ -217,6 +221,7 @@ run_wait() {
     CI_TIMEOUT_SEC="${CI_TIMEOUT_SEC_OVERRIDE:-6}" \
     CI_INTERVAL_SEC=1 \
     CI_SKIP_ON_TIMEOUT="${CI_SKIP_ON_TIMEOUT_OVERRIDE:-true}" \
+    CI_CHECKS_FILE="$CHECKS_OUT" \
     GITHUB_OUTPUT="$output_file" \
     bash "$WAIT_SCRIPT" >/dev/null 2>&1
   ) || rc=$?
@@ -236,6 +241,16 @@ echo '{"state": "pending", "total_count": 0}' > "$CI_TMP/combined.json"
 RESULT="$(run_wait)"
 check "exit 0 on checks-only success" "$(echo "$RESULT" | grep '^rc=')" "rc=0"
 check_contains "final state is success" "$RESULT" "ci_status_final=success"
+CHECKS_CONTENT="$(cat "$CHECKS_OUT" 2>/dev/null || true)"
+check_contains "checks summary names the external check" "$CHECKS_CONTENT" "build"
+check_contains "checks summary records its conclusion" "$CHECKS_CONTENT" "success"
+if echo "$CHECKS_CONTENT" | grep -q "ai-review"; then
+  echo "FAIL: own workflow run leaked into the CI checks summary"
+  FAIL=$((FAIL + 1))
+else
+  echo "PASS: own workflow run excluded from CI checks summary"
+  PASS=$((PASS + 1))
+fi
 
 echo ""
 echo "--- Own run is the only check: concludes none instead of hanging ---"
@@ -244,6 +259,13 @@ echo '{"state": "pending", "total_count": 0}' > "$CI_TMP/combined.json"
 RESULT="$(run_wait)"
 check "exit 0 when only own run exists" "$(echo "$RESULT" | grep '^rc=')" "rc=0"
 check_contains "final state is none" "$RESULT" "ci_status_final=none"
+if [ -s "$CHECKS_OUT" ]; then
+  echo "FAIL: CI checks file written when no external checks exist"
+  FAIL=$((FAIL + 1))
+else
+  echo "PASS: no CI checks file when only own run exists"
+  PASS=$((PASS + 1))
+fi
 
 echo ""
 echo "--- External check failure is terminal ---"


### PR DESCRIPTION
## Why

A PR review on [dispatch#341](https://github.com/misospace/dispatch/pull/341) reported "Run Full Test Suite After Upgrade — **Not verifiable from corpus**" because the tool harness tried `npm test`, which is (correctly) not allowlisted. The harness runs same-repo code against untrusted PR input, so model-controlled command execution must stay forbidden.

The right fix isn't to let the reviewer run the suite — it's to let **CI** run the tests (in its own sandbox) and have the reviewer *consume* the results.

## What changed

- **`wait_for_ci.sh`** already fetched per-check detail to compute the gate, then threw it away. It now renders those outcomes (check name / status / conclusion, own-workflow run excluded, plus legacy commit statuses) to a new `CI_CHECKS_FILE` at each terminal state (success / failure / timeout). No extra API calls.
- **`action.yml`** wires `CI_CHECKS_FILE` (under `runner.temp`) into both the wait step (writer) and the review step (reader).
- **`run_review.sh`** folds the file into the review corpus as a **CI Check Results** section, right after Evidence Providers (high-value, ahead of the truncatable tail). Omitted when absent/empty.
- **This repo's `ai-pr-review.yaml`** enables `ci_status_check: "true"` (600s timeout) to dogfood it.
- Docs + tests updated.

The reviewer still never executes the test suite itself.

## Tests

- `tests/test_ci_status_check.sh`: 56/56 (new assertions: summary names the check, records conclusion, excludes the action's own run, writes no file when only own-run exists)
- Full python suite: 652 passed; corpus-survival + action-syntax suites pass.
