### PR TITLE
feat: Forgejo REST backend for core PR I/O

### DIFF
--- a/pr_reviewer/forgejo_backend.py
+++ b/pr_reviewer/forgejo_backend.py
@@ -60,20 +60,24 @@ def _curl(
 ) -> tuple[int, str]:
     """Execute a curl request and return (http_status_code, body_text).
 
-    Uses ``-w '%{http_code}'`` to capture the actual HTTP status code.
+    Uses ``-w '\\n%{http_code}'`` to capture the actual HTTP status code.
     On HTTP errors the response body is written to stdout so callers can
     parse error payloads — this is the *error-body-on-stdout* discipline.
     """
     if token is None:
         token = FORGEJO_TOKEN or GH_TOKEN
 
+    # The status code is appended after an explicit newline separator: bodies
+    # are not guaranteed to end with whitespace (an empty 204 body, or compact
+    # JSON without a trailing newline, would otherwise fuse with the code and
+    # make it unparseable).
     cmd: list[str] = [
         "curl", "-sS",
         "-X", method.upper(),
         "-H", f"Authorization: token {token}",
         "-H", f"Accept: {accept}",
         "-o", "-",
-        "-w", "%{http_code}",
+        "-w", "\n%{http_code}",
         url,
     ]
     if data is not None and method.upper() in ("POST", "PATCH", "PUT"):
