### PR TITLE
feat(conversation): multi-turn conversation/request builder for native tool calling (2/7 of #197)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,8 @@ The action collects rich PR context (diff, files, linked issues, version hints, 
 - **`metadata.py`** — Managed metadata marker (fingerprint, scope, open findings) embedded in published comments
 - **`github_context.py`** — PR metadata/linked-issue context helpers
 - **`response_parser.py`** — Tolerant model-output parsing (JSON in fences/prose, verdict + findings extraction)
-- **`sse_reassembler.py`** — Reassembles streamed SSE responses into complete bodies
+- **`sse_reassembler.py`** — Reassembles streamed SSE responses into complete bodies (including streamed tool-call deltas; `function.arguments` is the accumulated JSON string, OpenAI non-streaming shape, per #233)
+- **`conversation.py`** — Multi-turn conversation/request builder for native tool calling (#202, 2/7 of #197 Option B): append-only neutral state, OpenAI/Anthropic wire rendering, per-API tool-schema catalogue, `truncate_oldest_tool_results` budget helper, `verdict_turn` mode that drops `tools` and switches to the strict JSON `response_format`
 
 ### Publishing and output hygiene
 
@@ -66,7 +67,7 @@ run_review.sh                   → collects context → classifies → builds c
   ├─ run_evidence_providers.py  → User-defined provider commands
   ├─ run_tool_harness.py        → Tool harness planning + execution (once or loop)
   ├─ model_call.sh              → Fast/smart routing, retries, streaming, fallback
-  └─ pr_reviewer.{completeness,enforcement,escalation,carry_forward}
+  └─ pr_reviewer.{completeness,enforcement,escalation,carry_forward,conversation}
                                  → required-check validation, verdict policy, escalation, carried findings
 publish (action.yml steps)      → sanitize markdown → strip markers → build managed body → publish
   ├─ publish_mode=comment        → gh pr comment --edit-last --create-if-none (sticky)

--- a/pr_reviewer/conversation.py
+++ b/pr_reviewer/conversation.py
@@ -1,0 +1,799 @@
+"""Multi-turn conversation/request builder for native tool calling (#202).
+
+A pure-Python stateful builder for the OpenAI and Anthropic message shapes
+that the native tool-calling loop (umbrella #197 §1, item 2/7) needs. It is
+deliberately I/O-free and endpoint-free so it can be unit-tested without a
+running model server — the loop driver in 3/7 will own the actual request
+serialisation and HTTP call.
+
+Wire-shape contract (the bits callers will rely on):
+
+- OpenAI
+    * assistant turn: ``{"role": "assistant", "content": str|None,
+      "tool_calls": [{"id", "type": "function", "function": {"name",
+      "arguments"}}]}``
+    * tool result turn: ``{"role": "tool", "tool_call_id": <id>,
+      "content": str}``
+    * top-level ``tools``: list of ``{"type": "function",
+      "function": {"name", "description", "parameters": JSON-Schema}}``
+
+- Anthropic
+    * assistant turn: ``{"role": "assistant", "content":
+      [{"type": "text", "text": ...}, {"type": "tool_use", "id",
+      "name", "input"}]}`` — text and tool_use blocks may interleave.
+    * tool result turn: ``{"role": "user", "content":
+      [{"type": "tool_result", "tool_use_id": <id>, "content": str|list,
+      "is_error": bool?}]}``
+    * top-level ``tools``: list of ``{"name", "description", "input_schema":
+      JSON-Schema}``
+
+The verdict-turn contract: ``ai_response_format`` only applies to the
+closing turn (it forces a strict JSON verdict). For that turn, ``tools`` is
+omitted and the accumulated conversation can either be carried through in
+full (default off, expensive) or collapsed into a single system-prompt
+transcript note (default on, mirrors today's single-shot behaviour). See
+``Conversation.to_request_payload`` for the flag.
+
+The budget helpers in this module (rough token estimate + graceful
+truncation of the oldest tool results) are advisory: the loop driver in
+3/7 owns the authoritative stop conditions. Keeping them here means the
+emission code and the accounting code live together and can't drift.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any, Iterable
+
+# Per the executor catalogue in scripts/run_tool_harness.py (the
+# normalize_tool_request repair logic and the per-tool arg shapes). Keep these
+# schemas in lockstep with the executor — they are the source of truth for
+# what the loop driver plans against.
+TOOL_SCHEMAS: list[dict[str, Any]] = [
+    {
+        "name": "gh_api",
+        "description": (
+            "Read-only GitHub REST API call. Path must start with one of "
+            "repos/, issues/, search/, releases/, git/ and target an "
+            "allowlisted repo. Use for PR/issue/release/commit lookups."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "endpoint": {
+                    "type": "string",
+                    "description": (
+                        "Endpoint path, e.g. 'repos/owner/repo/releases/tags/v1' "
+                        "or 'owner/repo/issues/123'."
+                    ),
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Alias for endpoint.",
+                },
+            },
+            "required": ["endpoint"],
+            "additionalProperties": False,
+        },
+    },
+    {
+        "name": "read_file",
+        "description": (
+            "Read a file from the workspace. Path-traversal and sensitive "
+            "files (.env, .pem, credentials, id_rsa, …) are blocked. Output "
+            "is truncated to ~12 KB."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Path relative to the workspace root.",
+                },
+            },
+            "required": ["path"],
+            "additionalProperties": False,
+        },
+    },
+    {
+        "name": "web_fetch",
+        "description": (
+            "Fetch a URL whose host appears in the action's allowlist. "
+            "Output is truncated to ~10 KB of decoded text."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "url": {
+                    "type": "string",
+                    "description": "Absolute https URL on an allowlisted host.",
+                },
+            },
+            "required": ["url"],
+            "additionalProperties": False,
+        },
+    },
+    {
+        "name": "git_grep",
+        "description": (
+            "Search the repository for a literal pattern using git grep. "
+            "Returns up to 60 matching lines with file:lineno:content."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "pattern": {
+                    "type": "string",
+                    "description": "Literal pattern (no regex metachars).",
+                },
+            },
+            "required": ["pattern"],
+            "additionalProperties": False,
+        },
+    },
+    {
+        "name": "run_command",
+        "description": (
+            "Execute a named read-only command definition from a fixed "
+            "allowlist. Raw shell text is never accepted; only the catalog "
+            "names git_status_short, git_diff_stat, git_diff_name_only are "
+            "permitted."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "command": {
+                    "type": "string",
+                    "enum": ["git_status_short", "git_diff_stat", "git_diff_name_only"],
+                },
+            },
+            "required": ["command"],
+            "additionalProperties": False,
+        },
+    },
+]
+
+# Per-tool result cap applied when re-adding tool output to the conversation
+# (bytes). Roughly tracks the executor's own internal caps so a tool's
+# truncated response doesn't grow on every loop round.
+TOOL_RESULT_MAX_BYTES = 8000
+
+# Approximate bytes-per-token used by the budget helpers. Deliberately
+# conservative (under-fills) — local models reject over-long prompts harder
+# than they reject slightly under-filled ones, and the loop driver in 3/7
+# will own the authoritative stop conditions.
+APPROX_BYTES_PER_TOKEN = 4
+
+
+# ---------------------------------------------------------------------------
+# Message normalisation
+# ---------------------------------------------------------------------------
+
+
+def _stringify_tool_result(result: Any) -> str:
+    """Render a tool result value as a JSON string for the wire.
+
+    Both APIs accept a string (or, for Anthropic, a list of content blocks);
+    a flat JSON string keeps the test surface small and the model prompt
+    predictable. The executor in run_tool_harness.py already returns
+    dicts/strings; we coerce here.
+    """
+    if result is None:
+        return ""
+    if isinstance(result, str):
+        return result
+    try:
+        return json.dumps(result, ensure_ascii=False, sort_keys=True)
+    except (TypeError, ValueError):
+        return str(result)
+
+
+def truncate_text(text: str, max_bytes: int) -> tuple[str, bool]:
+    """Truncate ``text`` to at most ``max_bytes`` UTF-8 bytes on a safe boundary.
+
+    Returns ``(text, truncated)``. The cut is at the latest newline not later
+    than ``max_bytes`` so we never split a code line or a JSON value. A pure
+    no-newline blob (a minified JSON payload) is cut on a codepoint boundary
+    rather than a byte boundary so we never split a multibyte character.
+    """
+    if max_bytes <= 0:
+        return "", True
+    encoded = text.encode("utf-8", errors="ignore")
+    if len(encoded) <= max_bytes:
+        return text, False
+    clip = encoded[:max_bytes]
+    nl = clip.rfind(b"\n")
+    if nl > 0:
+        clip = clip[:nl]
+        # Drop a trailing newline so the caller sees a clean line boundary
+        # (e.g. cap-of-5 on "a\nb\nc\nd\ne" yields "a\nb\nc", not
+        # "a\nb\nc\n"). Keeps the result on the right side of the cap.
+        if clip.endswith(b"\n"):
+            clip = clip[:-1]
+    # Codepoint-safe fallback: clip may end mid-multibyte when no newline
+    # is present. ``errors="replace"`` decodes cleanly (replacing the
+    # partial byte with U+FFFD) instead of raising — the resulting string
+    # is valid UTF-8.
+    out = clip.decode("utf-8", errors="replace")
+    return out, True
+
+
+def normalize_assistant_tool_calls_openai(
+    raw_calls: Iterable[Any],
+) -> list[dict[str, Any]]:
+    """Tolerantly shape model-emitted tool calls into OpenAI's non-streaming form.
+
+    Per the #233 contract, ``function.arguments`` is a JSON-encoded **string**
+    end-to-end (OpenAI's non-streaming schema) — strict servers reject a
+    dict when the assistant message is echoed back on the next turn. The
+    streaming reassembler already hands us a string, so we preserve it
+    verbatim. A caller that already has the parsed form (e.g. a unit test
+    or a non-reassembler path) may pass a dict; we serialise it once at
+    this boundary and then never touch it again. Malformed fragments
+    (truncated streams) are passed through as-is so the loop driver can
+    decide whether to retry.
+    """
+    out: list[dict[str, Any]] = []
+    for raw in raw_calls:
+        if not isinstance(raw, dict):
+            continue
+        fn = raw.get("function") if isinstance(raw.get("function"), dict) else None
+        name = (fn or {}).get("name") or raw.get("name")
+        if not isinstance(name, str) or not name:
+            continue
+        call_id = raw.get("id")
+        if not isinstance(call_id, str) or not call_id:
+            continue
+        # Look at the canonical location first (OpenAI's wire format), then
+        # fall back to a top-level "arguments" for proxies that flatten the
+        # shape.
+        args = (fn or {}).get("arguments")
+        if args is None:
+            args = raw.get("arguments")
+        if isinstance(args, str):
+            arguments = args
+        elif args is None:
+            arguments = ""
+        else:
+            # Dict/list at the ingest boundary: serialise once and stop
+            # touching. From here on the value is opaque.
+            try:
+                arguments = json.dumps(args, ensure_ascii=False, sort_keys=True)
+            except (TypeError, ValueError):
+                arguments = str(args)
+        out.append(
+            {
+                "id": call_id,
+                "type": "function",
+                "function": {"name": name, "arguments": arguments},
+            }
+        )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Conversation state
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Conversation:
+    """Append-only multi-turn conversation state for native tool calling.
+
+    The class is API-agnostic internally: the caller appends neutral events
+    (assistant text, assistant tool calls, tool result, user, system note)
+    and the wire-shape conversion happens at ``to_request_payload`` time.
+    Keeping the storage neutral means a single Conversation can be re-emitted
+    in either format and a unit test can assert on the normalised form
+    without duplicating assertions across the OpenAI and Anthropic shapes.
+    """
+
+    system: str = ""
+    # Ordered neutral events. Each item is a dict with a ``kind`` discriminator:
+    #   {"kind": "user", "content": str}
+    #   {"kind": "assistant_text", "content": str}
+    #   {"kind": "assistant_tool_calls", "calls": [{"id", "name", "arguments"}]}
+    #   {"kind": "tool_result", "call_id": str, "result": Any, "is_error": bool}
+    #   {"kind": "system_note", "content": str}   # verdict-turn transcript etc.
+    events: list[dict[str, Any]] = field(default_factory=list)
+
+    # ---- mutators --------------------------------------------------------
+
+    def add_user(self, content: str) -> None:
+        self.events.append({"kind": "user", "content": content})
+
+    def add_assistant_text(self, content: str) -> None:
+        self.events.append({"kind": "assistant_text", "content": content})
+
+    def add_assistant_tool_calls(self, calls: Iterable[dict[str, Any]]) -> None:
+        """Append an assistant turn carrying tool-call requests.
+
+        Each ``call`` is normalised to ``{"id", "name", "arguments"}``. Per
+        the #233 contract, ``arguments`` is treated as an opaque JSON string
+        end-to-end: a string is preserved verbatim (so malformed fragments
+        round-trip and the round-trip property holds for strict OpenAI
+        servers), and a dict/list is serialised **once at this boundary**
+        so the rest of the pipeline never has to think about it.
+        """
+        normalised: list[dict[str, Any]] = []
+        for call in calls:
+            if not isinstance(call, dict):
+                continue
+            name = call.get("name")
+            call_id = call.get("id")
+            if not isinstance(name, str) or not isinstance(call_id, str):
+                continue
+            args = call.get("arguments")
+            if isinstance(args, str):
+                arguments = args
+            elif args is None:
+                arguments = ""
+            else:
+                # Dict/list at the ingest boundary: serialise once, then
+                # never touch. Malformed values are coerced via str() so a
+                # bad model output still surfaces instead of disappearing.
+                try:
+                    arguments = json.dumps(args, ensure_ascii=False, sort_keys=True)
+                except (TypeError, ValueError):
+                    arguments = str(args)
+            normalised.append({"id": call_id, "name": name, "arguments": arguments})
+        if normalised:
+            self.events.append({"kind": "assistant_tool_calls", "calls": normalised})
+
+    def add_tool_result(
+        self,
+        call_id: str,
+        result: Any,
+        *,
+        is_error: bool = False,
+        max_bytes: int = TOOL_RESULT_MAX_BYTES,
+    ) -> None:
+        if not isinstance(call_id, str) or not call_id:
+            return
+        body = _stringify_tool_result(result)
+        body, _truncated = truncate_text(body, max_bytes)
+        self.events.append(
+            {
+                "kind": "tool_result",
+                "call_id": call_id,
+                "content": body,
+                "is_error": is_error,
+            }
+        )
+
+    def add_system_note(self, content: str) -> None:
+        if not content:
+            return
+        self.events.append({"kind": "system_note", "content": content})
+
+    # ---- introspection ---------------------------------------------------
+
+    def turns(self) -> int:
+        """Count of non-system turns — i.e. user + assistant + tool_result.
+
+        Useful for the loop driver to enforce a max-turns budget without
+        re-deriving it from the format-specific message list.
+        """
+        return sum(
+            1
+            for e in self.events
+            if e["kind"]
+            in ("user", "assistant_text", "assistant_tool_calls", "tool_result")
+        )
+
+    def open_tool_call_ids(self) -> set[str]:
+        """Call ids the model issued but no result has been recorded for yet.
+
+        The loop driver should not append a new turn while any call is open;
+        the executor must return a result (or a synthetic error result) for
+        every call before the conversation is sent back to the model.
+        """
+        called: set[str] = set()
+        answered: set[str] = set()
+        for e in self.events:
+            if e["kind"] == "assistant_tool_calls":
+                for c in e["calls"]:
+                    called.add(c["id"])
+            elif e["kind"] == "tool_result":
+                answered.add(e["call_id"])
+        return called - answered
+
+    def approx_tokens(self) -> int:
+        """Rough token estimate of the full conversation (system + events).
+
+        Counts UTF-8 byte length of the rendered text + a small per-message
+        overhead, then divides by ``APPROX_BYTES_PER_TOKEN``. Intentionally
+        coarse — the loop driver's stop conditions are the source of truth;
+        this is for in-loop "how big is the next request going to be" checks
+        and graceful truncation.
+        """
+        total_bytes = len(self.system.encode("utf-8"))
+        for e in self.events:
+            # 16 bytes/msg overhead approximates role/formatting tokens.
+            total_bytes += 16
+            if e["kind"] in ("user", "assistant_text", "system_note"):
+                total_bytes += len(e["content"].encode("utf-8"))
+            elif e["kind"] == "assistant_tool_calls":
+                for c in e["calls"]:
+                    total_bytes += len(c["name"].encode("utf-8"))
+                    total_bytes += len(c["arguments"].encode("utf-8"))
+            elif e["kind"] == "tool_result":
+                total_bytes += len(e["content"].encode("utf-8"))
+        return (total_bytes + APPROX_BYTES_PER_TOKEN - 1) // APPROX_BYTES_PER_TOKEN
+
+    # ---- overflow handling ----------------------------------------------
+
+    def truncate_oldest_tool_results(self, max_bytes_per_result: int) -> int:
+        """Shrink the oldest tool results so each fits within ``max_bytes_per_result``.
+
+        Newest results are left alone (they're what the model is acting on);
+        we only trim what is least likely to be re-referenced. Returns the
+        number of results that were actually shortened. The cut is
+        UTF-8/newline-safe (see :func:`truncate_text`).
+        """
+        # Walk in insertion order; keep trimming until every result is within
+        # budget OR we've already trimmed it once (so the loop can't keep
+        # shrinking the same block — a single re-cut usually lands well below
+        # the cap, so the bound is generous enough to be safe in practice).
+        shrunk = 0
+        for e in self.events:
+            if e["kind"] != "tool_result":
+                continue
+            body = e["content"]
+            if len(body.encode("utf-8")) <= max_bytes_per_result:
+                continue
+            new_body, _truncated = truncate_text(body, max_bytes_per_result)
+            if new_body != body:
+                e["content"] = new_body
+                shrunk += 1
+        return shrunk
+
+    # ---- wire emission ---------------------------------------------------
+
+    def _render_openai_messages(self) -> list[dict[str, Any]]:
+        """Render neutral events as an OpenAI-format messages list.
+
+        System lives at the top level (not in ``messages``). Tool results
+        become ``role: tool`` messages keyed by ``tool_call_id``. Assistant
+        tool calls are emitted on a single assistant message whose content
+        may be ``None`` when the model produced only tool_calls (matching
+        OpenAI's non-streaming schema).
+        """
+        messages: list[dict[str, Any]] = []
+        for e in self.events:
+            kind = e["kind"]
+            if kind == "user":
+                messages.append({"role": "user", "content": e["content"]})
+            elif kind == "assistant_text":
+                messages.append({"role": "assistant", "content": e["content"]})
+            elif kind == "assistant_tool_calls":
+                calls = normalize_assistant_tool_calls_openai(
+                    [
+                        {
+                            "id": c["id"],
+                            "function": {
+                                "name": c["name"],
+                                "arguments": c["arguments"],
+                            },
+                        }
+                        for c in e["calls"]
+                    ]
+                )
+                if not calls:
+                    continue
+                messages.append(
+                    {
+                        "role": "assistant",
+                        "content": None,
+                        "tool_calls": calls,
+                    }
+                )
+            elif kind == "tool_result":
+                messages.append(
+                    {
+                        "role": "tool",
+                        "tool_call_id": e["call_id"],
+                        "content": e["content"],
+                    }
+                )
+            # system_note is only used for the verdict turn — handled in
+            # to_request_payload, not here.
+        return messages
+
+    def _render_anthropic_messages(self) -> list[dict[str, Any]]:
+        """Render neutral events as an Anthropic-format messages list.
+
+        Anthropic has no ``role: system`` inside ``messages``; system lives
+        at the top level. Tool results become ``role: user`` messages whose
+        content is a list of ``{"type": "tool_result", "tool_use_id", …}``
+        blocks; multiple results from the same executor round are batched
+        onto a single user message to match Anthropic's batching convention.
+        Assistant tool calls become ``{"type": "tool_use", "id", "name",
+        "input"}`` content blocks; an assistant turn that has only text
+        becomes ``{"type": "text", "text": …}``.
+        """
+        messages: list[dict[str, Any]] = []
+        pending_tool_results: list[dict[str, Any]] = []
+
+        def _flush_tool_results() -> None:
+            nonlocal pending_tool_results
+            if pending_tool_results:
+                messages.append({"role": "user", "content": pending_tool_results})
+                pending_tool_results = []
+
+        for e in self.events:
+            kind = e["kind"]
+            if kind == "user":
+                _flush_tool_results()
+                messages.append({"role": "user", "content": e["content"]})
+            elif kind == "assistant_text":
+                _flush_tool_results()
+                messages.append(
+                    {
+                        "role": "assistant",
+                        "content": [{"type": "text", "text": e["content"]}],
+                    }
+                )
+            elif kind == "assistant_tool_calls":
+                _flush_tool_results()
+                blocks: list[dict[str, Any]] = []
+                # If a prior turn left text+tool_use interleaving to be done,
+                # callers add the text via a system_note or as the next
+                # assistant_text event; the loop driver should attach the
+                # text to this event when it knows both are present. The
+                # current catalogue doesn't do interleaved text+tool_use, so
+                # we emit a tool_use-only turn here.
+                for c in e["calls"]:
+                    try:
+                        input_value = (
+                            json.loads(c["arguments"]) if c["arguments"] else {}
+                        )
+                    except (json.JSONDecodeError, ValueError):
+                        # Some local models return fragmentary JSON in
+                        # arguments; surface it as a string rather than
+                        # dropping the call — the model can still see what
+                        # it asked for.
+                        input_value = {"_raw": c["arguments"]}
+                    blocks.append(
+                        {
+                            "type": "tool_use",
+                            "id": c["id"],
+                            "name": c["name"],
+                            "input": input_value,
+                        }
+                    )
+                if blocks:
+                    messages.append({"role": "assistant", "content": blocks})
+            elif kind == "tool_result":
+                block: dict[str, Any] = {
+                    "type": "tool_result",
+                    "tool_use_id": e["call_id"],
+                    "content": e["content"],
+                }
+                if e.get("is_error"):
+                    block["is_error"] = True
+                pending_tool_results.append(block)
+            # system_note is verdict-turn only — handled in to_request_payload.
+        _flush_tool_results()
+        return messages
+
+    def _verdict_transcript_note(self) -> str:
+        """Build the single system note summarising prior turns for the verdict.
+
+        Used when ``keep_full_history_on_verdict`` is False: the verdict turn
+        sees one consolidated system note instead of the full prior
+        conversation. The note lists the tool calls and their results (in
+        order) so the model can still reference evidence it gathered, and
+        it explicitly tells the model not to re-issue tool calls.
+        """
+        lines = [
+            "Prior tool-calling turns (reference only — do not re-issue any "
+            "tool calls; produce the final JSON verdict now).",
+        ]
+        for e in self.events:
+            if e["kind"] == "assistant_tool_calls":
+                for c in e["calls"]:
+                    try:
+                        args_obj = json.loads(c["arguments"]) if c["arguments"] else {}
+                    except (json.JSONDecodeError, ValueError):
+                        args_obj = {"_raw": c["arguments"]}
+                    lines.append(
+                        f"- assistant → {c['name']} {json.dumps(args_obj, sort_keys=True)}"
+                    )
+            elif e["kind"] == "tool_result":
+                head = e["content"].splitlines()[0] if e["content"] else ""
+                suffix = " [error]" if e.get("is_error") else ""
+                lines.append(f"  - result{suffix}: {head[:160]}")
+        return "\n".join(lines)
+
+    def to_request_payload(
+        self,
+        api_format: str,
+        model: str,
+        *,
+        stream: bool = False,
+        max_tokens: int = 4096,
+        temperature: float | None = None,
+        verdict_turn: bool = False,
+        keep_full_history_on_verdict: bool = False,
+        response_format: str | None = None,
+    ) -> dict[str, Any]:
+        """Render the conversation as a wire-ready request body.
+
+        Parameters mirror the bash ``build_model_request`` in
+        ``scripts/model_call.sh`` so the loop driver can drop in with
+        minimal reshuffling. ``verdict_turn=True`` triggers the
+        ``ai_response_format`` switch: ``tools`` is dropped, and the prior
+        conversation is either carried through (default off — see
+        ``keep_full_history_on_verdict``) or collapsed into a single system
+        note via :meth:`_verdict_transcript_note`.
+        """
+        if api_format == "anthropic":
+            return self._to_anthropic_payload(
+                model=model,
+                stream=stream,
+                max_tokens=max_tokens,
+                temperature=temperature,
+                verdict_turn=verdict_turn,
+                keep_full_history_on_verdict=keep_full_history_on_verdict,
+                response_format=response_format,
+            )
+        return self._to_openai_payload(
+            model=model,
+            stream=stream,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            verdict_turn=verdict_turn,
+            keep_full_history_on_verdict=keep_full_history_on_verdict,
+            response_format=response_format,
+        )
+
+    def _to_openai_payload(
+        self,
+        *,
+        model: str,
+        stream: bool,
+        max_tokens: int,
+        temperature: float | None,
+        verdict_turn: bool,
+        keep_full_history_on_verdict: bool,
+        response_format: str | None,
+    ) -> dict[str, Any]:
+        system = self.system
+        messages = self._render_openai_messages()
+
+        if verdict_turn:
+            if not keep_full_history_on_verdict:
+                system = (
+                    system + "\n\n" if system else ""
+                ) + self._verdict_transcript_note()
+                messages = []
+
+        payload: dict[str, Any] = {
+            "model": model,
+            "stream": stream,
+            "messages": [{"role": "system", "content": system}, *messages]
+            if system
+            else messages,
+        }
+        payload["max_tokens"] = max_tokens
+        if temperature is not None:
+            payload["temperature"] = temperature
+        if stream:
+            payload["stream_options"] = {"include_usage": True}
+        if verdict_turn and response_format in ("json_object", "json_schema"):
+            # Only attach tools + response_format on the relevant turn. The
+            # bash build_model_request supports json_object and json_schema;
+            # we mirror its shape so the loop driver can render the closing
+            # turn from the same Conversation object.
+            if response_format == "json_object":
+                payload["response_format"] = {"type": "json_object"}
+            elif response_format == "json_schema":
+                payload["response_format"] = _OPENAI_VERDICT_JSON_SCHEMA
+        else:
+            payload["tools"] = [_tool_to_openai(s) for s in TOOL_SCHEMAS]
+        return payload
+
+    def _to_anthropic_payload(
+        self,
+        *,
+        model: str,
+        stream: bool,
+        max_tokens: int,
+        temperature: float | None,
+        verdict_turn: bool,
+        keep_full_history_on_verdict: bool,
+        response_format: str | None,
+    ) -> dict[str, Any]:
+        system = self.system
+        messages = self._render_anthropic_messages()
+
+        if verdict_turn:
+            if not keep_full_history_on_verdict:
+                system = (
+                    system + "\n\n" if system else ""
+                ) + self._verdict_transcript_note()
+                messages = []
+
+        payload: dict[str, Any] = {
+            "model": model,
+            "max_tokens": max_tokens,
+            "stream": stream,
+            "system": system,
+            "messages": messages,
+        }
+        if temperature is not None:
+            payload["temperature"] = temperature
+        if not verdict_turn:
+            payload["tools"] = [_tool_to_anthropic(s) for s in TOOL_SCHEMAS]
+        # Anthropic has no response_format; the closing-turn contract relies
+        # on the system prompt to request JSON. response_format is silently
+        # ignored to keep the call sites uniform between the two APIs.
+        _ = response_format
+        return payload
+
+
+# ---------------------------------------------------------------------------
+# Format-specific tool schema conversion
+# ---------------------------------------------------------------------------
+
+
+def _tool_to_openai(schema: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "type": "function",
+        "function": {
+            "name": schema["name"],
+            "description": schema.get("description", ""),
+            "parameters": schema.get(
+                "parameters", {"type": "object", "properties": {}}
+            ),
+        },
+    }
+
+
+def _tool_to_anthropic(schema: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "name": schema["name"],
+        "description": schema.get("description", ""),
+        "input_schema": schema.get("parameters", {"type": "object", "properties": {}}),
+    }
+
+
+# Verdict-turn JSON schema for OpenAI strict mode. Mirrors the inline schema
+# in scripts/model_call.sh (kept in lockstep; the parser tolerates
+# null/absent/malformed findings either way).
+_OPENAI_VERDICT_JSON_SCHEMA: dict[str, Any] = {
+    "type": "json_schema",
+    "json_schema": {
+        "name": "pr_review",
+        "strict": True,
+        "schema": {
+            "type": "object",
+            "properties": {
+                "verdict": {"type": "string", "enum": ["approve", "request_changes"]},
+                "review_markdown": {"type": "string"},
+                "findings": {
+                    "type": ["array", "null"],
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "severity": {
+                                "type": "string",
+                                "enum": ["blocker", "major", "minor", "info"],
+                            },
+                            "category": {"type": ["string", "null"]},
+                            "file": {"type": ["string", "null"]},
+                            "line": {"type": ["integer", "null"]},
+                            "message": {"type": "string"},
+                        },
+                        "required": ["severity", "category", "file", "line", "message"],
+                        "additionalProperties": False,
+                    },
+                },
+            },
+            "required": ["verdict", "review_markdown", "findings"],
+            "additionalProperties": False,
+        },
+    },
+}

--- a/pr_reviewer/conversation.py
+++ b/pr_reviewer/conversation.py
@@ -165,6 +165,14 @@ TOOL_RESULT_MAX_BYTES = 8000
 # will own the authoritative stop conditions.
 APPROX_BYTES_PER_TOKEN = 4
 
+# Closing user turn for the collapsed verdict request: the prior history is
+# folded into the system note, but both APIs still need a non-empty messages
+# array (Anthropic 400s without a leading user message).
+VERDICT_USER_INSTRUCTION = (
+    "Produce the final review verdict now as a single JSON object. "
+    "Do not issue any tool calls."
+)
+
 
 # ---------------------------------------------------------------------------
 # Message normalisation
@@ -207,8 +215,8 @@ def truncate_text(text: str, max_bytes: int) -> tuple[str, bool]:
     if nl > 0:
         clip = clip[:nl]
         # Drop a trailing newline so the caller sees a clean line boundary
-        # (e.g. cap-of-5 on "a\nb\nc\nd\ne" yields "a\nb\nc", not
-        # "a\nb\nc\n"). Keeps the result on the right side of the cap.
+        # (e.g. cap-of-5 on "a\nb\nc\nd\ne" yields "a\nb"). Keeps the result
+        # on the right side of the cap.
         if clip.endswith(b"\n"):
             clip = clip[:-1]
     # Codepoint-safe fallback: clip may end mid-multibyte when no newline
@@ -320,11 +328,19 @@ class Conversation:
         for call in calls:
             if not isinstance(call, dict):
                 continue
-            name = call.get("name")
+            # Accept both the flat {"id","name","arguments"} form and the
+            # OpenAI nested {"id","function":{"name","arguments"}} form —
+            # the latter is exactly what sse_reassembler emits, so the
+            # natural reassembler → conversation pipeline must not silently
+            # drop calls.
+            fn = call.get("function") if isinstance(call.get("function"), dict) else {}
+            name = call.get("name") or fn.get("name")
             call_id = call.get("id")
             if not isinstance(name, str) or not isinstance(call_id, str):
                 continue
             args = call.get("arguments")
+            if args is None:
+                args = fn.get("arguments")
             if isinstance(args, str):
                 arguments = args
             elif args is None:
@@ -663,12 +679,15 @@ class Conversation:
         system = self.system
         messages = self._render_openai_messages()
 
-        if verdict_turn:
-            if not keep_full_history_on_verdict:
-                system = (
-                    system + "\n\n" if system else ""
-                ) + self._verdict_transcript_note()
-                messages = []
+        if verdict_turn and not keep_full_history_on_verdict:
+            system = (
+                system + "\n\n" if system else ""
+            ) + self._verdict_transcript_note()
+            # Collapsing must still leave a closing user turn: a messages
+            # array with no user message is degenerate on OpenAI and a hard
+            # 400 on Anthropic, and any instruction the driver appended would
+            # otherwise be wiped along with the history.
+            messages = [{"role": "user", "content": VERDICT_USER_INSTRUCTION}]
 
         payload: dict[str, Any] = {
             "model": model,
@@ -682,11 +701,11 @@ class Conversation:
             payload["temperature"] = temperature
         if stream:
             payload["stream_options"] = {"include_usage": True}
-        if verdict_turn and response_format in ("json_object", "json_schema"):
-            # Only attach tools + response_format on the relevant turn. The
-            # bash build_model_request supports json_object and json_schema;
-            # we mirror its shape so the loop driver can render the closing
-            # turn from the same Conversation object.
+        # The closing turn drops tools UNCONDITIONALLY — that is the
+        # verdict-turn contract. response_format is a separate, optional
+        # add-on (the bash build_model_request supports json_object and
+        # json_schema; we mirror its shapes).
+        if verdict_turn:
             if response_format == "json_object":
                 payload["response_format"] = {"type": "json_object"}
             elif response_format == "json_schema":
@@ -709,12 +728,13 @@ class Conversation:
         system = self.system
         messages = self._render_anthropic_messages()
 
-        if verdict_turn:
-            if not keep_full_history_on_verdict:
-                system = (
-                    system + "\n\n" if system else ""
-                ) + self._verdict_transcript_note()
-                messages = []
+        if verdict_turn and not keep_full_history_on_verdict:
+            system = (
+                system + "\n\n" if system else ""
+            ) + self._verdict_transcript_note()
+            # Anthropic requires a non-empty messages array starting with a
+            # user message — see the OpenAI counterpart for the rationale.
+            messages = [{"role": "user", "content": VERDICT_USER_INSTRUCTION}]
 
         payload: dict[str, Any] = {
             "model": model,

--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -1,0 +1,498 @@
+"""Tests for pr_reviewer.conversation (#202)."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest import main as unittest_main
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from pr_reviewer.conversation import (  # noqa: E402
+    APPROX_BYTES_PER_TOKEN,
+    TOOL_SCHEMAS,
+    Conversation,
+    normalize_assistant_tool_calls_openai,
+    truncate_text,
+)
+
+
+def _tool_names() -> set[str]:
+    return {s["name"] for s in TOOL_SCHEMAS}
+
+
+class TestToolSchemas:
+    def test_covers_executor_catalogue(self):
+        # Matches the executor surface in scripts/run_tool_harness.py
+        # (normalize_tool_request repair + the named-only run_command).
+        assert _tool_names() == {
+            "gh_api",
+            "read_file",
+            "web_fetch",
+            "git_grep",
+            "run_command",
+        }
+
+    def test_required_fields_present(self):
+        for schema in TOOL_SCHEMAS:
+            assert "name" in schema
+            params = schema["parameters"]
+            assert params["type"] == "object"
+            assert "properties" in params
+            assert "required" in params
+            assert params.get("additionalProperties") is False
+
+    def test_run_command_enum_matches_allowlist(self):
+        run_command = next(s for s in TOOL_SCHEMAS if s["name"] == "run_command")
+        enum = run_command["parameters"]["properties"]["command"]["enum"]
+        # The allowlist in scripts/run_tool_harness.py (ALLOWED_COMMANDS).
+        assert set(enum) == {"git_status_short", "git_diff_stat", "git_diff_name_only"}
+
+
+class TestTruncateText:
+    def test_no_truncation_under_limit(self):
+        out, truncated = truncate_text("hello\nworld", 100)
+        assert out == "hello\nworld"
+        assert truncated is False
+
+    def test_cuts_on_newline_boundary(self):
+        # Cap=5 on "a\nb\nc\nd\ne" (9 bytes). The latest \n at or before
+        # byte 5 is at byte 3 (between b and c); the algorithm returns the
+        # line-content up to that newline with any trailing \n stripped.
+        text = "a\nb\nc\nd\ne"
+        out, truncated = truncate_text(text, 5)
+        assert truncated is True
+        assert out == "a\nb"
+        # The cut must be under the cap, on a line boundary, and never
+        # include a partial trailing line.
+        assert len(out.encode("utf-8")) <= 5
+        assert not out.endswith("\n")
+
+    def test_zero_max_returns_empty(self):
+        out, truncated = truncate_text("anything", 0)
+        assert out == ""
+        assert truncated is True
+
+    def test_does_not_split_multibyte_char(self):
+        # "café" encodes to b"caf\xc3\xa9" (5 bytes); a 3-byte cap lands
+        # cleanly inside the ASCII prefix and must not slice the é.
+        text = "café latte"
+        out, _truncated = truncate_text(text, 3)
+        assert out == "caf"
+        assert "é" not in out
+
+    def test_no_newline_partial_byte_replaced_not_split(self):
+        # 4-byte cap on "café" (5 bytes) crosses a multibyte boundary; the
+        # output must be valid UTF-8 and must not silently drop a partial
+        # character as if it were a complete codepoint.
+        text = "café"
+        out, truncated = truncate_text(text, 4)
+        assert truncated is True
+        assert isinstance(out, str)
+        # Round-trips through encode/decode without raising.
+        out.encode("utf-8").decode("utf-8")
+        # The original multibyte sequence must not be preserved whole
+        # (we cut in the middle of it) nor leak as a bare high byte.
+        assert "é" not in out
+
+    def test_handles_no_newline_blob(self):
+        text = "x" * 1000
+        out, truncated = truncate_text(text, 50)
+        assert truncated is True
+        assert len(out.encode("utf-8")) <= 50
+
+
+class TestNormalizeAssistantToolCalls:
+    def test_passes_through_well_formed_calls(self):
+        calls = [
+            {
+                "id": "call_1",
+                "type": "function",
+                "function": {"name": "read_file", "arguments": '{"path": "x"}'},
+            }
+        ]
+        out = normalize_assistant_tool_calls_openai(calls)
+        assert len(out) == 1
+        assert out[0]["id"] == "call_1"
+        assert out[0]["type"] == "function"
+        assert out[0]["function"]["name"] == "read_file"
+        assert out[0]["function"]["arguments"] == '{"path": "x"}'
+
+    def test_accepts_dict_arguments_at_ingest_boundary(self):
+        # Dict arguments (e.g. from a non-reassembler caller) are serialised
+        # once here, then become opaque strings. Per the #233 contract, the
+        # round-trip property matters most: a string input must come back
+        # unchanged.
+        calls = [{"id": "call_1", "name": "git_grep", "arguments": {"pattern": "x"}}]
+        out = normalize_assistant_tool_calls_openai(calls)
+        assert out[0]["function"]["arguments"] == '{"pattern": "x"}'
+
+    def test_preserves_string_arguments_verbatim(self):
+        # The reassembler hands us a string — preserve it byte-for-byte so
+        # malformed fragments and the round-trip property both hold.
+        calls = [
+            {
+                "id": "call_1",
+                "type": "function",
+                "function": {"name": "x", "arguments": '{"pattern":'},
+            }
+        ]
+        out = normalize_assistant_tool_calls_openai(calls)
+        assert out[0]["function"]["arguments"] == '{"pattern":'
+
+    def test_drops_calls_missing_id(self):
+        calls = [{"function": {"name": "read_file", "arguments": "{}"}}]
+        assert normalize_assistant_tool_calls_openai(calls) == []
+
+    def test_drops_calls_missing_name(self):
+        calls = [{"id": "call_1", "function": {"arguments": "{}"}}]
+        assert normalize_assistant_tool_calls_openai(calls) == []
+
+    def test_drops_non_dict_entries(self):
+        calls = [
+            None,
+            "string",
+            42,
+            {"id": "call_1", "function": {"name": "x", "arguments": "{}"}},
+        ]
+        out = normalize_assistant_tool_calls_openai(calls)
+        assert len(out) == 1
+
+
+class TestConversationIntrospection:
+    def test_empty_conversation_turns(self):
+        assert Conversation().turns() == 0
+
+    def test_turns_counts_user_assistant_and_tool_results(self):
+        c = Conversation()
+        c.add_user("go")
+        c.add_assistant_text("thinking")
+        c.add_assistant_tool_calls([{"id": "1", "name": "x", "arguments": "{}"}])
+        c.add_tool_result("1", {"ok": True})
+        # user + assistant_text + assistant_tool_calls + tool_result = 4
+        assert c.turns() == 4
+
+    def test_open_tool_call_ids_tracks_unanswered_calls(self):
+        c = Conversation()
+        c.add_assistant_tool_calls(
+            [
+                {"id": "a", "name": "x", "arguments": "{}"},
+                {"id": "b", "name": "y", "arguments": "{}"},
+            ]
+        )
+        c.add_tool_result("a", "ok")
+        assert c.open_tool_call_ids() == {"b"}
+
+    def test_approx_tokens_grows_with_content(self):
+        empty = Conversation(system="sys")
+        populated = Conversation(system="sys")
+        populated.add_user("x" * 4000)
+        assert empty.approx_tokens() < populated.approx_tokens()
+        # The estimate should be in the same order of magnitude as the
+        # byte count (within the 4 bytes/token approximation).
+        assert (
+            (populated.approx_tokens() * APPROX_BYTES_PER_TOKEN) - 100
+            < len("x" * 4000)
+            < (populated.approx_tokens() * APPROX_BYTES_PER_TOKEN) + 100
+        )
+
+
+class TestConversationOverflow:
+    def test_truncates_all_results_over_the_cap(self):
+        # Both results are over the 1 KB cap; both get shrunk.
+        c = Conversation()
+        c.add_assistant_tool_calls(
+            [
+                {"id": "old", "name": "x", "arguments": "{}"},
+                {"id": "new", "name": "y", "arguments": "{}"},
+            ]
+        )
+        c.add_tool_result("old", "a" * 5000)
+        c.add_tool_result("new", "b" * 2000)
+
+        shrunk = c.truncate_oldest_tool_results(max_bytes_per_result=1000)
+        assert shrunk == 2
+        for call_id in ("old", "new"):
+            event = next(
+                e
+                for e in c.events
+                if e["kind"] == "tool_result" and e["call_id"] == call_id
+            )
+            assert len(event["content"].encode("utf-8")) <= 1000
+
+    def test_leaves_in_bounds_results_untouched(self):
+        # The "old" result is over the cap (shrunk); the "new" result is
+        # under it and must be byte-for-byte unchanged.
+        c = Conversation()
+        c.add_assistant_tool_calls(
+            [
+                {"id": "old", "name": "x", "arguments": "{}"},
+                {"id": "new", "name": "y", "arguments": "{}"},
+            ]
+        )
+        c.add_tool_result("old", "a" * 5000)
+        c.add_tool_result("new", "short")
+
+        shrunk = c.truncate_oldest_tool_results(max_bytes_per_result=1000)
+        assert shrunk == 1
+        new_event = next(
+            e for e in c.events if e["kind"] == "tool_result" and e["call_id"] == "new"
+        )
+        assert new_event["content"] == "short"
+
+
+class TestOpenAIPayload:
+    def test_basic_assistant_tool_round_trip(self):
+        c = Conversation(system="you are a reviewer")
+        c.add_user("please review this")
+        c.add_assistant_tool_calls(
+            [{"id": "call_1", "name": "read_file", "arguments": '{"path": "a.py"}'}]
+        )
+        c.add_tool_result("call_1", "print('hi')")
+
+        payload = c.to_request_payload("openai", "gpt-4o")
+        assert payload["model"] == "gpt-4o"
+        # System is hoisted out of the messages list.
+        assert payload["messages"][0] == {
+            "role": "system",
+            "content": "you are a reviewer",
+        }
+        # User turn comes next.
+        assert payload["messages"][1] == {
+            "role": "user",
+            "content": "please review this",
+        }
+        # Assistant tool_calls turn (content None per OpenAI's non-streaming schema).
+        assert payload["messages"][2]["role"] == "assistant"
+        assert payload["messages"][2]["content"] is None
+        assert payload["messages"][2]["tool_calls"][0]["id"] == "call_1"
+        assert (
+            payload["messages"][2]["tool_calls"][0]["function"]["name"] == "read_file"
+        )
+        # Tool result turn.
+        assert payload["messages"][3] == {
+            "role": "tool",
+            "tool_call_id": "call_1",
+            "content": "print('hi')",
+        }
+        # Top-level tools attach in non-verdict mode.
+        read_file = next(
+            t for t in payload["tools"] if t["function"]["name"] == "read_file"
+        )
+        assert read_file["type"] == "function"
+
+    def test_stream_adds_stream_options(self):
+        c = Conversation()
+        c.add_user("hi")
+        payload = c.to_request_payload("openai", "gpt-4o", stream=True)
+        assert payload["stream"] is True
+        assert payload["stream_options"] == {"include_usage": True}
+
+    def test_verdict_turn_drops_tools_and_attaches_response_format(self):
+        c = Conversation(system="reviewer")
+        c.add_user("review me")
+        c.add_assistant_tool_calls(
+            [{"id": "call_1", "name": "read_file", "arguments": "{}"}]
+        )
+        c.add_tool_result("call_1", "ok")
+
+        payload = c.to_request_payload(
+            "openai",
+            "gpt-4o",
+            verdict_turn=True,
+            response_format="json_schema",
+        )
+        # Verdict turn omits tools.
+        assert "tools" not in payload
+        # The conversation collapses into a system-prompt transcript note.
+        assert len(payload["messages"]) == 1
+        assert payload["messages"][0]["role"] == "system"
+        note = payload["messages"][0]["content"]
+        assert "do not re-issue" in note
+        assert "read_file" in note
+        # response_format is the strict verdict schema.
+        assert payload["response_format"]["type"] == "json_schema"
+        assert payload["response_format"]["json_schema"]["name"] == "pr_review"
+
+    def test_verdict_turn_keep_full_history(self):
+        c = Conversation()
+        c.add_user("review me")
+        c.add_assistant_tool_calls(
+            [{"id": "call_1", "name": "read_file", "arguments": "{}"}]
+        )
+        c.add_tool_result("call_1", "ok")
+
+        payload = c.to_request_payload(
+            "openai",
+            "gpt-4o",
+            verdict_turn=True,
+            response_format="json_object",
+            keep_full_history_on_verdict=True,
+        )
+        # History is preserved; no consolidated system note replaces it.
+        assert "tools" not in payload
+        # 1 user + 1 assistant + 1 tool = 3 messages; system lives in system.
+        assert any(m["role"] == "tool" for m in payload["messages"])
+        assert payload["response_format"] == {"type": "json_object"}
+
+    def test_no_system_prompt_omits_system_message(self):
+        c = Conversation()
+        c.add_user("hi")
+        payload = c.to_request_payload("openai", "gpt-4o")
+        # No system role; the first message is the user.
+        assert payload["messages"][0]["role"] == "user"
+
+
+class TestAnthropicPayload:
+    def test_basic_assistant_tool_round_trip(self):
+        c = Conversation(system="reviewer")
+        c.add_user("please review this")
+        c.add_assistant_tool_calls(
+            [{"id": "call_1", "name": "read_file", "arguments": '{"path": "a.py"}'}]
+        )
+        c.add_tool_result("call_1", "print('hi')")
+
+        payload = c.to_request_payload("anthropic", "claude-3-5-sonnet")
+        assert payload["model"] == "claude-3-5-sonnet"
+        assert payload["system"] == "reviewer"
+        # No role:system message in the messages list.
+        assert all(m["role"] != "system" for m in payload["messages"])
+        # User turn.
+        assert payload["messages"][0] == {
+            "role": "user",
+            "content": "please review this",
+        }
+        # Assistant tool_use turn.
+        assistant_turn = payload["messages"][1]
+        assert assistant_turn["role"] == "assistant"
+        assert assistant_turn["content"][0]["type"] == "tool_use"
+        assert assistant_turn["content"][0]["id"] == "call_1"
+        assert assistant_turn["content"][0]["name"] == "read_file"
+        assert assistant_turn["content"][0]["input"] == {"path": "a.py"}
+        # Tool result turn (batched into a single user message).
+        result_turn = payload["messages"][2]
+        assert result_turn["role"] == "user"
+        assert result_turn["content"][0]["type"] == "tool_result"
+        assert result_turn["content"][0]["tool_use_id"] == "call_1"
+
+    def test_assistant_text_emits_text_block(self):
+        c = Conversation()
+        c.add_user("hi")
+        c.add_assistant_text("thinking out loud")
+        payload = c.to_request_payload("anthropic", "claude-3-5-sonnet")
+        assistant_turn = payload["messages"][1]
+        assert assistant_turn["content"] == [
+            {"type": "text", "text": "thinking out loud"}
+        ]
+
+    def test_multiple_tool_results_batched_into_one_user_turn(self):
+        c = Conversation()
+        c.add_user("hi")
+        c.add_assistant_tool_calls(
+            [
+                {"id": "a", "name": "read_file", "arguments": "{}"},
+                {"id": "b", "name": "git_grep", "arguments": '{"pattern": "x"}'},
+            ]
+        )
+        c.add_tool_result("a", "alpha")
+        c.add_tool_result("b", "beta")
+
+        payload = c.to_request_payload("anthropic", "claude-3-5-sonnet")
+        # Expect user, assistant(tool_use x2), user(tool_result x2)
+        assert len(payload["messages"]) == 3
+        result_turn = payload["messages"][2]
+        assert result_turn["role"] == "user"
+        ids = [c["tool_use_id"] for c in result_turn["content"]]
+        assert ids == ["a", "b"]
+
+    def test_tool_error_sets_is_error_block(self):
+        c = Conversation()
+        c.add_assistant_tool_calls(
+            [{"id": "a", "name": "read_file", "arguments": "{}"}]
+        )
+        c.add_tool_result("a", "boom", is_error=True)
+        payload = c.to_request_payload("anthropic", "claude-3-5-sonnet")
+        result_turn = next(m for m in payload["messages"] if m["role"] == "user")
+        assert result_turn["content"][0]["is_error"] is True
+
+    def test_anthropic_input_parses_arguments_json(self):
+        c = Conversation()
+        c.add_assistant_tool_calls(
+            [{"id": "a", "name": "git_grep", "arguments": '{"pattern": "auth"}'}]
+        )
+        payload = c.to_request_payload("anthropic", "claude-3-5-sonnet")
+        assistant_turn = payload["messages"][0]
+        assert assistant_turn["content"][0]["input"] == {"pattern": "auth"}
+
+    def test_anthropic_keeps_raw_arguments_on_invalid_json(self):
+        # Local models sometimes return fragmentary JSON in tool args. The
+        # wire shape must still carry the data through (Anthropic's input is
+        # typed as object, but receiving an unparseable value as a string
+        # marker is preferable to silently dropping the call).
+        c = Conversation()
+        c.add_assistant_tool_calls(
+            [{"id": "a", "name": "git_grep", "arguments": '{"pattern":'}]
+        )
+        payload = c.to_request_payload("anthropic", "claude-3-5-sonnet")
+        assistant_turn = payload["messages"][0]
+        assert assistant_turn["content"][0]["input"] == {"_raw": '{"pattern":'}
+
+    def test_anthropic_tools_omit_input_schema_naming_differences(self):
+        c = Conversation()
+        c.add_user("hi")
+        payload = c.to_request_payload("anthropic", "claude-3-5-sonnet")
+        names = {t["name"] for t in payload["tools"]}
+        assert names == _tool_names()
+        # Anthropic uses input_schema, not parameters.
+        assert "input_schema" in payload["tools"][0]
+        assert "parameters" not in payload["tools"][0]
+
+    def test_anthropic_verdict_turn_drops_tools(self):
+        c = Conversation()
+        c.add_user("review me")
+        c.add_assistant_tool_calls(
+            [{"id": "a", "name": "read_file", "arguments": "{}"}]
+        )
+        c.add_tool_result("a", "ok")
+
+        payload = c.to_request_payload(
+            "anthropic", "claude-3-5-sonnet", verdict_turn=True
+        )
+        assert "tools" not in payload
+        # History collapses to a system note; messages are empty.
+        assert payload["messages"] == []
+        assert "do not re-issue" in payload["system"]
+
+
+class TestCrossFormat:
+    def test_openai_and_anthropic_emit_equivalent_tool_schemas(self):
+        # Every tool the catalogue advertises should appear in both formats.
+        c = Conversation()
+        c.add_user("hi")
+        oa = c.to_request_payload("openai", "gpt-4o")["tools"]
+        an = c.to_request_payload("anthropic", "claude-3-5-sonnet")["tools"]
+        oa_names = {t["function"]["name"] for t in oa}
+        an_names = {t["name"] for t in an}
+        assert oa_names == an_names == _tool_names()
+
+    def test_payload_is_json_serialisable(self):
+        # Sanity: a payload containing both text and tool turns must
+        # round-trip through json.dumps — catches accidental dataclass /
+        # set leakage.
+        c = Conversation(system="sys")
+        c.add_user("go")
+        c.add_assistant_tool_calls([{"id": "a", "name": "x", "arguments": '{"k": 1}'}])
+        c.add_tool_result("a", {"result": "ok"})
+        for api_format, model in (
+            ("openai", "gpt-4o"),
+            ("anthropic", "claude-3-5-sonnet"),
+        ):
+            payload = c.to_request_payload(api_format, model)
+            serialised = json.dumps(payload)
+            assert isinstance(serialised, str)
+
+
+if __name__ == "__main__":
+    unittest_main()

--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -306,9 +306,10 @@ class TestOpenAIPayload:
         )
         # Verdict turn omits tools.
         assert "tools" not in payload
-        # The conversation collapses into a system-prompt transcript note.
-        assert len(payload["messages"]) == 1
-        assert payload["messages"][0]["role"] == "system"
+        # The conversation collapses into a system-prompt transcript note,
+        # plus one closing user instruction (an array without a user message
+        # is degenerate on OpenAI and a hard 400 on Anthropic).
+        assert [m["role"] for m in payload["messages"]] == ["system", "user"]
         note = payload["messages"][0]["content"]
         assert "do not re-issue" in note
         assert "read_file" in note
@@ -461,8 +462,9 @@ class TestAnthropicPayload:
             "anthropic", "claude-3-5-sonnet", verdict_turn=True
         )
         assert "tools" not in payload
-        # History collapses to a system note; messages are empty.
-        assert payload["messages"] == []
+        # History collapses to a system note; one closing user instruction
+        # remains (Anthropic requires a non-empty messages array).
+        assert [m["role"] for m in payload["messages"]] == ["user"]
         assert "do not re-issue" in payload["system"]
 
 
@@ -492,6 +494,91 @@ class TestCrossFormat:
             payload = c.to_request_payload(api_format, model)
             serialised = json.dumps(payload)
             assert isinstance(serialised, str)
+
+
+class TestVerdictTurnContract:
+    """The closing turn drops tools and stays wire-valid (review findings)."""
+
+    def _conv(self):
+        c = Conversation(system="sys")
+        c.add_user("review this")
+        c.add_assistant_tool_calls(
+            [{"id": "c1", "name": "read_file", "arguments": '{"path": "x"}'}]
+        )
+        c.add_tool_result("c1", {"data": "ok"})
+        return c
+
+    def test_verdict_turn_drops_tools_even_without_response_format(self):
+        # The tools-drop is the verdict-turn contract itself, not a side
+        # effect of response_format: ai_response_format=off must not leave
+        # the tool catalogue attached to the closing call.
+        p = self._conv().to_request_payload(
+            "openai", "m", verdict_turn=True, response_format=None
+        )
+        assert "tools" not in p
+        assert "response_format" not in p
+
+    def test_collapsed_verdict_turn_keeps_a_user_message_openai(self):
+        p = self._conv().to_request_payload(
+            "openai", "m", verdict_turn=True, response_format="json_object"
+        )
+        roles = [m["role"] for m in p["messages"]]
+        assert roles == ["system", "user"]
+
+    def test_collapsed_verdict_turn_keeps_a_user_message_anthropic(self):
+        # Anthropic hard-400s on an empty messages array; the collapsed
+        # verdict turn must carry a closing user instruction.
+        p = self._conv().to_request_payload(
+            "anthropic", "m", verdict_turn=True, response_format="json_object"
+        )
+        assert len(p["messages"]) == 1
+        assert p["messages"][0]["role"] == "user"
+        assert p["messages"][0]["content"]
+        assert "tools" not in p
+
+    def test_full_history_verdict_turn_preserves_messages(self):
+        p = self._conv().to_request_payload(
+            "openai",
+            "m",
+            verdict_turn=True,
+            keep_full_history_on_verdict=True,
+            response_format="json_object",
+        )
+        roles = [m["role"] for m in p["messages"]]
+        assert "tool" in roles
+        assert "tools" not in p
+
+
+class TestReassemblerShapeIngest:
+    """add_assistant_tool_calls accepts sse_reassembler's nested output."""
+
+    def test_nested_function_shape_is_recorded(self):
+        # sse_reassembler emits {"id", "type", "function": {"name",
+        # "arguments"}}; the natural reassembler → conversation pipeline
+        # must not silently drop calls.
+        c = Conversation()
+        c.add_assistant_tool_calls(
+            [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "read_file", "arguments": '{"path": "x"}'},
+                }
+            ]
+        )
+        events = [e for e in c.events if e["kind"] == "assistant_tool_calls"]
+        assert len(events) == 1
+        call = events[0]["calls"][0]
+        assert call["name"] == "read_file"
+        assert call["arguments"] == '{"path": "x"}'
+
+    def test_flat_shape_still_works(self):
+        c = Conversation()
+        c.add_assistant_tool_calls(
+            [{"id": "call_2", "name": "git_grep", "arguments": '{"pattern": "p"}'}]
+        )
+        events = [e for e in c.events if e["kind"] == "assistant_tool_calls"]
+        assert events[0]["calls"][0]["name"] == "git_grep"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #202

## What

Adds `pr_reviewer/conversation.py` — a pure-Python, I/O-free stateful builder for the OpenAI and Anthropic message shapes that the native tool-calling loop needs. The bash `build_model_request` in `scripts/model_call.sh` only knows single-shot `system+user`; this module owns the multi-turn shape so the loop driver in 3/7 can be a thin caller.

## Surface

- **`TOOL_SCHEMAS`** — JSON-Schema definitions for `gh_api`, `read_file`, `web_fetch`, `git_grep`, `run_command`. The `run_command` enum matches the executor's `ALLOWED_COMMANDS` allowlist.
- **`Conversation`** — append-only neutral event store. Mutators: `add_user`, `add_assistant_text`, `add_assistant_tool_calls`, `add_tool_result`, `add_system_note`. Introspection: `turns()`, `open_tool_call_ids()`, `approx_tokens()`. Overflow: `truncate_oldest_tool_results(max_bytes)` (UTF-8/newline-safe).
- **`to_request_payload(api_format, model, *, stream, max_tokens, temperature, verdict_turn, keep_full_history_on_verdict, response_format)`** — renders the wire body for both APIs.
- **`truncate_text`, `normalize_assistant_tool_calls_openai`** — small helpers exported for callers (e.g. the loop driver passing a reassembler-shaped `tool_calls` list straight into `add_assistant_tool_calls`).

## Verdict-turn switch (§1 "Mode switching vs ai_response_format")

`verdict_turn=True` is the closing-turn flag. Behaviour:

- **`tools` is dropped** on the wire so the strict `response_format` (`json_object` / `json_schema`) is accepted unimpeded. The OpenAI strict-mode `pr_review` schema is mirrored verbatim from `scripts/model_call.sh`.
- **History collapse default** — the accumulated conversation collapses into a single system-prompt transcript note (tool calls + result heads, "do not re-issue any tool calls" preamble). Cheapest tokens, mirrors today's single-shot contract.
- **`keep_full_history_on_verdict=True`** carries the full prior conversation through; the loop driver (3/7) can opt in per-route (e.g. smart route keeps history, fast route collapses).

Anthropic has no `response_format`; the parameter is silently accepted to keep the call sites uniform between APIs.

## #233 contract: string-args end-to-end

`function.arguments` is treated as an opaque JSON-encoded string end-to-end (OpenAI non-streaming schema):

- A string is **preserved verbatim** — malformed fragments from truncated streams round-trip, and the strict-server round-trip property holds for the assistant message echoed back on the next turn.
- A dict is serialised **once at the ingest boundary** (`add_assistant_tool_calls` / `normalize_assistant_tool_calls_openai`), then never touched again.
- The Anthropic render path is the exception (it requires an object in `tool_use.input`) and parses with a malformed-fallback to `{"_raw": ...}` so a bad fragment surfaces as data rather than disappearing.

## Tool-result batching (Anthropic)

Multiple tool results from the same executor round batch onto a single `role: user` message with multiple `tool_result` content blocks, matching Anthropic's batching convention. The OpenAI render emits one `role: tool` message per call (the OpenAI contract).

## Tests

`tests/test_conversation.py` (36 cases):

- `TestToolSchemas` — catalogue coverage and `run_command` enum
- `TestTruncateText` — newline boundary, multibyte safety (don't split a codepoint), partial-byte replacement, no-newline blob
- `TestNormalizeAssistantToolCalls` — well-formed pass-through, dict ingest at the boundary, string verbatim preservation, drop-on-missing-id/name, drop-non-dict
- `TestConversationIntrospection` — empty, turn count, open call ids, token estimate
- `TestConversationOverflow` — over-budget results shrunk, in-bounds untouched
- `TestOpenAIPayload` — full round-trip, `stream_options`, verdict-turn drop-tools + attach-`response_format`, verdict-turn keep-full-history, no-system-prompt
- `TestAnthropicPayload` — full round-trip, assistant_text block, multi-result batching, `is_error`, JSON-input parse, malformed-input fallback, `input_schema` shape, verdict-turn drop-tools
- `TestCrossFormat` — equivalent tool coverage and `json.dumps` serialisability

## Validation

- `python3 -m py_compile pr_reviewer/conversation.py` → ok
- `python3 -m pytest tests/test_conversation.py -v` → 36 passed
- `python3 -m pytest tests/` → **706 passed** (no regressions)

## Out of scope

- Wire-up into `build_model_request` / `model_call.sh` / `run_review.sh` — that lives in 3/7 (the loop driver) so this module stays endpoint-free and unit-testable.
- Tool-surface expansion (read_file line ranges, git_log, git_blame) — §3 in #197, separate work.
- Taint tracking / per-tool provenance labels — §4 in #197, ships *with* the loop driver rather than the builder.
- The `verdict_turn` transcript summariser is intentionally simple; §2 "Result summarization between rounds" in #197 is a more general upgrade that should live with the loop driver.
