### PR TITLE
feat: force_review input to bypass the diff-unchanged guard (#231)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,8 @@ The action collects rich PR context (diff, files, linked issues, version hints, 
 ### Action definition and orchestration
 
 - **`action.yml`** — Action definition with all inputs/outputs and composite run steps (precheck → CI wait → review → publish). The publish steps live inline in this file using helpers from `scripts/publish_helpers.sh`.
-- **`scripts/check_review_needed.sh`** — Precheck: computes `git patch-id --stable` fingerprint, decides full vs. incremental scope, and skips if unchanged since last managed comment
+- **`scripts/check_review_needed.sh`** — Precheck: computes `git patch-id --stable` fingerprint, decides full vs. incremental scope, and skips if unchanged since last managed comment (unless `force_review=true`)
+- **`scripts/parse_review_command.sh`** — Authorization gate for an on-demand re-review command (`/ai-review`): matches the command in a comment and requires the commenter to have `write`/`admin` via the collaborators API before honoring it
 - **`scripts/wait_for_ci.sh`** — Optional CI gating: polls the Checks API until checks reach a terminal state (`ci_status_check=true`), then renders the per-check outcomes to `CI_CHECKS_FILE` for the review corpus
 - **`scripts/run_review.sh`** — Main review orchestration script (collects context, builds corpus, classifies, routes, calls model, validates and enforces verdicts)
 - **`scripts/model_call.sh`** — Shared model-call layer: request building, streaming/SSE handling, retries, error-body preservation for both API formats

--- a/README.md
+++ b/README.md
@@ -328,6 +328,7 @@ Only three inputs are required: `github_token`, `ai_base_url`, and `ai_model`. E
 |-------|-------------|----------|---------|
 | `review_scope` | Controls whether the action reviews the full PR or only changes since the last managed review. Accepted values: `auto` (default, full on first run, incremental on later safe updates), `full` (always full review), `incremental` (delta review, falls back to full if prior metadata unavailable) | No | `auto` |
 | `skip_if_diff_unchanged` | Skip the LLM review when the current PR patch matches the last managed review fingerprint | No | `true` |
+| `force_review` | Bypass the diff-unchanged guard and review even when the fingerprint matches. For an on-demand re-review (e.g. an `/ai-review` comment or `repository_dispatch`) when the diff is unchanged but the model/standards changed | No | `false` |
 | `ci_status_check` | Wait for all CI checks to reach a terminal state before starting the AI review. Default false — immediate review. | No | `false` |
 | `ci_timeout_sec` | Maximum seconds to wait for CI checks to complete when ci_status_check=true. | No | `300` |
 | `ci_interval_sec` | Seconds between CI status polls when ci_status_check=true. | No | `15` |
@@ -442,6 +443,36 @@ The per-check outcomes (name, status, conclusion) are also folded into the revie
 ```
 
 When `ci_skip_on_timeout: true` (the default), the action proceeds with the review after `ci_timeout_sec` even if checks are still running. Set it to `false` to fail the action on timeout instead. The `ci_status_skipped` and `ci_status_final` outputs indicate whether the CI wait completed and what the final state was.
+
+### 🔁 Forcing a re-review
+
+By default an unchanged PR is not re-reviewed — the precheck skips when the diff + config fingerprint matches the last managed review (`skip_if_diff_unchanged`). Set `force_review: "true"` to bypass that guard and review anyway. This is for on-demand re-reviews when the diff is unchanged but something the fingerprint can't see has changed — a model repointed behind a stable alias, updated standards, or a flaky first pass.
+
+A common pattern is an `/ai-review` comment command. Because `issue_comment` workflows run with the base repo's secrets and a write-scoped token, **the command must be authorized against the commenter's repository permission** — `scripts/parse_review_command.sh` does this (matches the command and requires `write`/`admin` via the collaborators API; `author_association` alone is not trusted):
+
+```yaml
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  rereview:
+    if: github.event.issue.pull_request
+    runs-on: ubuntu-latest
+    steps:
+      - name: Authorize re-review command
+        id: cmd
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          COMMENTER_LOGIN: ${{ github.event.comment.user.login }}
+          REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash "$GITHUB_ACTION_PATH/scripts/parse_review_command.sh"
+      # then check out the PR head + run the action with force_review: "true"
+      # only when steps.cmd.outputs.should_review == 'true'
+```
+
+`force_review` is also useful straight from a `workflow_dispatch` input or a `repository_dispatch` payload, neither of which needs the comment-permission gate (both already require a token with write access to fire).
 
 ### 🧾 With evidence providers
 

--- a/action.yml
+++ b/action.yml
@@ -384,6 +384,10 @@ inputs:
     description: If true, skip the LLM review when the effective PR diff matches the last managed review comment fingerprint
     required: false
     default: "true"
+  force_review:
+    description: If true, bypass the diff-unchanged guard and always review, even when the fingerprint matches the last managed comment. Intended for an on-demand "re-review" trigger (e.g. a /ai-review comment or repository_dispatch) when the diff is unchanged but the underlying model/standards changed. Default false.
+    required: false
+    default: "false"
   comment_marker:
     description: HTML marker for the managed PR comment
     required: false
@@ -488,6 +492,7 @@ runs:
         PUBLISH_MODE: ${{ inputs.publish_mode }}
         REVIEW_SCOPE: ${{ inputs.review_scope }}
         SKIP_IF_DIFF_UNCHANGED: ${{ inputs.skip_if_diff_unchanged }}
+        FORCE_REVIEW: ${{ inputs.force_review }}
         ACTION_REF: ${{ github.action_ref }}
         AI_MODEL: ${{ inputs.ai_model }}
         AI_API_FORMAT: ${{ inputs.ai_api_format }}

--- a/scripts/check_review_needed.sh
+++ b/scripts/check_review_needed.sh
@@ -5,6 +5,7 @@ REPO="${REPO:-${GITHUB_REPOSITORY:-}}"
 PR_NUMBER="${PR_NUMBER:-}"
 COMMENT_MARKER="${COMMENT_MARKER:-<!-- ai-pr-reviewer -->}"
 SKIP_IF_DIFF_UNCHANGED="${SKIP_IF_DIFF_UNCHANGED:-true}"
+FORCE_REVIEW="${FORCE_REVIEW:-false}"
 OUTPUT_FILE="${GITHUB_OUTPUT:-/dev/null}"
 REVIEW_SCOPE="${REVIEW_SCOPE:-auto}"
 PUBLISH_MODE="${PUBLISH_MODE:-comment}"
@@ -236,7 +237,15 @@ last_broad_fingerprint="$(printf '%s\n' "$last_comment_body" | sed -n 's/^<!-- a
 should_review=true
 skip_reason=""
 
-if [[ "$SKIP_IF_DIFF_UNCHANGED" == "true" && -n "$last_broad_fingerprint" && "$last_broad_fingerprint" == "$broad_fingerprint" ]]; then
+# force_review wins over the diff-unchanged guard: an on-demand re-review
+# (e.g. a /ai-review comment) must run even when the fingerprint is unchanged,
+# because the reason to re-review is usually something the fingerprint can't
+# see — a model repointed behind a stable alias, updated standards, a flaky
+# first pass. The fingerprint is still computed above so the fresh review
+# re-stamps the comment normally.
+if [[ "$FORCE_REVIEW" == "true" ]]; then
+  echo "force_review=true — bypassing the diff-unchanged guard" >&2
+elif [[ "$SKIP_IF_DIFF_UNCHANGED" == "true" && -n "$last_broad_fingerprint" && "$last_broad_fingerprint" == "$broad_fingerprint" ]]; then
   should_review=false
   skip_reason="diff-unchanged"
 fi

--- a/scripts/parse_review_command.sh
+++ b/scripts/parse_review_command.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ── parse_review_command.sh ─────────────────────────────────────────────
+# Decides whether an on-demand "re-review" command in a PR/issue comment
+# should be honored. This is the authorization gate for a comment-triggered
+# re-review (issue_comment workflows run with base-repo secrets and a
+# write-scoped token — the pull_request_target trust class — so the command
+# MUST be gated on the commenter's actual repository permission).
+#
+# Inputs (env):
+#   COMMENT_BODY          – the triggering comment body
+#   COMMENTER_LOGIN       – github.event.comment.user.login
+#   REPO                  – owner/name
+#   GH_TOKEN / GITHUB_TOKEN
+#   REVIEW_COMMAND        – command token to match (default "/ai-review")
+#   IS_PR_COMMENT         – "true" only for comments on PRs (default "true");
+#                           issue_comment fires for plain issues too.
+#   GITHUB_OUTPUT         – step output sink
+#
+# Outputs (GITHUB_OUTPUT):
+#   should_review=true|false
+#   reason=<no-command|not-a-pr|invalid-login|insufficient-permission|
+#           permission-check-failed|command-authorized>
+#
+# Authorization is intentionally strict: author_association is NOT trusted
+# (CONTRIBUTOR/NONE are external; org members may hold read-only roles).
+# Permission is read from the collaborators API and must be write or admin.
+
+COMMENT_BODY="${COMMENT_BODY:-}"
+COMMENTER_LOGIN="${COMMENTER_LOGIN:-}"
+REPO="${REPO:-${GITHUB_REPOSITORY:-}}"
+GH_TOKEN="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
+export GH_TOKEN
+REVIEW_COMMAND="${REVIEW_COMMAND:-/ai-review}"
+IS_PR_COMMENT="${IS_PR_COMMENT:-true}"
+OUTPUT_FILE="${GITHUB_OUTPUT:-/dev/null}"
+
+emit() {
+  # $1=should_review  $2=reason
+  echo "should_review=$1" >> "$OUTPUT_FILE"
+  echo "reason=$2" >> "$OUTPUT_FILE"
+  echo "[re-review] should_review=$1 reason=$2" >&2
+  exit 0
+}
+
+# 1. Must be a comment on a PR (issue_comment also fires for plain issues).
+if [[ "$IS_PR_COMMENT" != "true" ]]; then
+  emit false "not-a-pr"
+fi
+
+# 2. The command must appear as its own token at the start of a line
+#    (ignoring leading whitespace), so it isn't matched inside prose or a
+#    quoted backlog of someone else's comment.
+command_present=false
+while IFS= read -r line; do
+  trimmed="${line#"${line%%[![:space:]]*}"}"   # strip leading whitespace
+  if [[ "$trimmed" == "$REVIEW_COMMAND" || "$trimmed" == "$REVIEW_COMMAND "* ]]; then
+    command_present=true
+    break
+  fi
+done <<< "$COMMENT_BODY"
+
+if [[ "$command_present" != "true" ]]; then
+  emit false "no-command"
+fi
+
+# 3. Validate the login shape before interpolating it into an API path.
+if [[ ! "$COMMENTER_LOGIN" =~ ^[A-Za-z0-9](-?[A-Za-z0-9])*$ ]]; then
+  emit false "invalid-login"
+fi
+
+# 4. Authorize against real repository permission. rc-check the call: gh
+#    prints error bodies to stdout on failure, so `$(... || echo "")` would
+#    capture JSON garbage — assign only when gh exits zero.
+permission=""
+if out="$(gh api "repos/${REPO}/collaborators/${COMMENTER_LOGIN}/permission" --jq '.permission' 2>/dev/null)"; then
+  permission="$out"
+else
+  emit false "permission-check-failed"
+fi
+
+case "$permission" in
+  admin|write) emit true "command-authorized" ;;
+  *)           emit false "insufficient-permission" ;;
+esac

--- a/tests/test_check_review_needed.sh
+++ b/tests/test_check_review_needed.sh
@@ -120,6 +120,7 @@ run_precheck() {
     TOOL_MIN_SUCCESSFUL_REQUESTS="${TOOL_MIN_SUCCESSFUL_REQUESTS:-0}" \
     TOOL_ENABLE_FOR_FORKS="${TOOL_ENABLE_FOR_FORKS:-false}" \
     SKIP_IF_DIFF_UNCHANGED="${SKIP_IF_DIFF_UNCHANGED:-true}" \
+    FORCE_REVIEW="${FORCE_REVIEW:-false}" \
     COMMENT_MARKER="${COMMENT_MARKER:-<!-- ai-pr-reviewer -->}" \
     PUBLISH_MODE="${PUBLISH_MODE:-comment}" \
     bash "$PRECHECK_SCRIPT"
@@ -214,6 +215,26 @@ echo ""
 echo "=== Test 6: SKIP_IF_DIFF_UNCHANGED=false → always review ==="
 ACTION_REF="v1.0.0" AI_MODEL="gpt-4" AI_API_FORMAT="openai" CONTEXT_LIMIT_MODE="normal" TOOL_MODE="off" SKIP_IF_DIFF_UNCHANGED=false RESULT="$(run_precheck)"
 check "should_review=true when skip disabled" "$(echo "$RESULT" | grep '^should_review=' | head -1 | cut -d= -f2)" "true"
+
+# ── Test 6b: force_review=true overrides the matching fingerprint ─────
+echo ""
+echo "=== Test 6b: FORCE_REVIEW=true reviews even when fingerprint matches ==="
+# Self-contained: compute a fresh fingerprint under the current env (earlier
+# tests leak config vars via bash assignment-only-command persistence), pin
+# the guard on, and clean FORCE_REVIEW up afterwards so later tests are unaffected.
+SKIP_IF_DIFF_UNCHANGED=true
+unset FORCE_REVIEW 2>/dev/null || true
+set_empty_comments
+FP6B="$(run_precheck | grep '^diff_fingerprint=' | head -1 | cut -d= -f2)"
+set_comments "<!-- ai-pr-reviewer -->
+<!-- ai-pr-review-fingerprint:${FP6B} -->
+APPROVE"
+RESULT="$(run_precheck)"
+check "should_review=false without force (matching fingerprint)" "$(echo "$RESULT" | grep '^should_review=' | head -1 | cut -d= -f2)" "false"
+FORCE_REVIEW=true
+RESULT="$(run_precheck)"
+check "should_review=true when force_review bypasses the guard" "$(echo "$RESULT" | grep '^should_review=' | head -1 | cut -d= -f2)" "true"
+unset FORCE_REVIEW
 
 # ── Test 7: Fingerprint format includes both diff and config parts ───
 echo ""

--- a/tests/test_parse_review_command.sh
+++ b/tests/test_parse_review_command.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Tests for scripts/parse_review_command.sh — the authorization gate for a
+# comment-triggered re-review.
+
+if [ -z "${BASH_VERSINFO:-}" ] || [ "${BASH_VERSINFO[0]}" -lt 4 ]; then
+  echo "SKIP: bash >= 4 required (found ${BASH_VERSION:-unknown}); on macOS run with PATH=\"/opt/homebrew/bin:\$PATH\"" >&2
+  exit 0
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+HELPER="$ROOT_DIR/scripts/parse_review_command.sh"
+
+PASS=0
+FAIL=0
+check() {
+  local desc="$1" result="$2" expected="$3"
+  if [[ "$result" == "$expected" ]]; then
+    echo "  PASS: $desc"; PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc (got '$result', expected '$expected')"; FAIL=$((FAIL + 1))
+  fi
+}
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+mkdir -p "$TMP/bin"
+
+# Mock gh: derive permission from the login in the API path. The "ghost404"
+# login mimics gh's real failure mode — it writes a JSON error body to STDOUT
+# and exits non-zero, so we verify the helper rc-checks rather than capturing
+# that body as a "permission".
+cat > "$TMP/bin/gh" <<'SHELLEOF'
+#!/usr/bin/env bash
+args="$*"
+case "$args" in
+  *collaborators/adminuser/permission*) echo "admin"; exit 0 ;;
+  *collaborators/writeuser/permission*) echo "write"; exit 0 ;;
+  *collaborators/readuser/permission*)  echo "read";  exit 0 ;;
+  *collaborators/ghost404/permission*)  echo '{"message":"Not Found","status":"404"}'; exit 1 ;;
+esac
+echo '{"message":"unexpected mock call"}'; exit 1
+SHELLEOF
+chmod +x "$TMP/bin/gh"
+
+# $1=body $2=login $3=is_pr -> echoes "should_review|reason"
+run_helper() {
+  local out="$TMP/out_$RANDOM$RANDOM"
+  (
+    PATH="$TMP/bin:$PATH" \
+    REPO="test/repo" GH_TOKEN="x" \
+    COMMENT_BODY="$1" COMMENTER_LOGIN="$2" IS_PR_COMMENT="${3:-true}" \
+    REVIEW_COMMAND="${REVIEW_COMMAND:-/ai-review}" \
+    GITHUB_OUTPUT="$out" \
+    bash "$HELPER" >/dev/null 2>&1
+  )
+  local sr rs
+  sr="$(grep '^should_review=' "$out" | head -1 | cut -d= -f2)"
+  rs="$(grep '^reason=' "$out" | head -1 | cut -d= -f2)"
+  echo "${sr}|${rs}"
+}
+
+echo "=== parse_review_command.sh ==="
+
+check "write-access user with command is authorized" \
+  "$(run_helper "/ai-review please" writeuser)" "true|command-authorized"
+
+check "admin user is authorized" \
+  "$(run_helper "/ai-review" adminuser)" "true|command-authorized"
+
+check "read-only user is rejected" \
+  "$(run_helper "/ai-review" readuser)" "false|insufficient-permission"
+
+check "non-collaborator (gh 404 to stdout) is rejected, not mis-parsed" \
+  "$(run_helper "/ai-review" ghost404)" "false|permission-check-failed"
+
+check "no command in body is a silent no-op" \
+  "$(run_helper "looks good to me, /ai-reviews are great" writeuser)" "false|no-command"
+
+check "command only mid-line (in prose) does not match" \
+  "$(run_helper "I think we should run /ai-review later" adminuser)" "false|no-command"
+
+check "command indented on its own line still matches" \
+  "$(run_helper "  /ai-review" writeuser)" "true|command-authorized"
+
+check "comment on a plain issue (not a PR) is ignored" \
+  "$(run_helper "/ai-review" adminuser false)" "false|not-a-pr"
+
+check "malformed login is rejected before any API call" \
+  "$(run_helper "/ai-review" "bad login;rm -rf")" "false|invalid-login"
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+[[ "$FAIL" -gt 0 ]] && exit 1 || exit 0


### PR DESCRIPTION
Implements the foundation of #231 — an on-demand "re-review" override for the diff-unchanged guard.

## Why

The precheck skips a review when the diff + config fingerprint matches the last managed comment. That's right almost always, but there's no way to force a fresh review of an *unchanged* PR — and the reason to re-review is often something the fingerprint can't see: a model repointed behind a stable LiteLLM alias, updated standards, or a flaky first pass. Today the only workarounds are a dummy commit or flipping `skip_if_diff_unchanged` fleet-wide.

## What's in this PR (the decision-light foundation)

- **`force_review` input** ([action.yml](action.yml)) → wired into the precheck; [check_review_needed.sh](scripts/check_review_needed.sh) bypasses the diff-unchanged skip when `true`. The fingerprint is still computed, so the fresh review re-stamps the comment normally.
- **`scripts/parse_review_command.sh`** — a reusable, tested **authorization gate** for a comment-triggered re-review. It matches an `/ai-review` command and requires the commenter to hold `write`/`admin` via the collaborators API.
  - `issue_comment` workflows run with the base repo's secrets and a write-scoped token (the `pull_request_target` trust class), so **`author_association` alone is not trusted** — `CONTRIBUTOR`/`NONE` are external and org members can have read-only roles.
  - rc-checks the `gh api` call so an error body printed to stdout on failure can't be mis-parsed as a permission.
  - Command must be its own token at line start (not matched inside prose); login is shape-validated before interpolation.
- README "Forcing a re-review" section (with the security note + an example gated `issue_comment` workflow) and AGENTS.md script inventory.

## What's deliberately NOT here

The per-repo `issue_comment` trigger wiring (7 deployment workflows) is a follow-up — it needs the trigger-shape decision and is the security-sensitive surface. `force_review` is usable today via `workflow_dispatch`/`repository_dispatch`, neither of which needs the comment gate.

## Tests

- [tests/test_check_review_needed.sh](tests/test_check_review_needed.sh): 25/25 — new case asserts force bypasses a matching fingerprint.
- [tests/test_parse_review_command.sh](tests/test_parse_review_command.sh): 9/9 — write/admin authorized; read/non-collaborator/404-to-stdout/plain-issue/prose-only/malformed-login all rejected.
- Full python suite: 652 passed.