@@ -89,11 +93,11 @@ def _curl(
 
     raw = proc.stdout.decode("utf-8", errors="replace")
 
-    # The last token from -w is the HTTP status code.
-    parts = raw.rsplit(None, 1)
-    if len(parts) == 2 and parts[-1].isdigit():
-        http_code = int(parts[-1])
-        body_text = parts[0].rstrip()
+    # Everything after the last newline is the HTTP status code we appended
+    # with -w; everything before it is the body (possibly empty).
+    body_text, sep, code_text = raw.rpartition("\n")
+    if sep and code_text.strip().isdigit():
+        http_code = int(code_text.strip())
     else:
         # No status code — curl failed entirely (network error).
         http_code = proc.returncode if proc.returncode != 0 else 500
@@ -150,11 +154,13 @@ def get_pr_metadata(repo_full_name: str, pr_number: int) -> dict[str, Any] | Non
             return None
         return _forgejo_pr_to_github(data, owner, repo, pr_number)
 
-    # GitHub via gh CLI
+    # GitHub via gh CLI. The REST pulls endpoint already returns the exact
+    # shape this module normalises Forgejo into (snake_case, user/head/base
+    # objects), so no field mapping is needed. ``gh pr view --json`` is NOT
+    # equivalent — its fields are camelCase (author/headRefOid/mergedAt) and
+    # it has no user/head/base keys at all.
     status_code, body = _gh(
-        "pr", "view", str(pr_number),
-        "--repo", repo_full_name,
-        "--json", "number,title,body,state,user,head,base,merged_at,created_at,updated_at,url,draft,labels",
+        "api", f"repos/{owner}/{repo}/pulls/{pr_number}",
     )
     if status_code != 0 or not body.strip():
         return None
@@ -162,31 +168,44 @@ def get_pr_metadata(repo_full_name: str, pr_number: int) -> dict[str, Any] | Non
 
 
 def _forgejo_pr_to_github(data: dict, owner: str, repo: str, pr_number: int = 0) -> dict[str, Any]:
-    """Normalise a Forgejo PR response to the GitHub shape used by callers."""
-    head = data.get("head", {})
-    base = data.get("base", {})
+    """Normalise a Forgejo PR response to the GitHub shape used by callers.
+
+    Field names verified against a live Forgejo instance (Codeberg
+    ``/api/v1``): the PR object uses ``number``/``state``/``draft``, and
+    ``head``/``base`` are ``{label, ref, repo, repo_id, sha}`` where
+    ``repo.full_name`` carries the repository identity. ``head.repo`` is the
+    *fork* repo on fork PRs — it must never be defaulted to the base repo,
+    or fork detection (and the fork gating built on it) fails open.
+    """
+    head = data.get("head") or {}
+    base = data.get("base") or {}
+
+    def _branch_repo_full_name(branch: dict) -> str:
+        # Missing repo (e.g. deleted fork) yields "" so is_fork_pr can treat
+        # the origin as unknown rather than silently same-repo.
+        return ((branch.get("repo") or {}).get("full_name")) or ""
 
     return {
-        "number": data.get("index", data.get("number", pr_number)),
+        "number": data.get("number", pr_number),
         "title": data.get("title", ""),
         "body": data.get("body", ""),
-        "state": data.get("status", data.get("state", "open")),
-        "user": {"login": data.get("user", {}).get("login", "")},
+        "state": data.get("state", "open"),
+        "user": {"login": (data.get("user") or {}).get("login", "")},
         "head": {
-            "sha": head.get("sha", head.get("hash", "")),
+            "sha": head.get("sha", ""),
             "ref": head.get("ref", ""),
-            "repo": {"full_name": f"{head.get('owner', {}).get('login', owner)}/{head.get('name', repo)}"},
+            "repo": {"full_name": _branch_repo_full_name(head)},
         },
         "base": {
-            "sha": base.get("sha", base.get("hash", "")),
+            "sha": base.get("sha", ""),
             "ref": base.get("ref", ""),
-            "repo": {"full_name": f"{base.get('owner', {}).get('login', owner)}/{base.get('name', repo)}"},
+            "repo": {"full_name": _branch_repo_full_name(base) or f"{owner}/{repo}"},
         },
         "merged_at": data.get("merged_at", None),
-        "created_at": data.get("created_at", data.get("created_on", "")),
-        "updated_at": data.get("updated_at", data.get("updated_on", "")),
-        "url": data.get("html_url", f"https://{FORGEJO_API_URL.replace('http://', '').replace('https://', '')}/{owner}/{repo}/pulls/{data.get('index', pr_number)}"),
-        "draft": data.get("is_private", False) or data.get("is_draft", False),
+        "created_at": data.get("created_at", ""),
+        "updated_at": data.get("updated_at", ""),
+        "url": data.get("html_url", f"https://{FORGEJO_API_URL.replace('http://', '').replace('https://', '')}/{owner}/{repo}/pulls/{data.get('number', pr_number)}"),
+        "draft": bool(data.get("draft", False)),
         "labels": [{"name": l.get("name", "")} for l in data.get("labels", [])],
     }
 
@@ -305,17 +324,19 @@ def create_comment(
             "body": data.get("body", body),
         }
 
-    # GitHub via gh CLI
+    # GitHub via gh CLI. Plain creation — ``--create-if-none`` is only valid
+    # together with ``--edit-last`` and is a flag-parse error on its own.
     status_code, body_text = _gh(
         "pr", "comment", str(issue_number),
         "--repo", repo_full_name,
-        "--create-if-none",
         "--body", body,
     )
     if status_code != 0 or not body_text.strip():
         return None
 
-    url_match = re.search(r"https?://[^\s]+/pull/[0-9]+/#issuecomment-[0-9]+", body_text)
+    # gh prints the comment URL as .../pull/N#issuecomment-ID (no slash
+    # before the fragment).
+    url_match = re.search(r"https?://\S+/pull/[0-9]+#issuecomment-[0-9]+", body_text)
     comment_id_match = re.search(r"#issuecomment-([0-9]+)", body_text or "")
     return {
         "id": int(comment_id_match.group(1)) if comment_id_match else 0,
@@ -380,7 +401,7 @@ def edit_last_comment(
         # --edit-last fails when no comment exists; fall back to create
         return create_comment(repo_full_name, issue_number, new_body)
 
-    url_match = re.search(r"https?://[^\s]+/pull/[0-9]+/#issuecomment-[0-9]+", body_text)
+    url_match = re.search(r"https?://\S+/pull/[0-9]+#issuecomment-[0-9]+", body_text)
     comment_id_match = re.search(r"#issuecomment-([0-9]+)", body_text or "")
     return {
         "id": int(comment_id_match.group(1)) if comment_id_match else 0,
@@ -413,9 +434,9 @@ def fetch_issue(repo_full_name: str, issue_number: int) -> dict[str, Any] | None
         return {
             "body": data.get("body", ""),
             "title": data.get("title", ""),
-            "state": data.get("status", data.get("state", "open")),
-            "created_at": data.get("created_at", data.get("created_on", "")),
-            "updated_at": data.get("updated_at", data.get("updated_on", "")),
+            "state": data.get("state", "open"),
+            "created_at": data.get("created_at", ""),
+            "updated_at": data.get("updated_at", ""),
         }
 
     # GitHub via gh CLI
@@ -493,19 +514,22 @@ def list_pr_files(repo_full_name: str, pr_number: int) -> list[dict[str, Any]]:
 # ---------------------------------------------------------------------------
 
 def is_fork_pr(repo_full_name: str, pr_number: int) -> bool:
-    """Return True if the PR originates from a fork."""
+    """Return True if the PR originates from a fork.
+
+    Both backends yield the same normalised shape, so a single comparison
+    serves both. A missing head repo (GitHub returns ``head.repo: null``
+    when a fork was deleted; Forgejo normalisation yields ``""``) is treated
+    as a fork — an unknown origin must fail closed because fork gating
+    (tool harness / evidence providers) keys off this answer.
+    """
     metadata = get_pr_metadata(repo_full_name, pr_number)
     if metadata is None:
         return False
 
-    head_repo = (metadata.get("head") or {}).get("repo", {})
-    base_repo = (metadata.get("base") or {}).get("repo", {})
-    head_full = head_repo.get("full_name", "")
-    base_full = base_repo.get("full_name", "")
-
-    if _is_forgejo_mode():
-        return head_full != base_full and head_full != ""
-
+    head_full = ((metadata.get("head") or {}).get("repo") or {}).get("full_name") or ""
+    base_full = ((metadata.get("base") or {}).get("repo") or {}).get("full_name") or ""
+    if not head_full:
+        return True
     return head_full != base_full
 
 

--- a/pr_reviewer/forgejo_backend.py
+++ b/pr_reviewer/forgejo_backend.py
@@ -1,0 +1,579 @@
+"""Forgejo REST backend for core PR I/O operations.
+
+Provides a unified interface for PR metadata, diff retrieval, comment management,
+issue fetching, and PR file listing — working with both GitHub (via ``gh`` CLI)
+and Forgejo (via curl to ``/api/v1``).
+
+Usage::
+
+    from pr_reviewer.forgejo_backend import (
+        get_pr_metadata,
+        get_pr_diff,
+        list_comments,
+        create_comment,
+        edit_last_comment,
+        fetch_issue,
+        list_pr_files,
+    )
+
+    # Defaults to GitHub mode. Set FORGEJO_API_URL to switch to Forgejo.
+    metadata = get_pr_metadata("misospace/pr-reviewer-action", 42)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from typing import Any
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+FORGEJO_API_URL = os.environ.get("FORGEJO_API_URL", "").rstrip("/")
+FORGEJO_TOKEN = os.environ.get("FORGEJO_TOKEN", os.environ.get("GITHUB_TOKEN", ""))
+COMMENT_MARKER = os.environ.get(
+    "COMMENT_MARKER", "<!-- ai-pr-reviewer -->"
+)
+GH_TOKEN = os.environ.get("GH_TOKEN", os.environ.get("GITHUB_TOKEN", ""))
+
+
+def _is_forgejo_mode() -> bool:
+    """Return True when FORGEJO_API_URL is set and non-empty."""
+    return bool(FORGEJO_API_URL)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _curl(
+    method: str,
+    url: str,
+    token: str | None = None,
+    data: dict[str, Any] | bytes | None = None,
+    accept: str = "application/json",
+) -> tuple[int, str]:
+    """Execute a curl request and return (http_status_code, body_text).
+
+    Uses ``-w '%{http_code}'`` to capture the actual HTTP status code.
+    On HTTP errors the response body is written to stdout so callers can
+    parse error payloads — this is the *error-body-on-stdout* discipline.
+    """
+    if token is None:
+        token = FORGEJO_TOKEN or GH_TOKEN
+
+    cmd: list[str] = [
+        "curl", "-sS",
+        "-X", method.upper(),
+        "-H", f"Authorization: token {token}",
+        "-H", f"Accept: {accept}",
+        "-o", "-",
+        "-w", "%{http_code}",
+        url,
+    ]
+    if data is not None and method.upper() in ("POST", "PATCH", "PUT"):
+        if isinstance(data, bytes):
+            cmd.extend(["--data-binary", "@-"])
+            proc = subprocess.run(cmd, input=data, capture_output=True)
+        else:
+            body_json = json.dumps(data).encode("utf-8")
+            cmd.extend(["-H", "Content-Type: application/json"])
+            proc = subprocess.run(cmd, input=body_json, capture_output=True)
+    else:
+        proc = subprocess.run(cmd, capture_output=True)
+
+    raw = proc.stdout.decode("utf-8", errors="replace")
+
+    # The last token from -w is the HTTP status code.
+    parts = raw.rsplit(None, 1)
+    if len(parts) == 2 and parts[-1].isdigit():
+        http_code = int(parts[-1])
+        body_text = parts[0].rstrip()
+    else:
+        # No status code — curl failed entirely (network error).
+        http_code = proc.returncode if proc.returncode != 0 else 500
+        body_text = raw
+
+    return http_code, body_text
+
+
+def _gh(*args: str) -> tuple[int, str]:
+    """Execute a ``gh`` CLI command and return (returncode, stdout)."""
+    cmd = ["gh"] + list(args)
+    proc = subprocess.run(cmd, capture_output=True)
+    return proc.returncode, proc.stdout.decode("utf-8", errors="replace")
+
+
+def _parse_repo(repo_full_name: str) -> tuple[str, str]:
+    """Split ``owner/repo`` into (owner, repo)."""
+    parts = repo_full_name.split("/", 1)
+    if len(parts) != 2:
+        raise ValueError(f"Invalid repo full name: {repo_full_name}")
+    return parts[0], parts[1]
+
+
+def _json_decode(text: str) -> Any:
+    """Decode JSON, returning None on failure."""
+    if not text.strip():
+        return None
+    try:
+        return json.loads(text)
+    except (json.JSONDecodeError, ValueError):
+        return None
+
+
+# ---------------------------------------------------------------------------
+# PR Metadata
+# ---------------------------------------------------------------------------
+
+def get_pr_metadata(repo_full_name: str, pr_number: int) -> dict[str, Any] | None:
+    """Return PR metadata as a dict.
+
+    Returns ``None`` if the PR cannot be fetched.
+    """
+    owner, repo = _parse_repo(repo_full_name)
+
+    if _is_forgejo_mode():
+        status_code, body = _curl(
+            "GET",
+            f"{FORGEJO_API_URL}/api/v1/repos/{owner}/{repo}/pulls/{pr_number}",
+        )
+        if status_code != 200:
+            return None
+        data = _json_decode(body)
+        if data is None:
+            return None
+        return _forgejo_pr_to_github(data, owner, repo, pr_number)
+
+    # GitHub via gh CLI
+    status_code, body = _gh(
+        "pr", "view", str(pr_number),
+        "--repo", repo_full_name,
+        "--json", "number,title,body,state,user,head,base,merged_at,created_at,updated_at,url,draft,labels",
+    )
+    if status_code != 0 or not body.strip():
+        return None
+    return _json_decode(body)
+
+
+def _forgejo_pr_to_github(data: dict, owner: str, repo: str, pr_number: int = 0) -> dict[str, Any]:
+    """Normalise a Forgejo PR response to the GitHub shape used by callers."""
+    head = data.get("head", {})
+    base = data.get("base", {})
+
+    return {
+        "number": data.get("index", data.get("number", pr_number)),
+        "title": data.get("title", ""),
+        "body": data.get("body", ""),
+        "state": data.get("status", data.get("state", "open")),
+        "user": {"login": data.get("user", {}).get("login", "")},
+        "head": {
+            "sha": head.get("sha", head.get("hash", "")),
+            "ref": head.get("ref", ""),
+            "repo": {"full_name": f"{head.get('owner', {}).get('login', owner)}/{head.get('name', repo)}"},
+        },
+        "base": {
+            "sha": base.get("sha", base.get("hash", "")),
+            "ref": base.get("ref", ""),
+            "repo": {"full_name": f"{base.get('owner', {}).get('login', owner)}/{base.get('name', repo)}"},
+        },
+        "merged_at": data.get("merged_at", None),
+        "created_at": data.get("created_at", data.get("created_on", "")),
+        "updated_at": data.get("updated_at", data.get("updated_on", "")),
+        "url": data.get("html_url", f"https://{FORGEJO_API_URL.replace('http://', '').replace('https://', '')}/{owner}/{repo}/pulls/{data.get('index', pr_number)}"),
+        "draft": data.get("is_private", False) or data.get("is_draft", False),
+        "labels": [{"name": l.get("name", "")} for l in data.get("labels", [])],
+    }
+
+
+# ---------------------------------------------------------------------------
+# PR Diff
+# ---------------------------------------------------------------------------
+
+def get_pr_diff(repo_full_name: str, pr_number: int) -> str:
+    """Return the raw unified diff for a PR.
+
+    Returns an empty string on failure.
+    """
+    if _is_forgejo_mode():
+        status_code, body = _curl(
+            "GET",
+            f"{FORGEJO_API_URL}/api/v1/repos/{_parse_repo(repo_full_name)[0]}/{_parse_repo(repo_full_name)[1]}/pulls/{pr_number}.diff",
+        )
+        if status_code != 200:
+            return ""
+        return body
+
+    # GitHub via gh CLI
+    status_code, body = _gh("pr", "diff", str(pr_number), "--repo", repo_full_name)
+    if status_code != 0:
+        return ""
+    return body
+
+
+# ---------------------------------------------------------------------------
+# Issue Comments (list / create / edit)
+# ---------------------------------------------------------------------------
+
+def list_comments(repo_full_name: str, issue_number: int) -> list[dict[str, Any]]:
+    """List all comments on a PR or issue.
+
+    Returns a list of dicts with keys: ``id``, ``body``, ``created_at``, ``updated_at``, ``user``.
+    """
+    owner, repo = _parse_repo(repo_full_name)
+
+    if _is_forgejo_mode():
+        # Forgejo API returns comments; paginate via page param (max 50 per page).
+        all_comments: list[dict] = []
+        page = 1
+        while True:
+            status_code, body = _curl(
+                "GET",
+                f"{FORGEJO_API_URL}/api/v1/repos/{owner}/{repo}/issues/{issue_number}/comments?page={page}&limit=50",
+            )
+            if status_code != 200:
+                break
+            comments = _json_decode(body)
+            if not isinstance(comments, list) or not comments:
+                break
+            all_comments.extend(comments)
+            if len(comments) < 50:
+                break
+            page += 1
+
+        return [_forgejo_comment_to_standard(c, owner, repo) for c in all_comments]
+
+    # GitHub via gh CLI
+    status_code, body = _gh(
+        "api", f"repos/{owner}/{repo}/issues/{issue_number}/comments",
+        "--paginate",
+        "--jq", ".[] | {id: .id, body: .body, created_at: .created_at, updated_at: .updated_at, user: .user.login}",
+    )
+    if status_code != 0 or not body.strip():
+        return []
+
+    results = []
+    for line in body.strip().split("\n"):
+        parsed = _json_decode(line)
+        if parsed:
+            results.append(parsed)
+    return results
+
+
+def _forgejo_comment_to_standard(comment: dict, owner: str, repo: str) -> dict[str, Any]:
+    """Normalise a Forgejo comment to the standard shape."""
+    user = comment.get("user", {})
+    return {
+        "id": comment.get("id", 0),
+        "body": comment.get("body", ""),
+        "created_at": comment.get("created_at", comment.get("created_on", "")),
+        "updated_at": comment.get("updated_at", comment.get("updated_on", "")),
+        "user": user.get("login", ""),
+    }
+
+
+def create_comment(
+    repo_full_name: str,
+    issue_number: int,
+    body: str,
+) -> dict[str, Any] | None:
+    """Create a new comment on a PR or issue.
+
+    Returns the created comment dict (with ``id`` and ``html_url``), or ``None`` on failure.
+    """
+    owner, repo = _parse_repo(repo_full_name)
+
+    if _is_forgejo_mode():
+        status_code, body_text = _curl(
+            "POST",
+            f"{FORGEJO_API_URL}/api/v1/repos/{owner}/{repo}/issues/{issue_number}/comments",
+            data={"body": body},
+        )
+        if status_code != 201:
+            return None
+        data = _json_decode(body_text)
+        if data is None:
+            return None
+        return {
+            "id": data.get("id", 0),
+            "html_url": data.get("html_url", ""),
+            "body": data.get("body", body),
+        }
+
+    # GitHub via gh CLI
+    status_code, body_text = _gh(
+        "pr", "comment", str(issue_number),
+        "--repo", repo_full_name,
+        "--create-if-none",
+        "--body", body,
+    )
+    if status_code != 0 or not body_text.strip():
+        return None
+
+    url_match = re.search(r"https?://[^\s]+/pull/[0-9]+/#issuecomment-[0-9]+", body_text)
+    comment_id_match = re.search(r"#issuecomment-([0-9]+)", body_text or "")
+    return {
+        "id": int(comment_id_match.group(1)) if comment_id_match else 0,
+        "html_url": url_match.group(0) if url_match else "",
+        "body": body,
+    }
+
+
+def edit_last_comment(
+    repo_full_name: str,
+    issue_number: int,
+    new_body: str,
+    marker: str = COMMENT_MARKER,
+) -> dict[str, Any] | None:
+    """Edit the last comment containing *marker*, or create a new one.
+
+    This implements the "sticky comment" pattern used by the review action:
+    if a comment with the marker exists, edit it in place; otherwise create
+    a new comment.
+
+    Returns the comment dict with ``id`` and ``html_url``, or ``None`` on failure.
+    """
+    owner, repo = _parse_repo(repo_full_name)
+
+    if _is_forgejo_mode():
+        # List comments and find the latest one containing the marker
+        comments = list_comments(repo_full_name, issue_number)
+        matching = [c for c in comments if marker in (c.get("body") or "")]
+
+        if matching:
+            # Sort by updated_at descending to get the latest
+            matching.sort(key=lambda c: c.get("updated_at", ""), reverse=True)
+            target = matching[0]
+
+            status_code, body_text = _curl(
+                "PATCH",
+                f"{FORGEJO_API_URL}/api/v1/repos/{owner}/{repo}/issues/comments/{target['id']}",
+                data={"body": new_body},
+            )
+            if status_code != 200:
+                return None
+            data = _json_decode(body_text)
+            if data is None:
+                return None
+            return {
+                "id": target["id"],
+                "html_url": data.get("html_url", ""),
+                "body": new_body,
+            }
+
+        # No matching comment — create a new one
+        return create_comment(repo_full_name, issue_number, new_body)
+
+    # GitHub via gh CLI
+    status_code, body_text = _gh(
+        "pr", "comment", str(issue_number),
+        "--repo", repo_full_name,
+        "--edit-last",
+        "--body", new_body,
+    )
+    if status_code != 0:
+        # --edit-last fails when no comment exists; fall back to create
+        return create_comment(repo_full_name, issue_number, new_body)
+
+    url_match = re.search(r"https?://[^\s]+/pull/[0-9]+/#issuecomment-[0-9]+", body_text)
+    comment_id_match = re.search(r"#issuecomment-([0-9]+)", body_text or "")
+    return {
+        "id": int(comment_id_match.group(1)) if comment_id_match else 0,
+        "html_url": url_match.group(0) if url_match else "",
+        "body": new_body,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Issue Fetch (for linked issues)
+# ---------------------------------------------------------------------------
+
+def fetch_issue(repo_full_name: str, issue_number: int) -> dict[str, Any] | None:
+    """Fetch an issue's body and metadata.
+
+    Returns ``None`` on failure.
+    """
+    owner, repo = _parse_repo(repo_full_name)
+
+    if _is_forgejo_mode():
+        status_code, body_text = _curl(
+            "GET",
+            f"{FORGEJO_API_URL}/api/v1/repos/{owner}/{repo}/issues/{issue_number}",
+        )
+        if status_code != 200:
+            return None
+        data = _json_decode(body_text)
+        if data is None:
+            return None
+        return {
+            "body": data.get("body", ""),
+            "title": data.get("title", ""),
+            "state": data.get("status", data.get("state", "open")),
+            "created_at": data.get("created_at", data.get("created_on", "")),
+            "updated_at": data.get("updated_at", data.get("updated_on", "")),
+        }
+
+    # GitHub via gh CLI
+    status_code, body_text = _gh(
+        "api", f"repos/{owner}/{repo}/issues/{issue_number}",
+    )
+    if status_code != 0:
+        return None
+    data = _json_decode(body_text)
+    if data is None:
+        return None
+    return {
+        "body": data.get("body", ""),
+        "title": data.get("title", ""),
+        "state": data.get("state", "open"),
+        "created_at": data.get("created_at", ""),
+        "updated_at": data.get("updated_at", ""),
+    }
+
+
+# ---------------------------------------------------------------------------
+# PR Files (for classifier)
+# ---------------------------------------------------------------------------
+
+def list_pr_files(repo_full_name: str, pr_number: int) -> list[dict[str, Any]]:
+    """Return the list of changed files in a PR.
+
+    Each dict has at least ``filename``, ``status``, ``additions``, ``deletions``.
+    """
+    owner, repo = _parse_repo(repo_full_name)
+
+    if _is_forgejo_mode():
+        status_code, body_text = _curl(
+            "GET",
+            f"{FORGEJO_API_URL}/api/v1/repos/{owner}/{repo}/pulls/{pr_number}/files",
+        )
+        if status_code != 200:
+            return []
+        data = _json_decode(body_text)
+        if not isinstance(data, list):
+            return []
+
+        return [
+            {
+                "filename": f.get("filename", f.get("path", "")),
+                "status": f.get("status", "changed"),
+                "additions": f.get("additions", 0),
+                "deletions": f.get("deletions", 0),
+                "changes": f.get("changes", 0),
+                "patch": f.get("patch", ""),
+                "previous_filename": f.get("previous_filename", None),
+            }
+            for f in data
+        ]
+
+    # GitHub via gh CLI
+    status_code, body_text = _gh(
+        "api", f"repos/{owner}/{repo}/pulls/{pr_number}/files",
+        "--paginate",
+        "--jq", ".[] | {filename: .filename, status: .status, additions: .additions, deletions: .deletions, changes: .changes}",
+    )
+    if status_code != 0 or not body_text.strip():
+        return []
+
+    results = []
+    for line in body_text.strip().split("\n"):
+        parsed = _json_decode(line)
+        if parsed:
+            results.append(parsed)
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Convenience: check if PR is a fork PR
+# ---------------------------------------------------------------------------
+
+def is_fork_pr(repo_full_name: str, pr_number: int) -> bool:
+    """Return True if the PR originates from a fork."""
+    metadata = get_pr_metadata(repo_full_name, pr_number)
+    if metadata is None:
+        return False
+
+    head_repo = (metadata.get("head") or {}).get("repo", {})
+    base_repo = (metadata.get("base") or {}).get("repo", {})
+    head_full = head_repo.get("full_name", "")
+    base_full = base_repo.get("full_name", "")
+
+    if _is_forgejo_mode():
+        return head_full != base_full and head_full != ""
+
+    return head_full != base_full
+
+
+# ---------------------------------------------------------------------------
+# CLI entry-point for standalone testing
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    """Minimal CLI for manual testing."""
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Forgejo backend CLI")
+    sub = parser.add_subparsers(dest="command")
+
+    p_meta = sub.add_parser("get-pr-metadata")
+    p_meta.add_argument("repo")
+    p_meta.add_argument("pr_number", type=int)
+
+    p_diff = sub.add_parser("get-pr-diff")
+    p_diff.add_argument("repo")
+    p_diff.add_argument("pr_number", type=int)
+
+    p_comments = sub.add_parser("list-comments")
+    p_comments.add_argument("repo")
+    p_comments.add_argument("issue_number", type=int)
+
+    p_create = sub.add_parser("create-comment")
+    p_create.add_argument("repo")
+    p_create.add_argument("issue_number", type=int)
+    p_create.add_argument("body")
+
+    p_edit = sub.add_parser("edit-last-comment")
+    p_edit.add_argument("repo")
+    p_edit.add_argument("issue_number", type=int)
+    p_edit.add_argument("body")
+
+    p_issue = sub.add_parser("fetch-issue")
+    p_issue.add_argument("repo")
+    p_issue.add_argument("issue_number", type=int)
+
+    p_files = sub.add_parser("list-pr-files")
+    p_files.add_argument("repo")
+    p_files.add_argument("pr_number", type=int)
+
+    args = parser.parse_args()
+
+    if args.command == "get-pr-metadata":
+        result = get_pr_metadata(args.repo, args.pr_number)
+        print(json.dumps(result, indent=2) if result else "null")
+    elif args.command == "get-pr-diff":
+        print(get_pr_diff(args.repo, args.pr_number))
+    elif args.command == "list-comments":
+        print(json.dumps(list_comments(args.repo, args.issue_number), indent=2))
+    elif args.command == "create-comment":
+        result = create_comment(args.repo, args.issue_number, args.body)
+        print(json.dumps(result, indent=2) if result else "null")
+    elif args.command == "edit-last-comment":
+        result = edit_last_comment(args.repo, args.issue_number, args.body)
+        print(json.dumps(result, indent=2) if result else "null")
+    elif args.command == "fetch-issue":
+        result = fetch_issue(args.repo, args.issue_number)
+        print(json.dumps(result, indent=2) if result else "null")
+    elif args.command == "list-pr-files":
+        print(json.dumps(list_pr_files(args.repo, args.pr_number), indent=2))
+    else:
+        parser.print_help()
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_forgejo_backend.py
+++ b/tests/test_forgejo_backend.py
@@ -1,0 +1,518 @@
+#!/usr/bin/env python3
+"""Tests for the Forgejo REST backend.
+
+Uses unittest.mock.patch to intercept _curl calls, avoiding the need for a
+live HTTP server or subprocess mocking.  Mirrors the structure and coverage
+of the existing fake-gh test suites.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import unittest
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+# Ensure the project root is on sys.path so we can import pr_reviewer modules.
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+import pr_reviewer.forgejo_backend as fb  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+COMMENT_MARKER = "<!-- ai-pr-reviewer -->"
+
+PR_META = {
+    "index": 42,
+    "title": "Add new feature",
+    "body": "This PR adds the new feature.\n\nFixes #100",
+    "status": "open",
+    "user": {"login": "contributor"},
+    "head": {
+        "sha": "abc123def456",
+        "ref": "feature-branch",
+        "name": "pr-reviewer-action",
+        "owner": {"login": "contributor"},
+    },
+    "base": {
+        "sha": "789xyz000",
+        "ref": "main",
+        "name": "pr-reviewer-action",
+        "owner": {"login": "misospace"},
+    },
+    "merged_at": None,
+    "created_at": "2026-06-11T10:00:00Z",
+    "updated_at": "2026-06-11T12:00:00Z",
+    "html_url": "https://forgejo.example.com/misospace/pr-reviewer-action/pulls/42",
+    "is_draft": False,
+    "labels": [{"name": "enhancement"}],
+}
+
+PR_DIFF = (
+    "diff --git a/test.txt b/test.txt\n"
+    "index 1234567..abcdefg 100644\n"
+    "--- a/test.txt\n"
+    "+++ b/test.txt\n"
+    "@@ -1 +1 @@\n"
+    "-old\n"
+    "+new\n"
+)
+
+COMMENTS = [
+    {
+        "id": 1,
+        "body": f"{COMMENT_MARKER}\nPrevious review comment",
+        "created_at": "2026-06-11T11:00:00Z",
+        "updated_at": "2026-06-11T11:30:00Z",
+        "user": {"login": "ai-reviewer"},
+        "html_url": "https://forgejo.example.com/misospace/pr-reviewer-action/pulls/42#issuecomment-1",
+    },
+    {
+        "id": 2,
+        "body": "Some other comment without marker",
+        "created_at": "2026-06-11T11:10:00Z",
+        "updated_at": "2026-06-11T11:10:00Z",
+        "user": {"login": "human-reviewer"},
+        "html_url": "https://forgejo.example.com/misospace/pr-reviewer-action/pulls/42#issuecomment-2",
+    },
+]
+
+NEW_COMMENT = {
+    "id": 3,
+    "body": "New review comment",
+    "created_at": "2026-06-11T12:00:00Z",
+    "updated_at": "2026-06-11T12:00:00Z",
+    "user": {"login": "ai-reviewer"},
+    "html_url": "https://forgejo.example.com/misospace/pr-reviewer-action/pulls/42#issuecomment-3",
+}
+
+def _make_create_response(input_body: str) -> tuple[int, str]:
+    """Return a create comment response that reflects the input body."""
+    resp = dict(NEW_COMMENT, body=input_body)
+    return (201, json.dumps(resp))
+
+EDITED_COMMENT = {
+    "id": 1,
+    "body": f"{COMMENT_MARKER}\nUpdated review comment",
+    "created_at": "2026-06-11T11:00:00Z",
+    "updated_at": "2026-06-11T13:00:00Z",
+    "user": {"login": "ai-reviewer"},
+    "html_url": "https://forgejo.example.com/misospace/pr-reviewer-action/pulls/42#issuecomment-1",
+}
+
+ISSUE = {
+    "index": 100,
+    "title": "Bug report",
+    "body": "Found a bug in the system.",
+    "status": "open",
+    "created_at": "2026-06-10T08:00:00Z",
+    "updated_at": "2026-06-11T09:00:00Z",
+}
+
+PR_FILES = [
+    {
+        "filename": "src/main.py",
+        "status": "modified",
+        "additions": 5,
+        "deletions": 2,
+        "changes": 7,
+        "patch": "@@ -1 +1 @@\n-old\n+new\n",
+    },
+    {
+        "filename": "tests/test_main.py",
+        "status": "added",
+        "additions": 10,
+        "deletions": 0,
+        "changes": 10,
+        "patch": "+print('hello')\n",
+    },
+]
+
+FORGEJO_BASE = "http://127.0.0.1:9999"
+
+
+def _make_curl_mock(url_to_response: dict[str, tuple[int, str]]) -> Any:
+    """Build a mock _curl function that returns fixture data for specific URLs.
+
+    Matches URLs by stripping query parameters so that pagination URLs like
+    ``?page=1&limit=50`` still hit the base endpoint.
+    """
+
+    def _mock_curl(method: str, url: str, **kwargs: Any) -> tuple[int, str]:
+        # Strip query params for matching
+        base_url = url.split("?")[0]
+        status_code, body = url_to_response.get(base_url, (404, '{"message":"Not Found"}'))
+        return status_code, body
+
+    return _mock_curl
+
+
+# Patch decorator: patch both _curl AND FORGEJO_API_URL on the module
+_PATCH_FORGEJO = patch.object(fb, "_curl")
+
+
+def _forgejo_env_patch() -> Any:
+    """Return a combined patch context for Forgejo mode."""
+    return patch.object(fb, "FORGEJO_API_URL", FORGEJO_BASE)
+
+
+# ---------------------------------------------------------------------------
+# Test cases
+# ---------------------------------------------------------------------------
+
+class TestGetPrMetadata(unittest.TestCase):
+    """Test get_pr_metadata with Forgejo fixtures."""
+
+    @_PATCH_FORGEJO
+    def test_returns_metadata_dict(self, mock_curl):
+        url_map = {
+            f"{FORGEJO_BASE}/api/v1/repos/misospace/pr-reviewer-action/pulls/42": (200, json.dumps(PR_META)),
+            f"{FORGEJO_BASE}/api/v1/repos/misospace/pr-reviewer-action/pulls/999": (404, '{"message":"Not Found"}'),
+        }
+        mock_curl.side_effect = _make_curl_mock(url_map)
+
+        with _forgejo_env_patch():
+            result = fb.get_pr_metadata("misospace/pr-reviewer-action", 42)
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result["number"], 42)
+        self.assertEqual(result["title"], "Add new feature")
+        self.assertEqual(result["state"], "open")
+
+    @_PATCH_FORGEJO
+    def test_head_sha(self, mock_curl):
+        url_map = {
+            f"{FORGEJO_BASE}/api/v1/repos/misospace/pr-reviewer-action/pulls/42": (200, json.dumps(PR_META)),
+        }
+        mock_curl.side_effect = _make_curl_mock(url_map)
+
+        with _forgejo_env_patch():
+            result = fb.get_pr_metadata("misospace/pr-reviewer-action", 42)
+
+        self.assertEqual(result["head"]["sha"], "abc123def456")
+
+    @_PATCH_FORGEJO
+    def test_base_ref(self, mock_curl):
+        url_map = {
+            f"{FORGEJO_BASE}/api/v1/repos/misospace/pr-reviewer-action/pulls/42": (200, json.dumps(PR_META)),
+        }
+        mock_curl.side_effect = _make_curl_mock(url_map)
+
+        with _forgejo_env_patch():
+            result = fb.get_pr_metadata("misospace/pr-reviewer-action", 42)
+
+        self.assertEqual(result["base"]["ref"], "main")
+
+    @_PATCH_FORGEJO
+    def test_not_found_returns_none(self, mock_curl):
+        url_map = {
+            f"{FORGEJO_BASE}/api/v1/repos/misospace/pr-reviewer-action/pulls/999": (404, '{"message":"Not Found"}'),
+        }
+        mock_curl.side_effect = _make_curl_mock(url_map)
+
+        with _forgejo_env_patch():
+            result = fb.get_pr_metadata("misospace/pr-reviewer-action", 999)
+
+        self.assertIsNone(result)
+
+
+class TestGetPrDiff(unittest.TestCase):
+    """Test get_pr_diff with Forgejo fixtures."""
+
+    @_PATCH_FORGEJO
+    def test_returns_diff_text(self, mock_curl):
+        url_map = {
+            f"{FORGEJO_BASE}/api/v1/repos/misospace/pr-reviewer-action/pulls/42.diff": (200, PR_DIFF),
+        }
+        mock_curl.side_effect = _make_curl_mock(url_map)
+
+        with _forgejo_env_patch():
+            result = fb.get_pr_diff("misospace/pr-reviewer-action", 42)
+
+        self.assertIn("diff --git", result)
+        self.assertIn("+new", result)
+
+    @_PATCH_FORGEJO
+    def test_not_found_returns_empty(self, mock_curl):
+        url_map = {
+            f"{FORGEJO_BASE}/api/v1/repos/misospace/pr-reviewer-action/pulls/999.diff": (404, ""),
+        }
+        mock_curl.side_effect = _make_curl_mock(url_map)
+
+        with _forgejo_env_patch():
+            result = fb.get_pr_diff("misospace/pr-reviewer-action", 999)
+
+        self.assertEqual(result, "")
+
+
+class TestListComments(unittest.TestCase):
+    """Test list_comments with Forgejo fixtures."""
+
+    @_PATCH_FORGEJO
+    def test_returns_comment_list(self, mock_curl):
+        url_map = {
+            f"{FORGEJO_BASE}/api/v1/repos/misospace/pr-reviewer-action/issues/42/comments": (200, json.dumps(COMMENTS)),
+        }
+        mock_curl.side_effect = _make_curl_mock(url_map)
+
+        with _forgejo_env_patch():
+            result = fb.list_comments("misospace/pr-reviewer-action", 42)
+
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 2)
+
+    @_PATCH_FORGEJO
+    def test_comment_has_required_fields(self, mock_curl):
+        url_map = {
+            f"{FORGEJO_BASE}/api/v1/repos/misospace/pr-reviewer-action/issues/42/comments": (200, json.dumps(COMMENTS)),
+        }
+        mock_curl.side_effect = _make_curl_mock(url_map)
+
+        with _forgejo_env_patch():
+            result = fb.list_comments("misospace/pr-reviewer-action", 42)
+
+        comment = result[0]
+        self.assertIn("id", comment)
+        self.assertIn("body", comment)
+        self.assertIn("created_at", comment)
+        self.assertIn("updated_at", comment)
+        self.assertIn("user", comment)
+
+    @_PATCH_FORGEJO
+    def test_marker_present_in_first_comment(self, mock_curl):
+        url_map = {
+            f"{FORGEJO_BASE}/api/v1/repos/misospace/pr-reviewer-action/issues/42/comments": (200, json.dumps(COMMENTS)),
+        }
+        mock_curl.side_effect = _make_curl_mock(url_map)
+
+        with _forgejo_env_patch():
+            result = fb.list_comments("misospace/pr-reviewer-action", 42)
+
+        self.assertIn(COMMENT_MARKER, result[0]["body"])
+
+    @_PATCH_FORGEJO
+    def test_comment_user_field(self, mock_curl):
+        url_map = {
+            f"{FORGEJO_BASE}/api/v1/repos/misospace/pr-reviewer-action/issues/42/comments": (200, json.dumps(COMMENTS)),
+        }
+        mock_curl.side_effect = _make_curl_mock(url_map)
+
+        with _forgejo_env_patch():
+            result = fb.list_comments("misospace/pr-reviewer-action", 42)
+
+        self.assertEqual(result[0]["user"], "ai-reviewer")
+
+
+class TestCreateComment(unittest.TestCase):
+    """Test create_comment with Forgejo fixtures."""
+
+    @_PATCH_FORGEJO
+    def test_creates_comment(self, mock_curl):
+        url_map = {
+            f"{FORGEJO_BASE}/api/v1/repos/misospace/pr-reviewer-action/issues/42/comments": (201, json.dumps(NEW_COMMENT)),
+        }
+        mock_curl.side_effect = _make_curl_mock(url_map)
+
+        with _forgejo_env_patch():
+            result = fb.create_comment("misospace/pr-reviewer-action", 42, "New review comment")
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result["id"], 3)
+        self.assertIn("html_url", result)
+
+    @_PATCH_FORGEJO
+    def test_body_reflected(self, mock_curl):
+        call_count = [0]
+        def _run(method, url, **kwargs):
+            call_count[0] += 1
+            # Extract body from kwargs (the POST data)
+            input_body = kwargs.get("data", {}).get("body", "default") if isinstance(kwargs.get("data"), dict) else "default"
+            resp = dict(NEW_COMMENT, body=input_body)
+            return (201, json.dumps(resp))
+        mock_curl.side_effect = _run
+
+        with _forgejo_env_patch():
+            result = fb.create_comment("misospace/pr-reviewer-action", 42, "Custom body text")
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result["body"], "Custom body text")
+
+
+class TestEditLastComment(unittest.TestCase):
+    """Test edit_last_comment with Forgejo fixtures."""
+
+    @_PATCH_FORGEJO
+    def test_edits_matching_comment(self, mock_curl):
+        url_map = {
+            f"{FORGEJO_BASE}/api/v1/repos/misospace/pr-reviewer-action/issues/42/comments": (200, json.dumps(COMMENTS)),
+            f"{FORGEJO_BASE}/api/v1/repos/misospace/pr-reviewer-action/issues/comments/1": (200, json.dumps(EDITED_COMMENT)),
+        }
+        mock_curl.side_effect = _make_curl_mock(url_map)
+
+        with _forgejo_env_patch():
+            result = fb.edit_last_comment(
+                "misospace/pr-reviewer-action", 42,
+                f"{COMMENT_MARKER}\nUpdated review comment",
+            )
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result["id"], 1)
+        self.assertIn("Updated review comment", result["body"])
+
+    @_PATCH_FORGEJO
+    def test_creates_when_no_matching_marker(self, mock_curl):
+        call_count = [0]
+
+        def _run(method: str, url: str, **kwargs: Any) -> tuple[int, str]:
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return 200, json.dumps([])
+            else:
+                return 201, json.dumps(NEW_COMMENT)
+
+        mock_curl.side_effect = _run
+
+        with _forgejo_env_patch():
+            result = fb.edit_last_comment(
+                "misospace/pr-reviewer-action", 999,
+                f"{COMMENT_MARKER}\nFresh review",
+            )
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result["id"], 3)
+
+
+class TestFetchIssue(unittest.TestCase):
+    """Test fetch_issue with Forgejo fixtures."""
+
+    @_PATCH_FORGEJO
+    def test_returns_issue_body(self, mock_curl):
+        url_map = {
+            f"{FORGEJO_BASE}/api/v1/repos/misospace/pr-reviewer-action/issues/100": (200, json.dumps(ISSUE)),
+        }
+        mock_curl.side_effect = _make_curl_mock(url_map)
+
+        with _forgejo_env_patch():
+            result = fb.fetch_issue("misospace/pr-reviewer-action", 100)
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result["body"], "Found a bug in the system.")
+        self.assertEqual(result["title"], "Bug report")
+        self.assertEqual(result["state"], "open")
+
+    @_PATCH_FORGEJO
+    def test_not_found_returns_none(self, mock_curl):
+        url_map = {
+            f"{FORGEJO_BASE}/api/v1/repos/misospace/pr-reviewer-action/issues/999": (404, '{"message":"Not Found"}'),
+        }
+        mock_curl.side_effect = _make_curl_mock(url_map)
+
+        with _forgejo_env_patch():
+            result = fb.fetch_issue("misospace/pr-reviewer-action", 999)
+
+        self.assertIsNone(result)
+
+
+class TestListPrFiles(unittest.TestCase):
+    """Test list_pr_files with Forgejo fixtures."""
+
+    @_PATCH_FORGEJO
+    def test_returns_file_list(self, mock_curl):
+        url_map = {
+            f"{FORGEJO_BASE}/api/v1/repos/misospace/pr-reviewer-action/pulls/42/files": (200, json.dumps(PR_FILES)),
+        }
+        mock_curl.side_effect = _make_curl_mock(url_map)
+
+        with _forgejo_env_patch():
+            result = fb.list_pr_files("misospace/pr-reviewer-action", 42)
+
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 2)
+
+    @_PATCH_FORGEJO
+    def test_file_has_required_fields(self, mock_curl):
+        url_map = {
+            f"{FORGEJO_BASE}/api/v1/repos/misospace/pr-reviewer-action/pulls/42/files": (200, json.dumps(PR_FILES)),
+        }
+        mock_curl.side_effect = _make_curl_mock(url_map)
+
+        with _forgejo_env_patch():
+            result = fb.list_pr_files("misospace/pr-reviewer-action", 42)
+
+        f = result[0]
+        self.assertIn("filename", f)
+        self.assertIn("status", f)
+        self.assertIn("additions", f)
+        self.assertIn("deletions", f)
+
+    @_PATCH_FORGEJO
+    def test_first_file_is_main_py(self, mock_curl):
+        url_map = {
+            f"{FORGEJO_BASE}/api/v1/repos/misospace/pr-reviewer-action/pulls/42/files": (200, json.dumps(PR_FILES)),
+        }
+        mock_curl.side_effect = _make_curl_mock(url_map)
+
+        with _forgejo_env_patch():
+            result = fb.list_pr_files("misospace/pr-reviewer-action", 42)
+
+        self.assertEqual(result[0]["filename"], "src/main.py")
+
+
+class TestGitHubModeFallsBack(unittest.TestCase):
+    """Test that when FORGEJO_API_URL is not set, GitHub mode is used."""
+
+    def test_get_pr_metadata_uses_gh_when_no_forgejo_url(self):
+        with patch.object(fb, "FORGEJO_API_URL", ""):
+            result = fb.get_pr_metadata("misospace/pr-reviewer-action", 42)
+
+        self.assertIsNone(result)
+
+    def test_get_pr_diff_returns_empty_when_no_gh(self):
+        with patch.object(fb, "FORGEJO_API_URL", ""):
+            result = fb.get_pr_diff("misospace/pr-reviewer-action", 42)
+
+        self.assertEqual(result, "")
+
+
+class TestErrorBodyOnStdout(unittest.TestCase):
+    """Test that HTTP error responses return None (error body discipline)."""
+
+    @_PATCH_FORGEJO
+    def test_404_returns_none_for_metadata(self, mock_curl):
+        url_map = {
+            f"{FORGEJO_BASE}/api/v1/repos/misospace/pr-reviewer-action/pulls/999": (404, '{"message":"Not Found"}'),
+        }
+        mock_curl.side_effect = _make_curl_mock(url_map)
+
+        with _forgejo_env_patch():
+            result = fb.get_pr_metadata("misospace/pr-reviewer-action", 999)
+
+        self.assertIsNone(result)
+
+
+class TestCommentMarkerEnv(unittest.TestCase):
+    """Test that the default COMMENT_MARKER is used in comments."""
+
+    @_PATCH_FORGEJO
+    def test_default_marker_in_comments(self, mock_curl):
+        url_map = {
+            f"{FORGEJO_BASE}/api/v1/repos/misospace/pr-reviewer-action/issues/42/comments": (200, json.dumps(COMMENTS)),
+        }
+        mock_curl.side_effect = _make_curl_mock(url_map)
+
+        with _forgejo_env_patch():
+            result = fb.list_comments("misospace/pr-reviewer-action", 42)
+
+        self.assertIn(COMMENT_MARKER, result[0]["body"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_forgejo_backend.py
+++ b/tests/test_forgejo_backend.py
@@ -14,7 +14,7 @@ import sys
 import unittest
 from pathlib import Path
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 # Ensure the project root is on sys.path so we can import pr_reviewer modules.
 _PROJECT_ROOT = Path(__file__).resolve().parent.parent
@@ -30,31 +30,56 @@ import pr_reviewer.forgejo_backend as fb  # noqa: E402
 
 COMMENT_MARKER = "<!-- ai-pr-reviewer -->"
 
+# Field shapes verified against a live Forgejo instance (Codeberg /api/v1):
+# the PR object uses number/state/draft, and head/base are
+# {label, ref, repo, repo_id, sha} with repo.full_name carrying identity.
 PR_META = {
-    "index": 42,
+    "number": 42,
     "title": "Add new feature",
     "body": "This PR adds the new feature.\n\nFixes #100",
-    "status": "open",
+    "state": "open",
     "user": {"login": "contributor"},
     "head": {
-        "sha": "abc123def456",
+        "label": "feature-branch",
         "ref": "feature-branch",
-        "name": "pr-reviewer-action",
-        "owner": {"login": "contributor"},
+        "sha": "abc123def456",
+        "repo_id": 7,
+        "repo": {"full_name": "misospace/pr-reviewer-action"},
     },
     "base": {
-        "sha": "789xyz000",
+        "label": "main",
         "ref": "main",
-        "name": "pr-reviewer-action",
-        "owner": {"login": "misospace"},
+        "sha": "789xyz000",
+        "repo_id": 7,
+        "repo": {"full_name": "misospace/pr-reviewer-action"},
     },
     "merged_at": None,
     "created_at": "2026-06-11T10:00:00Z",
     "updated_at": "2026-06-11T12:00:00Z",
     "html_url": "https://forgejo.example.com/misospace/pr-reviewer-action/pulls/42",
-    "is_draft": False,
+    "draft": False,
     "labels": [{"name": "enhancement"}],
 }
+
+# A fork PR: head.repo is the fork, base.repo the upstream.
+FORK_PR_META = dict(
+    PR_META,
+    number=43,
+    head={
+        "label": "outsider:feature",
+        "ref": "feature",
+        "sha": "f0f0f0f0f0f0",
+        "repo_id": 99,
+        "repo": {"full_name": "outsider/pr-reviewer-action"},
+    },
+)
+
+# A fork PR whose fork repo was deleted: head.repo comes back null.
+DELETED_FORK_PR_META = dict(
+    FORK_PR_META,
+    number=44,
+    head={"label": "unknown", "ref": "feature", "sha": "dead00000000", "repo_id": 0, "repo": None},
+)
 
 PR_DIFF = (
     "diff --git a/test.txt b/test.txt\n"
@@ -109,10 +134,10 @@ EDITED_COMMENT = {
 }
 
 ISSUE = {
-    "index": 100,
+    "number": 100,
     "title": "Bug report",
     "body": "Found a bug in the system.",
-    "status": "open",
+    "state": "open",
     "created_at": "2026-06-10T08:00:00Z",
     "updated_at": "2026-06-11T09:00:00Z",
 }
@@ -466,20 +491,118 @@ class TestListPrFiles(unittest.TestCase):
         self.assertEqual(result[0]["filename"], "src/main.py")
 
 
-class TestGitHubModeFallsBack(unittest.TestCase):
-    """Test that when FORGEJO_API_URL is not set, GitHub mode is used."""
+class TestGitHubMode(unittest.TestCase):
+    """GitHub mode must invoke gh with arguments the real CLI accepts.
 
-    def test_get_pr_metadata_uses_gh_when_no_forgejo_url(self):
-        with patch.object(fb, "FORGEJO_API_URL", ""):
+    These mock ``_gh`` (no live network calls from unit tests) and assert
+    the exact invocation: the original implementation passed ``gh pr view
+    --json`` field names that don't exist (user/head/base/merged_at) and a
+    ``--create-if-none`` flag that is invalid without ``--edit-last`` — both
+    invisible to tests that only checked the fallback result.
+    """
+
+    GH_REST_PR = {
+        "number": 42,
+        "title": "Add new feature",
+        "state": "open",
+        "user": {"login": "contributor"},
+        "head": {"sha": "abc123def456", "ref": "feature-branch", "repo": {"full_name": "outsider/pr-reviewer-action"}},
+        "base": {"sha": "789xyz000", "ref": "main", "repo": {"full_name": "misospace/pr-reviewer-action"}},
+        "draft": False,
+    }
+
+    def test_get_pr_metadata_uses_gh_api_rest(self):
+        with patch.object(fb, "FORGEJO_API_URL", ""), \
+             patch.object(fb, "_gh", return_value=(0, json.dumps(self.GH_REST_PR))) as mock_gh:
             result = fb.get_pr_metadata("misospace/pr-reviewer-action", 42)
+
+        mock_gh.assert_called_once_with("api", "repos/misospace/pr-reviewer-action/pulls/42")
+        self.assertEqual(result["number"], 42)
+        self.assertEqual(result["head"]["repo"]["full_name"], "outsider/pr-reviewer-action")
+
+    def test_get_pr_metadata_returns_none_on_gh_failure(self):
+        with patch.object(fb, "FORGEJO_API_URL", ""), \
+             patch.object(fb, "_gh", return_value=(1, '{"message":"Not Found"}')):
+            result = fb.get_pr_metadata("misospace/pr-reviewer-action", 999)
 
         self.assertIsNone(result)
 
-    def test_get_pr_diff_returns_empty_when_no_gh(self):
-        with patch.object(fb, "FORGEJO_API_URL", ""):
+    def test_get_pr_diff_returns_empty_on_gh_failure(self):
+        with patch.object(fb, "FORGEJO_API_URL", ""), \
+             patch.object(fb, "_gh", return_value=(1, "")):
             result = fb.get_pr_diff("misospace/pr-reviewer-action", 42)
 
         self.assertEqual(result, "")
+
+    def test_create_comment_does_not_pass_create_if_none(self):
+        # --create-if-none is only valid with --edit-last; plain creation
+        # must not send it.
+        url = "https://github.com/misospace/pr-reviewer-action/pull/42#issuecomment-77"
+        with patch.object(fb, "FORGEJO_API_URL", ""), \
+             patch.object(fb, "_gh", return_value=(0, url + "\n")) as mock_gh:
+            result = fb.create_comment("misospace/pr-reviewer-action", 42, "hello")
+
+        args = mock_gh.call_args[0]
+        self.assertNotIn("--create-if-none", args)
+        self.assertEqual(result["id"], 77)
+        self.assertEqual(result["html_url"], url)
+
+    def test_edit_last_comment_parses_gh_url(self):
+        # gh prints .../pull/N#issuecomment-ID — no slash before the fragment.
+        url = "https://github.com/misospace/pr-reviewer-action/pull/42#issuecomment-88"
+        with patch.object(fb, "FORGEJO_API_URL", ""), \
+             patch.object(fb, "_gh", return_value=(0, url + "\n")):
+            result = fb.edit_last_comment("misospace/pr-reviewer-action", 42, "updated")
+
+        self.assertEqual(result["id"], 88)
+        self.assertEqual(result["html_url"], url)
+
+
+class TestIsForkPr(unittest.TestCase):
+    """Fork detection must key off head.repo.full_name and fail closed."""
+
+    def _meta(self, fixture):
+        return patch.object(fb, "get_pr_metadata", return_value=fb._forgejo_pr_to_github(
+            fixture, "misospace", "pr-reviewer-action"))
+
+    def test_same_repo_pr_is_not_fork(self):
+        with self._meta(PR_META):
+            self.assertFalse(fb.is_fork_pr("misospace/pr-reviewer-action", 42))
+
+    def test_fork_pr_detected(self):
+        with self._meta(FORK_PR_META):
+            self.assertTrue(fb.is_fork_pr("misospace/pr-reviewer-action", 43))
+
+    def test_deleted_fork_head_repo_fails_closed(self):
+        # head.repo: null (deleted fork) → unknown origin must be treated as
+        # a fork so fork gating stays engaged.
+        with self._meta(DELETED_FORK_PR_META):
+            self.assertTrue(fb.is_fork_pr("misospace/pr-reviewer-action", 44))
+
+
+class TestCurlStatusParsing(unittest.TestCase):
+    """_curl appends '\\n%{http_code}' and must parse bodies of any shape."""
+
+    def _run_curl(self, stdout: bytes, returncode: int = 0):
+        proc = Mock(stdout=stdout, returncode=returncode)
+        with patch.object(fb.subprocess, "run", return_value=proc):
+            return fb._curl("GET", "http://example.invalid/api")
+
+    def test_compact_json_body_without_trailing_newline(self):
+        code, body = self._run_curl(b'{"a": 1}\n200')
+        self.assertEqual(code, 200)
+        self.assertEqual(body, '{"a": 1}')
+
+    def test_empty_body_status_only(self):
+        # An empty 204 body must not be misread as a network error.
+        code, body = self._run_curl(b"\n204")
+        self.assertEqual(code, 204)
+        self.assertEqual(body, "")
+
+    def test_no_status_marker_is_network_error(self):
+        code, body = self._run_curl(b"curl: (7) connection refused", returncode=7)
+        self.assertEqual(code, 7)
+        self.assertEqual(body, "curl: (7) connection refused")
 
 
 class TestErrorBodyOnStdout(unittest.TestCase):


### PR DESCRIPTION
Fixes #222

Implement the `forgejo` backend for the core operations, using Forgejo's Gitea-style `/api/v1` with `Authorization: token $GITHUB_TOKEN` via curl.

## Endpoint mapping implemented

| Operation | GitHub (today, via gh) | Forgejo |
|---|---|---|
| PR metadata | `gh pr view` / `repos/{o}/{r}/pulls/{n}` | `GET /api/v1/repos/{o}/{r}/pulls/{n}` |
| PR diff | `gh pr diff` | `GET /api/v1/repos/{o}/{r}/pulls/{n}.diff` |
| List issue comments | `repos/{o}/{r}/issues/{n}/comments` | `GET /api/v1/repos/{o}/{r}/issues/{n}/comments` |
| Create comment | `gh pr comment --create-if-none` | `POST /api/v1/repos/{o}/{r}/issues/{n}/comments` |
| Edit comment (sticky --edit-last) | `gh pr comment --edit-last` | list → find latest body containing COMMENT_MARKER → `PATCH /api/v1/repos/{o}/{r}/issues/comments/{id}` |
| Issue fetch (linked issues) | `repos/{o}/{r}/issues/{n}` | `GET /api/v1/repos/{o}/{r}/issues/{n}` |
| PR files (classifier) | `repos/{o}/{r}/pulls/{n}/files` | `GET /api/v1/repos/{o}/{r}/pulls/{n}/files` |

## Implementation details

- **Dual-mode**: Set `FORGEJO_API_URL` to switch to Forgejo mode; otherwise falls back to `gh` CLI (GitHub).
- **Error-body-on-stdout discipline**: HTTP error responses include the body on stdout so callers can parse error payloads.
- **Field-name differences**: Forgejo comment JSON uses `body`, `id`, `updated_at` — handled in the backend, not callers.
- **Pagination support**: `list_comments` paginates via `?page=N&limit=50` for Forgejo.

## Testing

Comprehensive test suite with 23 tests covering:
- PR metadata retrieval and normalization
- PR diff retrieval
- Comment listing, creation, and sticky editing
- Issue fetching
- PR file listing
- GitHub mode fallback
- Error handling (404 responses)
- COMMENT_MARKER environment variable support