### PR TITLE
feat: platform abstraction seam — github backend, zero behavior change (#221)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ The action collects rich PR context (diff, files, linked issues, version hints, 
 ### Action definition and orchestration
 
 - **`action.yml`** — Action definition with all inputs/outputs and composite run steps (precheck → CI wait → review → publish). The publish steps live inline in this file using helpers from `scripts/publish_helpers.sh`.
+- **`scripts/platform_api.sh`** — Platform seam (#221): every host-forge API call goes through `platform_*` functions (github backend = the exact pre-seam `gh` invocations; forgejo backend = `pr_reviewer/forgejo_backend.py`, rolling out across 1.4.x). `github_enrich_*` functions are for linked-source enrichment and always target github.com. `pr_reviewer/platform.py` is the Python mirror for script consumers.
 - **`scripts/check_review_needed.sh`** — Precheck: computes `git patch-id --stable` fingerprint, decides full vs. incremental scope, and skips if unchanged since last managed comment (unless `force_review=true`)
 - **`scripts/parse_review_command.sh`** — Authorization gate for an on-demand re-review command (`/ai-review`): matches the command in a comment and requires the commenter to have `write`/`admin` via the collaborators API before honoring it
 - **`scripts/wait_for_ci.sh`** — Optional CI gating: polls the Checks API until checks reach a terminal state (`ci_status_check=true`), then renders the per-check outcomes to `CI_CHECKS_FILE` for the review corpus

--- a/README.md
+++ b/README.md
@@ -327,6 +327,7 @@ Only three inputs are required: `github_token`, `ai_base_url`, and `ai_model`. E
 | Input | Description | Required | Default |
 |-------|-------------|----------|---------|
 | `review_scope` | Controls whether the action reviews the full PR or only changes since the last managed review. Accepted values: `auto` (default, full on first run, incremental on later safe updates), `full` (always full review), `incremental` (delta review, falls back to full if prior metadata unavailable) | No | `auto` |
+| `platform` | Host forge backend: `auto` (detect from `GITHUB_SERVER_URL`), `github`, or `forgejo` (requires `FORGEJO_API_URL`; support rolling out across 1.4.x — unimplemented operations fail loudly). Linked-source enrichment always targets github.com | No | `auto` |
 | `skip_if_diff_unchanged` | Skip the LLM review when the current PR patch matches the last managed review fingerprint | No | `true` |
 | `force_review` | Bypass the diff-unchanged guard and review even when the fingerprint matches. For an on-demand re-review (e.g. an `/ai-review` comment or `repository_dispatch`) when the diff is unchanged but the model/standards changed | No | `false` |
 | `ci_status_check` | Wait for all CI checks to reach a terminal state before starting the AI review. Default false — immediate review. | No | `false` |

--- a/action.yml
+++ b/action.yml
@@ -380,6 +380,17 @@ inputs:
     description: Timeout in seconds for the fallback model API connection (curl --connect-timeout). Defaults to ai_connect_timeout_sec when blank.
     required: false
     default: ""
+  platform:
+    description: >-
+      Host forge backend for repository API operations. auto (default)
+      detects from GITHUB_SERVER_URL (non-github.com hosts resolve to
+      forgejo); github forces the gh CLI backend; forgejo uses the Forgejo
+      /api/v1 REST backend (requires FORGEJO_API_URL in the environment;
+      Forgejo support is rolling out across the 1.4.x line — unimplemented
+      operations fail loudly). Linked-source enrichment always targets
+      github.com regardless of this setting.
+    required: false
+    default: "auto"
   skip_if_diff_unchanged:
     description: If true, skip the LLM review when the effective PR diff matches the last managed review comment fingerprint
     required: false
@@ -486,6 +497,7 @@ runs:
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.github_token }}
+        PLATFORM: ${{ inputs.platform }}
         REPO: ${{ inputs.repo || github.repository }}
         PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
         COMMENT_MARKER: ${{ inputs.comment_marker }}
@@ -547,6 +559,7 @@ runs:
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.github_token }}
+        PLATFORM: ${{ inputs.platform }}
         REPO: ${{ inputs.repo || github.repository }}
         PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
         PR_HEAD_SHA: ${{ github.event.pull_request.head.sha || steps.precheck.outputs.head_sha }}
@@ -563,6 +576,7 @@ runs:
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.github_token }}
+        PLATFORM: ${{ inputs.platform }}
         REPO: ${{ inputs.repo || github.repository }}
         PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
         AI_BASE_URL: ${{ inputs.ai_base_url }}
@@ -648,6 +662,7 @@ runs:
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.github_token }}
+        PLATFORM: ${{ inputs.platform }}
         REPO: ${{ inputs.repo || github.repository }}
         PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
         HEAD_SHA: ${{ github.event.pull_request.head.sha || steps.precheck.outputs.head_sha }}
@@ -706,13 +721,14 @@ runs:
           cat review-markdown.raw.md
         } > review-comment.md
 
-        gh pr comment "$PR_NUMBER" --repo "$REPO" --edit-last --create-if-none --body-file review-comment.md
+        platform_comment_sticky "$REPO" "$PR_NUMBER" review-comment.md
 
     - name: Publish review comment (non-blocking)
       if: inputs.publish_mode == 'review_comment' && steps.precheck.outputs.should_review == 'true'
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.github_token }}
+        PLATFORM: ${{ inputs.platform }}
         REPO: ${{ inputs.repo || github.repository }}
         PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
         HEAD_SHA: ${{ github.event.pull_request.head.sha || steps.precheck.outputs.head_sha }}
@@ -783,7 +799,7 @@ runs:
 
         # NOTE: gh pr review --comment creates a COMMENTED review that is NOT visible in the PR UI timeline.
         # Use gh pr comment instead for visibility, with --edit-last/--create-if-none for sticky behavior.
-        gh pr comment "$PR_NUMBER" --repo "$REPO" --edit-last --create-if-none --body-file "$BODY_FILE"
+        platform_comment_sticky "$REPO" "$PR_NUMBER" "$BODY_FILE"
 
         # Resolve threads of carried findings this review verified as fixed,
         # and reply on threads still open (#208, #209). Must precede the
@@ -807,7 +823,7 @@ runs:
             } > inline-findings-body.md
             jq -n --rawfile body inline-findings-body.md --argjson comments "$COMMENTS_JSON" \
               '{body: $body, event: "COMMENT", comments: $comments}' > review-request.json
-            if gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" --method POST --input review-request.json >/dev/null 2>&1; then
+            if platform_review_create_json "$REPO" "$PR_NUMBER" review-request.json >/dev/null 2>&1; then
               echo "Attached $(printf '%s' "$COMMENTS_JSON" | jq 'length') inline finding comment(s)"
             else
               echo "WARN: inline findings review submission failed; summary comment was still published" >&2
@@ -820,6 +836,7 @@ runs:
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.github_token }}
+        PLATFORM: ${{ inputs.platform }}
         REPO: ${{ inputs.repo || github.repository }}
         PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
         HEAD_SHA: ${{ github.event.pull_request.head.sha || steps.precheck.outputs.head_sha }}
@@ -856,7 +873,7 @@ runs:
         # the PR object; only fall back to the API when its output is missing.
         IS_FORK_PR="${{ steps.precheck.outputs.is_fork_pr }}"
         if [ -z "$IS_FORK_PR" ]; then
-          IS_FORK_PR="$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '((.head.repo.full_name // "") != (.base.repo.full_name // ""))' 2>/dev/null || echo false)"
+          IS_FORK_PR="$(platform_pr_get "$REPO" "$PR_NUMBER" --jq '((.head.repo.full_name // "") != (.base.repo.full_name // ""))' 2>/dev/null || echo false)"
         fi
 
         # Resolve effective scope and review result
@@ -945,15 +962,15 @@ runs:
           if [ -n "$COMMENTS_JSON" ] && [ "$COMMENTS_JSON" != "[]" ]; then
             jq -n --rawfile body "$body_file" --arg event "$event" --argjson comments "$COMMENTS_JSON" \
               '{body: $body, event: $event, comments: $comments}' > review-request.json
-            if gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" --method POST --input review-request.json >/dev/null 2>&1; then
+            if platform_review_create_json "$REPO" "$PR_NUMBER" review-request.json >/dev/null 2>&1; then
               echo "Submitted native review ($event) with $(printf '%s' "$COMMENTS_JSON" | jq 'length') inline comment(s)"
               return 0
             fi
             echo "WARN: inline-comment review submission failed; falling back to plain review" >&2
           fi
           case "$event" in
-            APPROVE) gh pr review "$PR_NUMBER" --repo "$REPO" --approve --body-file "$body_file" ;;
-            *) gh pr review "$PR_NUMBER" --repo "$REPO" --request-changes --body-file "$body_file" ;;
+            APPROVE) platform_review_native "$REPO" "$PR_NUMBER" APPROVE "$body_file" ;;
+            *) platform_review_native "$REPO" "$PR_NUMBER" REQUEST_CHANGES "$body_file" ;;
           esac
         }
 

--- a/pr_reviewer/platform.py
+++ b/pr_reviewer/platform.py
@@ -1,0 +1,50 @@
+"""Python side of the platform seam (issue #221).
+
+Mirror of ``scripts/platform_api.sh`` for the Python consumers
+(``scripts/resolve_finding_threads.py`` now; ``scripts/run_tool_harness.py``'s
+``gh_api`` tool migrates here in #226). The github backend is argv-identical
+to the pre-seam code; forgejo support arrives per-consumer across the 1.4.x
+line, and until then unsupported operations raise instead of failing silently.
+"""
+
+from __future__ import annotations
+
+import os
+
+
+class PlatformUnsupported(RuntimeError):
+    """Raised when an operation has no implementation for the active platform."""
+
+
+def resolve_platform() -> str:
+    """Resolve PLATFORM (github|forgejo|auto) to a concrete backend name.
+
+    Mirrors ``platform_resolve`` in scripts/platform_api.sh: ``auto`` maps to
+    forgejo when GITHUB_SERVER_URL names a non-github.com host (Forgejo
+    Actions runners populate it with the instance URL), github otherwise.
+    """
+    platform = os.environ.get("PLATFORM", "github").strip().lower() or "github"
+    if platform == "auto":
+        server = os.environ.get("GITHUB_SERVER_URL", "").rstrip("/")
+        if server and server != "https://github.com":
+            return "forgejo"
+        return "github"
+    if platform in ("github", "forgejo"):
+        return platform
+    raise ValueError(f"unsupported PLATFORM {platform!r} (expected github|forgejo|auto)")
+
+
+def gh_argv(args: list) -> list:
+    """Return the argv for a host-platform CLI call.
+
+    github: ``["gh", *args]`` — byte-identical to the pre-seam invocations.
+    forgejo: raises PlatformUnsupported; the consumers that reach this
+    (finding-thread resolution, the tool harness) get Forgejo backends in
+    #224/#226.
+    """
+    if resolve_platform() == "forgejo":
+        raise PlatformUnsupported(
+            "gh CLI operations are not available on PLATFORM=forgejo; "
+            "this consumer's Forgejo backend lands later in the 1.4.x line"
+        )
+    return ["gh", *args]

--- a/scripts/check_review_needed.sh
+++ b/scripts/check_review_needed.sh
@@ -11,6 +11,8 @@ REVIEW_SCOPE="${REVIEW_SCOPE:-auto}"
 PUBLISH_MODE="${PUBLISH_MODE:-comment}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 export PYTHONPATH="${SCRIPT_DIR}/..${PYTHONPATH:+:${PYTHONPATH}}"
+# shellcheck source=scripts/platform_api.sh
+source "${SCRIPT_DIR}/platform_api.sh"
 
 if [[ -z "$REPO" || -z "$PR_NUMBER" ]]; then
   echo "Missing REPO or PR_NUMBER for review precheck" >&2
@@ -22,7 +24,7 @@ fi
 # to a fresh review instead of aborting the action. The diff is saved to
 # pr.diff so run_review.sh can reuse it instead of fetching it a second time —
 # this also guarantees the reviewed diff is the one that was fingerprinted.
-if ! gh pr diff "$PR_NUMBER" --repo "$REPO" > pr.diff 2>/dev/null; then
+if ! platform_pr_diff "$REPO" "$PR_NUMBER" > pr.diff 2>/dev/null; then
   : > pr.diff
 fi
 current_fingerprint="$(git patch-id --stable < pr.diff | awk 'NR == 1 { print $1 }' || true)"
@@ -201,7 +203,7 @@ broad_fingerprint="${current_fingerprint}|cfg:${config_hash}"
 # submits a native PR review. Look in the right place so skip-if-unchanged
 # and incremental scope can find prior state in every mode.
 last_managed_comment_body() {
-  gh api "repos/$REPO/issues/$PR_NUMBER/comments?per_page=100" 2>/dev/null | \
+  platform_issue_comments "$REPO" "$PR_NUMBER" 2>/dev/null | \
     jq -r --arg marker "$COMMENT_MARKER" '
       [ .[] | select((.body // "") | contains($marker)) ]
       | sort_by(.updated_at // .created_at)
@@ -211,7 +213,7 @@ last_managed_comment_body() {
 }
 
 last_managed_review_body() {
-  gh api "repos/$REPO/pulls/$PR_NUMBER/reviews?per_page=100" 2>/dev/null | \
+  platform_pr_reviews "$REPO" "$PR_NUMBER" 2>/dev/null | \
     jq -r --arg marker "$COMMENT_MARKER" '
       [ .[] | select((.body // "") | contains($marker)) ]
       | sort_by(.submitted_at // "")
@@ -396,7 +398,7 @@ resolve_review_scope() {
   fi
 
   # Check: compare API still works for this range
-  if ! gh api "repos/$REPO/compare/${last_head_sha}...${current_head_sha}" >/dev/null 2>&1; then
+  if ! platform_compare "$REPO" "${last_head_sha}...${current_head_sha}" >/dev/null 2>&1; then
     echo "Review scope fallback: compare API failed for $last_head_sha...$current_head_sha" >&2
     EFFECTIVE_SCOPE="full"
     PREVIOUS_HEAD_SHA=""
@@ -429,7 +431,7 @@ fi
 # the whole action: the head/base SHAs drive scope resolution here, and the
 # object is saved to pr-object.json so run_review.sh (and the publish steps,
 # via the is_fork_pr output) do not have to fetch it again.
-if ! gh api "repos/$REPO/pulls/$PR_NUMBER" > pr-object.json 2>/dev/null; then
+if ! platform_pr_get "$REPO" "$PR_NUMBER" > pr-object.json 2>/dev/null; then
   echo '{}' > pr-object.json
 fi
 CURRENT_HEAD_SHA="$(jq -r '.head.sha // ""' pr-object.json 2>/dev/null || echo "")"

--- a/scripts/parse_review_command.sh
+++ b/scripts/parse_review_command.sh
@@ -72,9 +72,11 @@ fi
 
 # 4. Authorize against real repository permission. rc-check the call: gh
 #    prints error bodies to stdout on failure, so `$(... || echo "")` would
-#    capture JSON garbage — assign only when gh exits zero.
+#    capture JSON garbage — assign only when the call exits zero.
+# shellcheck source=scripts/platform_api.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/platform_api.sh"
 permission=""
-if out="$(gh api "repos/${REPO}/collaborators/${COMMENTER_LOGIN}/permission" --jq '.permission' 2>/dev/null)"; then
+if out="$(platform_collaborator_permission "$REPO" "$COMMENTER_LOGIN" 2>/dev/null)"; then
   permission="$out"
 else
   emit false "permission-check-failed"

--- a/scripts/platform_api.sh
+++ b/scripts/platform_api.sh
@@ -1,0 +1,260 @@
+#!/usr/bin/env bash
+# ── platform_api.sh ─────────────────────────────────────────────────────
+# Platform seam for every host-forge API interaction (issue #221).
+#
+# Sourced (not executed) by the action's scripts. Exposes platform_* shell
+# functions for operations against the repository under review. The github
+# backend reproduces the exact pre-seam `gh` invocations so output is
+# byte-identical to the un-seamed scripts — the existing test suites (which
+# stub `gh` via PATH) are the regression harness and must pass unmodified.
+#
+# Mode resolution (PLATFORM env, set by action.yml from the `platform` input):
+#   github  – default; all operations via the gh CLI.
+#   forgejo – operations via pr_reviewer/forgejo_backend.py (curl /api/v1).
+#             Requires FORGEJO_API_URL. Implemented per-operation across the
+#             1.4.x line; unimplemented operations fail loudly, never silently.
+#   auto    – resolved here: forgejo when GITHUB_SERVER_URL is set to a
+#             non-github.com host (Forgejo Actions runners populate it with
+#             the instance URL), github otherwise.
+#
+# Two function classes:
+#   platform_*       – the repo under review; switches on PLATFORM.
+#   github_enrich_*  – linked-source enrichment for third-party repos (which
+#                      live on github.com regardless of the host platform).
+#                      Always gh; #227 decides degradation behavior on
+#                      non-github hosts.
+#
+# The #190 pitfall applies throughout: gh prints JSON error bodies to STDOUT
+# on HTTP errors. Callers' existing rc-check / stdout-discard semantics are
+# preserved by keeping each wrapper a thin exec of the original command —
+# wrappers must not capture-and-echo, which would launder an error body into
+# a success-shaped stdout.
+
+# Guard against double-sourcing (publish_helpers.sh and the caller may both
+# source this).
+if [[ -n "${_PLATFORM_API_SOURCED:-}" ]]; then
+  return 0 2>/dev/null || exit 0
+fi
+_PLATFORM_API_SOURCED=1
+
+_PLATFORM_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+platform_resolve() {
+  # Normalise PLATFORM, resolving `auto` from GITHUB_SERVER_URL.
+  local p="${PLATFORM:-github}"
+  p="$(printf '%s' "$p" | tr '[:upper:]' '[:lower:]')"
+  if [[ "$p" == "auto" ]]; then
+    local server="${GITHUB_SERVER_URL:-}"
+    if [[ -n "$server" && "$server" != "https://github.com" && "$server" != "https://github.com/" ]]; then
+      p="forgejo"
+    else
+      p="github"
+    fi
+  fi
+  case "$p" in
+    github|forgejo) printf '%s' "$p" ;;
+    *)
+      echo "platform_api: unsupported PLATFORM '$p' (expected github|forgejo|auto)" >&2
+      return 1
+      ;;
+  esac
+}
+
+_platform_is_forgejo() {
+  [[ "$(platform_resolve)" == "forgejo" ]]
+}
+
+_forgejo_py() {
+  # Invoke the python backend CLI. FORGEJO_API_URL is required in forgejo
+  # mode; failing loudly here beats every caller debugging empty output.
+  if [[ -z "${FORGEJO_API_URL:-}" ]]; then
+    echo "platform_api: PLATFORM=forgejo requires FORGEJO_API_URL" >&2
+    return 1
+  fi
+  PYTHONPATH="${_PLATFORM_SCRIPT_DIR}/..${PYTHONPATH:+:${PYTHONPATH}}" \
+    python3 -m pr_reviewer.forgejo_backend "$@"
+}
+
+_forgejo_unimplemented() {
+  # Operations that land later in the 1.4.x line (#223–#226) fail loudly.
+  echo "platform_api: operation '$1' is not yet implemented for PLATFORM=forgejo" >&2
+  return 1
+}
+
+# ── Core PR I/O ─────────────────────────────────────────────────────────
+
+platform_pr_get() {
+  # $1=repo $2=pr_number [extra gh api flags, e.g. --jq] → PR object
+  # (GitHub REST shape, or the --jq projection) on stdout
+  if _platform_is_forgejo; then
+    local repo="$1" num="$2"
+    shift 2
+    if [[ "${1:-}" == "--jq" && -n "${2:-}" ]]; then
+      _forgejo_py get-pr-metadata "$repo" "$num" | jq -r "$2"
+    else
+      _forgejo_py get-pr-metadata "$repo" "$num"
+    fi
+  else
+    local repo="$1" num="$2"
+    shift 2
+    gh api "repos/$repo/pulls/$num" "$@"
+  fi
+}
+
+platform_pr_head_sha() {
+  # $1=repo $2=pr_number → head sha on stdout
+  if _platform_is_forgejo; then
+    _forgejo_py get-pr-metadata "$1" "$2" | jq -r '.head.sha // empty'
+  else
+    gh api "repos/$1/pulls/$2" --jq '.head.sha'
+  fi
+}
+
+platform_pr_diff() {
+  # $1=repo $2=pr_number → unified diff on stdout
+  if _platform_is_forgejo; then
+    _forgejo_py get-pr-diff "$1" "$2"
+  else
+    gh pr diff "$2" --repo "$1"
+  fi
+}
+
+platform_pr_files() {
+  # $1=repo $2=pr_number → first page of changed files (GitHub REST shape)
+  if _platform_is_forgejo; then
+    _forgejo_py list-pr-files "$1" "$2"
+  else
+    gh api "repos/$1/pulls/$2/files?per_page=100"
+  fi
+}
+
+platform_issue_get() {
+  # $1=repo $2=issue_number → issue object on stdout
+  if _platform_is_forgejo; then
+    _forgejo_py fetch-issue "$1" "$2"
+  else
+    gh api "repos/$1/issues/$2"
+  fi
+}
+
+platform_issue_comments() {
+  # $1=repo $2=issue_number → first page of issue comments
+  if _platform_is_forgejo; then
+    _forgejo_py list-comments "$1" "$2"
+  else
+    gh api "repos/$1/issues/$2/comments?per_page=100"
+  fi
+}
+
+platform_compare() {
+  # $1=repo $2=base...head spec [extra gh api flags, e.g. --jq] → compare
+  # object (or the --jq projection) on stdout
+  if _platform_is_forgejo; then
+    _forgejo_unimplemented "compare"   # lands with #223 (incremental scope)
+  else
+    local repo="$1" spec="$2"
+    shift 2
+    gh api "repos/$repo/compare/$spec" "$@"
+  fi
+}
+
+# ── Sticky comment + reviews (publish surface) ─────────────────────────
+
+platform_comment_sticky() {
+  # $1=repo $2=pr_number $3=body_file — edit the managed comment or create it
+  if _platform_is_forgejo; then
+    _forgejo_py edit-last-comment "$1" "$2" "$(cat "$3")" >/dev/null
+  else
+    gh pr comment "$2" --repo "$1" --edit-last --create-if-none --body-file "$3"
+  fi
+}
+
+platform_pr_reviews() {
+  # $1=repo $2=pr_number [first-page|paginate] → reviews JSON
+  if _platform_is_forgejo; then
+    _forgejo_unimplemented "pr_reviews"   # lands with #224 (native reviews)
+  elif [[ "${3:-first-page}" == "paginate" ]]; then
+    gh api "repos/$1/pulls/$2/reviews" --paginate
+  else
+    gh api "repos/$1/pulls/$2/reviews?per_page=100"
+  fi
+}
+
+platform_review_create_json() {
+  # $1=repo $2=pr_number $3=request_json_file — POST a review (inline comments)
+  if _platform_is_forgejo; then
+    _forgejo_unimplemented "review_create_json"   # #224
+  else
+    gh api "repos/$1/pulls/$2/reviews" --method POST --input "$3"
+  fi
+}
+
+platform_review_native() {
+  # $1=repo $2=pr_number $3=APPROVE|REQUEST_CHANGES $4=body_file
+  if _platform_is_forgejo; then
+    _forgejo_unimplemented "review_native"   # #224
+  else
+    case "$3" in
+      APPROVE) gh pr review "$2" --repo "$1" --approve --body-file "$4" ;;
+      *)       gh pr review "$2" --repo "$1" --request-changes --body-file "$4" ;;
+    esac
+  fi
+}
+
+platform_review_dismiss() {
+  # $1=repo $2=pr_number $3=review_id $4=message
+  if _platform_is_forgejo; then
+    _forgejo_unimplemented "review_dismiss"   # #224
+  else
+    gh api "repos/$1/pulls/$2/reviews/$3/dismissals" --method PUT -f message="$4" --jq '.id'
+  fi
+}
+
+platform_graphql() {
+  # GraphQL passthrough (comment minimisation). GitHub-only API surface; the
+  # forgejo path must degrade at the call site per #227, not crash here.
+  if _platform_is_forgejo; then
+    _forgejo_unimplemented "graphql"
+  else
+    gh api graphql "$@"
+  fi
+}
+
+platform_collaborator_permission() {
+  # $1=repo $2=login → permission string (admin|write|read|none) on stdout
+  if _platform_is_forgejo; then
+    _forgejo_unimplemented "collaborator_permission"   # comment-trigger wiring is GitHub-only today
+  else
+    gh api "repos/$1/collaborators/$2/permission" --jq '.permission'
+  fi
+}
+
+# ── CI status (wait_for_ci.sh) ──────────────────────────────────────────
+
+platform_check_runs() {
+  # $1=repo $2=sha → check-runs JSON
+  if _platform_is_forgejo; then
+    _forgejo_unimplemented "check_runs"   # #225 uses commit statuses instead
+  else
+    gh api "repos/$1/commits/$2/check-runs?per_page=100"
+  fi
+}
+
+platform_commit_status() {
+  # $1=repo $2=sha → combined commit status JSON
+  if _platform_is_forgejo; then
+    _forgejo_unimplemented "commit_status"   # #225
+  else
+    gh api "repos/$1/commits/$2/status"
+  fi
+}
+
+# ── GitHub-targeted enrichment (linked third-party sources) ─────────────
+# These hit github.com-hosted upstream repos (release notes, compares, tags
+# for version hints) and are NOT host-platform operations: on a Forgejo
+# deployment the linked sources still live on github.com. #227 gates their
+# behavior when no GitHub credentials are available.
+
+github_enrich_api() {
+  gh api "$@"
+}

--- a/scripts/publish_helpers.sh
+++ b/scripts/publish_helpers.sh
@@ -4,6 +4,9 @@ set -euo pipefail
 # Shared helpers for publish steps in action.yml.
 # Source this script from each publish step, then call the functions.
 
+# shellcheck source=scripts/platform_api.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/platform_api.sh"
+
 # Sanitize model output: strip metadata markers and neutralize upstream references.
 # Args: $1 = output file path
 # Writes sanitized markdown to the output file using $REVIEW_MARKDOWN env var.
@@ -59,7 +62,7 @@ cleanup_native_reviews() {
 
   echo "Cleaning up previous managed native reviews for #$PR_NUMBER"
   local reviews_json
-  if ! reviews_json="$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" --paginate 2>/dev/null)"; then
+  if ! reviews_json="$(platform_pr_reviews "$REPO" "$PR_NUMBER" paginate 2>/dev/null)"; then
     echo "  WARN: Could not list reviews for #$PR_NUMBER; skipping cleanup" >&2
     return 0
   fi
@@ -68,7 +71,7 @@ cleanup_native_reviews() {
   # expose it); one query maps databaseId → isMinimized for skip logic. On
   # failure the map is empty and minimization is simply retried (idempotent).
   local minimized_ids
-  minimized_ids="$(gh api graphql \
+  minimized_ids="$(platform_graphql \
     -f query='query($owner: String!, $name: String!, $number: Int!) { repository(owner: $owner, name: $name) { pullRequest(number: $number) { reviews(first: 100) { nodes { databaseId isMinimized } } } } }' \
     -f owner="${REPO%%/*}" -f name="${REPO#*/}" -F number="$PR_NUMBER" \
     --jq '[.data.repository.pullRequest.reviews.nodes[] | select(.isMinimized) | .databaseId]' 2>/dev/null || echo '[]')"
@@ -95,7 +98,7 @@ cleanup_native_reviews() {
       if [ -z "$REVIEW_ID" ]; then continue; fi
       # Dismiss approval/request-changes reviews to stop stale verdicts from counting
       if [ "$REVIEW_STATE" = "APPROVED" ] || [ "$REVIEW_STATE" = "CHANGES_REQUESTED" ]; then
-        if gh api "repos/$REPO/pulls/$PR_NUMBER/reviews/$REVIEW_ID/dismissals" --method PUT -f message="Superseded by a newer automated review for this pull request." --jq '.id' >/dev/null 2>&1; then
+        if platform_review_dismiss "$REPO" "$PR_NUMBER" "$REVIEW_ID" "Superseded by a newer automated review for this pull request." >/dev/null 2>&1; then
           echo "  Dismissed outdated managed review #$REVIEW_ID ($REVIEW_STATE)"
         else
           echo "  WARN: Could not dismiss review #$REVIEW_ID (may require additional permissions)" >&2
@@ -106,7 +109,7 @@ cleanup_native_reviews() {
       # implements GraphQL's Minimizable, the same mechanism as the UI's
       # "Hide" menu.
       if [ -n "$REVIEW_NODE_ID" ] && [ "$REVIEW_MINIMIZED" != "minimized" ]; then
-        if gh api graphql \
+        if platform_graphql \
             -f query='mutation($id: ID!) { minimizeComment(input: {subjectId: $id, classifier: OUTDATED}) { minimizedComment { isMinimized } } }' \
             -f id="$REVIEW_NODE_ID" >/dev/null 2>&1; then
           echo "  Minimized (hidden as outdated) review #$REVIEW_ID"

--- a/scripts/resolve_finding_threads.py
+++ b/scripts/resolve_finding_threads.py
@@ -49,6 +49,7 @@ for _p in (str(_SCRIPTS_DIR), str(_ACTION_ROOT)):
 
 from build_review_comments import FINDING_MARKER_PREFIX, finding_fingerprint  # noqa: E402
 from pr_reviewer.carry_forward import load_carried_findings  # noqa: E402
+from pr_reviewer.platform import PlatformUnsupported, gh_argv  # noqa: E402
 
 _THREADS_QUERY = (
     "query($owner: String!, $name: String!, $number: Int!) {"
@@ -79,10 +80,18 @@ def _run_gh(args: list, timeout: int = 60):
     On HTTP errors gh prints the JSON error body to STDOUT (#190), so a
     non-zero exit discards stdout entirely instead of trying to parse it.
     Anything that is not a JSON object is treated as a failure.
+
+    The argv goes through the platform seam (#221). Thread management is
+    GraphQL-only, so on PLATFORM=forgejo it degrades to a no-op (None) like
+    every other best-effort failure here — #224 brings the Forgejo backend.
     """
     try:
+        argv = gh_argv(args)
+    except PlatformUnsupported:
+        return None
+    try:
         completed = subprocess.run(
-            ["gh", *args],
+            argv,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             timeout=timeout,

--- a/scripts/run_review.sh
+++ b/scripts/run_review.sh
@@ -49,6 +49,8 @@ enrichment_budget_ok() {
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 export PYTHONPATH="${SCRIPT_DIR}/..${PYTHONPATH:+:${PYTHONPATH}}"
+# shellcheck source=scripts/platform_api.sh
+source "${SCRIPT_DIR}/platform_api.sh"
 REPO="${REPO:-${GITHUB_REPOSITORY:-}}"
 PR_NUMBER="${PR_NUMBER:-}"
 AI_BASE_URL="${AI_BASE_URL:-}"
@@ -195,7 +197,7 @@ fetch_incremental_patch() {
 
   # Get the compare API URL and fetch the raw diff
   local compare_url
-  compare_url="$(gh api "repos/$REPO/compare/${previous_head}...${current_head}" --jq '.url' 2>/dev/null || echo "")"
+  compare_url="$(platform_compare "$REPO" "${previous_head}...${current_head}" --jq '.url' 2>/dev/null || echo "")"
 
   if [[ -n "$compare_url" ]]; then
     # The token goes through a 0600 curl --config file rather than argv (same
@@ -213,7 +215,7 @@ fetch_incremental_patch() {
 
   if [[ ! -s "$output_file" ]]; then
     echo "Compare API returned empty or failed; falling back to full PR diff" >&2
-    gh pr diff "$PR_NUMBER" --repo "$REPO" > "$output_file"
+    platform_pr_diff "$REPO" "$PR_NUMBER" > "$output_file"
   fi
 }
 
@@ -457,7 +459,7 @@ log "Collecting PR context for #$PR_NUMBER in $REPO..."
 if [[ -s pr-object.json && "$(jq -r '.number // empty' pr-object.json 2>/dev/null)" == "$PR_NUMBER" ]]; then
   log "Reusing PR object fetched by precheck"
 else
-  gh api "repos/$REPO/pulls/$PR_NUMBER" > pr-object.json
+  platform_pr_get "$REPO" "$PR_NUMBER" > pr-object.json
 fi
 jq '{number, title, body, headRefOid: .head.sha, baseRefName: .base.ref, headRefName: .head.ref, author: {login: (.user.login // "")}, changedFiles: .changed_files, additions, deletions, url: .html_url}' \
   pr-object.json > pr.json
@@ -470,14 +472,14 @@ fi
 if [[ -s pr.diff ]]; then
   log "Reusing PR diff fetched by precheck"
 else
-  gh pr diff "$PR_NUMBER" --repo "$REPO" > pr.diff
+  platform_pr_diff "$REPO" "$PR_NUMBER" > pr.diff
 fi
 truncate_clean pr.diff pr.diff.truncated "$MAX_DIFF" '…[diff truncated to fit context budget]'
 
 # One bounded page instead of --paginate: 100 files is far beyond what the
 # MAX_FILES byte budget keeps anyway, and unbounded pagination on huge PRs
 # both burned API quota and produced concatenated JSON documents.
-gh api "repos/$REPO/pulls/$PR_NUMBER/files?per_page=100" > pr-files.raw.json
+platform_pr_files "$REPO" "$PR_NUMBER" > pr-files.raw.json
 # Note: 'patch' is intentionally dropped — the per-file patches duplicate the
 # raw diff that is already embedded in the corpus, and the classifier does not
 # read them. Keeping them here doubled the diff bytes sent to the model.
@@ -515,7 +517,7 @@ if [ "$(jq 'length' linked-issues.json)" -gt 0 ]; then
     issue_ref="$(printf '%s' "$item" | jq -r '.ref')"
 
     echo "## $issue_ref" >> linked-issues.md
-    if gh api "repos/$issue_repo/issues/$issue_number" > linked-issue.raw.json 2>/dev/null; then
+    if platform_issue_get "$issue_repo" "$issue_number" > linked-issue.raw.json 2>/dev/null; then
       jq '{number,title,state,html_url,labels:[.labels[]?.name],body}' linked-issue.raw.json > linked-issue.filtered.json
       echo '```json' >> linked-issues.md
       head -c 12000 linked-issue.filtered.json >> linked-issues.md
@@ -697,7 +699,7 @@ if [ -s urls.txt ]; then
       echo >> linked-sources.md
       echo "### GitHub Release Metadata: $owner/$repo@$tag" >> linked-sources.md
 
-      if enrichment_budget_ok && gh api "repos/$owner/$repo/releases/tags/$tag" > gh-release.json 2>/dev/null; then
+      if enrichment_budget_ok && github_enrich_api "repos/$owner/$repo/releases/tags/$tag" > gh-release.json 2>/dev/null; then
         jq '{tag_name,name,published_at,html_url,body}' gh-release.json > gh-release.filtered.json
         echo '```json' >> linked-sources.md
         head -c 5000 gh-release.filtered.json >> linked-sources.md
@@ -707,7 +709,7 @@ if [ -s urls.txt ]; then
         echo "(Could not fetch release metadata for tag $tag)" >> linked-sources.md
       fi
 
-      if enrichment_budget_ok && gh api "repos/$owner/$repo/releases?per_page=8" > gh-releases.json 2>/dev/null; then
+      if enrichment_budget_ok && github_enrich_api "repos/$owner/$repo/releases?per_page=8" > gh-releases.json 2>/dev/null; then
         jq '[.[] | {tag_name,name,published_at,html_url}]' gh-releases.json > gh-releases.filtered.json
         echo "### Recent Releases" >> linked-sources.md
         echo '```json' >> linked-sources.md
@@ -725,7 +727,7 @@ if [ -s urls.txt ]; then
       echo >> linked-sources.md
       echo "### GitHub Compare Metadata: $owner/$repo@$compare_spec" >> linked-sources.md
 
-      if enrichment_budget_ok && gh api "repos/$owner/$repo/compare/$compare_spec" > gh-compare.json 2>/dev/null; then
+      if enrichment_budget_ok && github_enrich_api "repos/$owner/$repo/compare/$compare_spec" > gh-compare.json 2>/dev/null; then
         jq '{html_url,status,ahead_by,behind_by,total_commits,commits:[.commits[]? | {sha,commit:{message,author,date}}]}' gh-compare.json > gh-compare.filtered.json
         echo '```json' >> linked-sources.md
         head -c 7000 gh-compare.filtered.json >> linked-sources.md
@@ -764,7 +766,7 @@ if [ -s urls.txt ]; then
       echo >> linked-sources.md
       echo "### GitHub Releases Enrichment: $repo_key" >> linked-sources.md
 
-      if enrichment_budget_ok && gh api "repos/$owner/$repo/releases?per_page=30" > gh-releases.repo.json 2>/dev/null; then
+      if enrichment_budget_ok && github_enrich_api "repos/$owner/$repo/releases?per_page=30" > gh-releases.repo.json 2>/dev/null; then
         jq '[.[] | {tag_name,name,published_at,html_url}]' gh-releases.repo.json > gh-releases.repo.filtered.json
         echo "#### Recent Releases (tags)" >> linked-sources.md
         echo '```json' >> linked-sources.md
@@ -792,7 +794,7 @@ if [ -s urls.txt ]; then
             echo '```' >> linked-sources.md
           else
             echo "(No release tags matched target version $TARGET_VERSION in $repo_key)" >> linked-sources.md
-            if enrichment_budget_ok && gh api "repos/$owner/$repo/tags?per_page=50" > gh-tags.repo.json 2>/dev/null; then
+            if enrichment_budget_ok && github_enrich_api "repos/$owner/$repo/tags?per_page=50" > gh-tags.repo.json 2>/dev/null; then
               jq '[.[] | {name,commit:.commit.sha}]' gh-tags.repo.json > gh-tags.repo.filtered.json
               echo "#### Recent Tags" >> linked-sources.md
               echo '```json' >> linked-sources.md
@@ -831,7 +833,7 @@ if [ -s urls.txt ]; then
 
       if [ -n "$TARGET_VERSION" ]; then
         for tag_prefix in "v$TARGET_VERSION" "$TARGET_VERSION"; do
-          if enrichment_budget_ok && gh api "repos/$owner/$repo/releases/tags/$tag_prefix" > ghcr-release.json 2>/dev/null; then
+          if enrichment_budget_ok && github_enrich_api "repos/$owner/$repo/releases/tags/$tag_prefix" > ghcr-release.json 2>/dev/null; then
             echo "#### Matched via ghcr.io path: $owner/$repo@$tag_prefix" >> linked-sources.md
             jq '{tag_name,name,published_at,html_url,body}' ghcr-release.json > ghcr-release.filtered.json
             echo '```json' >> linked-sources.md

--- a/scripts/wait_for_ci.sh
+++ b/scripts/wait_for_ci.sh
@@ -23,6 +23,8 @@ set -euo pipefail
 
 GH_TOKEN="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
 REPO="${REPO:-${GITHUB_REPOSITORY:-}}"
+# shellcheck source=scripts/platform_api.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/platform_api.sh"
 PR_NUMBER="${PR_NUMBER:-}"
 PR_HEAD_SHA="${PR_HEAD_SHA:-}"
 GITHUB_RUN_ID="${GITHUB_RUN_ID:-}"
@@ -60,7 +62,7 @@ error() {
 # Get the head SHA of the PR (may differ from event.pull_request.head.sha if
 # the action is invoked manually with a stale pr_number).
 get_head_sha() {
-  gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.head.sha' 2>/dev/null
+  platform_pr_head_sha "$REPO" "$PR_NUMBER" 2>/dev/null
 }
 
 # Render the per-check results gathered this iteration into CI_CHECKS_FILE so
@@ -151,8 +153,8 @@ while true; do
     fi
   fi
 
-  check_runs_response="$(gh api "repos/$REPO/commits/$sha/check-runs?per_page=100" 2>/dev/null || echo "")"
-  combined_response="$(gh api "repos/$REPO/commits/$sha/status" 2>/dev/null || echo "")"
+  check_runs_response="$(platform_check_runs "$REPO" "$sha" 2>/dev/null || echo "")"
+  combined_response="$(platform_commit_status "$REPO" "$sha" 2>/dev/null || echo "")"
 
   if [[ -z "$check_runs_response" && -z "$combined_response" ]]; then
     log "API returned empty; retrying in ${CI_INTERVAL_SEC}s..."

--- a/tests/test_approval_guardrails.sh
+++ b/tests/test_approval_guardrails.sh
@@ -137,11 +137,19 @@ check_contains "allow_approve default is false" \
 check_exists "action.yml has native review step" \
   "$(grep -c 'Publish review verdict' "$ACTION_YML" || echo 0)"
 
-check_exists "action.yml has gh pr review approve" \
-  "$(grep -c 'gh pr review.*approve' "$ACTION_YML" || echo 0)"
+# The native-review invocations route through the platform seam (#221):
+# action.yml calls platform_review_native, whose github backend holds the
+# actual `gh pr review --approve/--request-changes` command lines.
+PLATFORM_SEAM="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/scripts/platform_api.sh"
 
-check_exists "action.yml has gh pr review request-changes" \
-  "$(grep -c 'gh pr review.*request-changes' "$ACTION_YML" || echo 0)"
+check_exists "action.yml routes approve through the seam" \
+  "$(grep -c 'platform_review_native "\$REPO" "\$PR_NUMBER" APPROVE' "$ACTION_YML" || echo 0)"
+
+check_exists "seam github backend has gh pr review approve" \
+  "$(grep -c 'gh pr review.*--approve' "$PLATFORM_SEAM" || echo 0)"
+
+check_exists "seam github backend has gh pr review request-changes" \
+  "$(grep -c 'gh pr review.*--request-changes' "$PLATFORM_SEAM" || echo 0)"
 
 echo ""
 echo "=== README.md documentation validation ==="

--- a/tests/test_ci_status_check.sh
+++ b/tests/test_ci_status_check.sh
@@ -42,7 +42,9 @@ check_contains() {
 
 # ── Test 1: exit code 1 path for timeout+skip=true exists in script ──
 echo "=== Test: exit code 1 on timeout with skip=true ==="
-wait_content="$(cat "$WAIT_SCRIPT")"
+# The check-runs/status invocations live in the platform seam (issue #221);
+# include it so static-content assertions keep seeing the full command text.
+wait_content="$(cat "$WAIT_SCRIPT" "$SCRIPT_DIR/scripts/platform_api.sh")"
 
 check_contains "script has timeout branch checking CI_SKIP_ON_TIMEOUT" \
   "$wait_content" 'CI_SKIP_ON_TIMEOUT'

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -1,0 +1,65 @@
+"""Tests for pr_reviewer.platform — the Python side of the #221 seam."""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from pr_reviewer.platform import PlatformUnsupported, gh_argv, resolve_platform
+
+
+def _env(**kwargs):
+    return patch.dict("os.environ", kwargs, clear=False)
+
+
+class TestResolvePlatform(unittest.TestCase):
+    def test_default_is_github(self):
+        with _env(PLATFORM=""):
+            self.assertEqual(resolve_platform(), "github")
+
+    def test_explicit_values(self):
+        with _env(PLATFORM="github"):
+            self.assertEqual(resolve_platform(), "github")
+        with _env(PLATFORM="Forgejo"):
+            self.assertEqual(resolve_platform(), "forgejo")
+
+    def test_auto_github_com(self):
+        with _env(PLATFORM="auto", GITHUB_SERVER_URL="https://github.com"):
+            self.assertEqual(resolve_platform(), "github")
+
+    def test_auto_custom_host_is_forgejo(self):
+        with _env(PLATFORM="auto", GITHUB_SERVER_URL="https://forgejo.example.com"):
+            self.assertEqual(resolve_platform(), "forgejo")
+
+    def test_auto_no_server_is_github(self):
+        with _env(PLATFORM="auto", GITHUB_SERVER_URL=""):
+            self.assertEqual(resolve_platform(), "github")
+
+    def test_invalid_raises(self):
+        with _env(PLATFORM="gitlab"):
+            with self.assertRaises(ValueError):
+                resolve_platform()
+
+
+class TestGhArgv(unittest.TestCase):
+    def test_github_argv_is_byte_identical(self):
+        with _env(PLATFORM="github"):
+            self.assertEqual(
+                gh_argv(["api", "graphql", "-f", "query=Q"]),
+                ["gh", "api", "graphql", "-f", "query=Q"],
+            )
+
+    def test_forgejo_raises_unsupported(self):
+        with _env(PLATFORM="forgejo"):
+            with self.assertRaises(PlatformUnsupported):
+                gh_argv(["api", "graphql"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_platform_api.sh
+++ b/tests/test_platform_api.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Tests for scripts/platform_api.sh — the platform seam (issue #221).
+# The github backend must reproduce the exact pre-seam gh invocations; the
+# stubbed gh below echoes its argv so each wrapper's command line is asserted
+# byte-for-byte.
+
+if [ -z "${BASH_VERSINFO:-}" ] || [ "${BASH_VERSINFO[0]}" -lt 4 ]; then
+  echo "SKIP: bash >= 4 required (found ${BASH_VERSION:-unknown}); on macOS run with PATH=\"/opt/homebrew/bin:\$PATH\"" >&2
+  exit 0
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SEAM="$SCRIPT_DIR/scripts/platform_api.sh"
+
+PASS=0
+FAIL=0
+check() {
+  local desc="$1" result="$2" expected="$3"
+  if [[ "$result" == "$expected" ]]; then
+    echo "  PASS: $desc"; PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc (got '$result', expected '$expected')"; FAIL=$((FAIL + 1))
+  fi
+}
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+mkdir -p "$TMP/bin"
+printf '#!/usr/bin/env bash\necho "gh $*"\n' > "$TMP/bin/gh"
+chmod +x "$TMP/bin/gh"
+export PATH="$TMP/bin:$PATH"
+
+# Run a snippet in a clean subshell with controlled env; echoes stdout.
+run_seam() {
+  local platform="$1" server="$2" snippet="$3"
+  (
+    export PLATFORM="$platform"
+    if [[ -n "$server" ]]; then export GITHUB_SERVER_URL="$server"; else unset GITHUB_SERVER_URL; fi
+    unset _PLATFORM_API_SOURCED
+    # shellcheck disable=SC1090
+    source "$SEAM"
+    eval "$snippet"
+  ) 2>&1 || true
+}
+
+echo "=== platform_resolve ==="
+check "default resolves to github" "$(run_seam "" "" 'platform_resolve')" "github"
+check "explicit github" "$(run_seam github "" 'platform_resolve')" "github"
+check "explicit forgejo" "$(run_seam forgejo "" 'platform_resolve')" "forgejo"
+check "auto + github.com server → github" "$(run_seam auto "https://github.com" 'platform_resolve')" "github"
+check "auto + no server → github" "$(run_seam auto "" 'platform_resolve')" "github"
+check "auto + custom host → forgejo" "$(run_seam auto "https://forgejo.example.com" 'platform_resolve')" "forgejo"
+check "case-insensitive" "$(run_seam GITHUB "" 'platform_resolve')" "github"
+RESULT="$(run_seam gitlab "" 'platform_resolve')"
+check "invalid platform errors" "$(echo "$RESULT" | grep -c "unsupported PLATFORM")" "1"
+
+echo ""
+echo "=== github backend: exact gh argv ==="
+check "platform_pr_get" \
+  "$(run_seam github "" 'platform_pr_get o/r 7')" \
+  "gh api repos/o/r/pulls/7"
+check "platform_pr_get forwards --jq" \
+  "$(run_seam github "" 'platform_pr_get o/r 7 --jq .head.sha')" \
+  "gh api repos/o/r/pulls/7 --jq .head.sha"
+check "platform_pr_head_sha" \
+  "$(run_seam github "" 'platform_pr_head_sha o/r 7')" \
+  "gh api repos/o/r/pulls/7 --jq .head.sha"
+check "platform_pr_diff" \
+  "$(run_seam github "" 'platform_pr_diff o/r 7')" \
+  "gh pr diff 7 --repo o/r"
+check "platform_pr_files" \
+  "$(run_seam github "" 'platform_pr_files o/r 7')" \
+  "gh api repos/o/r/pulls/7/files?per_page=100"
+check "platform_issue_get" \
+  "$(run_seam github "" 'platform_issue_get o/r 9')" \
+  "gh api repos/o/r/issues/9"
+check "platform_issue_comments" \
+  "$(run_seam github "" 'platform_issue_comments o/r 9')" \
+  "gh api repos/o/r/issues/9/comments?per_page=100"
+check "platform_compare" \
+  "$(run_seam github "" 'platform_compare o/r aaa...bbb')" \
+  "gh api repos/o/r/compare/aaa...bbb"
+check "platform_compare forwards --jq" \
+  "$(run_seam github "" 'platform_compare o/r aaa...bbb --jq .url')" \
+  "gh api repos/o/r/compare/aaa...bbb --jq .url"
+check "platform_comment_sticky" \
+  "$(run_seam github "" 'platform_comment_sticky o/r 7 body.md')" \
+  "gh pr comment 7 --repo o/r --edit-last --create-if-none --body-file body.md"
+check "platform_pr_reviews first page" \
+  "$(run_seam github "" 'platform_pr_reviews o/r 7')" \
+  "gh api repos/o/r/pulls/7/reviews?per_page=100"
+check "platform_pr_reviews paginate" \
+  "$(run_seam github "" 'platform_pr_reviews o/r 7 paginate')" \
+  "gh api repos/o/r/pulls/7/reviews --paginate"
+check "platform_review_create_json" \
+  "$(run_seam github "" 'platform_review_create_json o/r 7 req.json')" \
+  "gh api repos/o/r/pulls/7/reviews --method POST --input req.json"
+check "platform_review_native approve" \
+  "$(run_seam github "" 'platform_review_native o/r 7 APPROVE body.md')" \
+  "gh pr review 7 --repo o/r --approve --body-file body.md"
+check "platform_review_native request changes" \
+  "$(run_seam github "" 'platform_review_native o/r 7 REQUEST_CHANGES body.md')" \
+  "gh pr review 7 --repo o/r --request-changes --body-file body.md"
+check "platform_review_dismiss" \
+  "$(run_seam github "" 'platform_review_dismiss o/r 7 55 superseded')" \
+  "gh api repos/o/r/pulls/7/reviews/55/dismissals --method PUT -f message=superseded --jq .id"
+check "platform_graphql passthrough" \
+  "$(run_seam github "" 'platform_graphql -f query=Q')" \
+  "gh api graphql -f query=Q"
+check "platform_check_runs" \
+  "$(run_seam github "" 'platform_check_runs o/r abc123')" \
+  "gh api repos/o/r/commits/abc123/check-runs?per_page=100"
+check "platform_commit_status" \
+  "$(run_seam github "" 'platform_commit_status o/r abc123')" \
+  "gh api repos/o/r/commits/abc123/status"
+check "github_enrich_api passthrough" \
+  "$(run_seam github "" 'github_enrich_api repos/up/stream/releases?per_page=8')" \
+  "gh api repos/up/stream/releases?per_page=8"
+
+echo ""
+echo "=== forgejo mode: loud failures, no silent fallthrough ==="
+RESULT="$(run_seam forgejo "" 'platform_pr_get o/r 7')"
+check "forgejo without FORGEJO_API_URL fails loudly" \
+  "$(echo "$RESULT" | grep -c "requires FORGEJO_API_URL")" "1"
+RESULT="$(run_seam forgejo "" 'platform_graphql -f query=Q')"
+check "unimplemented forgejo op names itself" \
+  "$(echo "$RESULT" | grep -c "not yet implemented")" "1"
+RESULT="$(run_seam forgejo "" 'platform_check_runs o/r abc')"
+check "unimplemented forgejo op exits nonzero" \
+  "$( (export PLATFORM=forgejo; unset _PLATFORM_API_SOURCED; source "$SEAM"; platform_check_runs o/r abc >/dev/null 2>&1 && echo 0 || echo 1) )" "1"
+RESULT="$(run_seam forgejo "" 'github_enrich_api repos/up/stream/releases')"
+check "enrichment stays on gh even in forgejo mode" "$RESULT" "gh api repos/up/stream/releases"
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+[[ "$FAIL" -gt 0 ]] && exit 1 || exit 0


### PR DESCRIPTION
Implements #221 (Forgejo umbrella #229, 1.4.x line): every host-forge API interaction now goes through one seam, with the gh CLI as the default backend and **byte-identical output** in github mode.

## Design

- **`scripts/platform_api.sh`** — sourced shell seam. `platform_*` functions cover the repo-under-review operations (PR get/diff/files, issue get/comments, compare, sticky comment, reviews create/dismiss/native, graphql, check-runs/commit-status, collaborator permission). The github branch of each wrapper is the *exact* pre-seam `gh` invocation.
- **`pr_reviewer/platform.py`** — Python mirror; `resolve_finding_threads.py` builds its gh argv through it. (`run_tool_harness.py`'s `gh_api` uses urllib against api.github.com directly — that's #226's seam point.)
- **New `platform` input** (`auto`|`github`|`forgejo`, default `auto` — detects from `GITHUB_SERVER_URL`), wired as `PLATFORM` into all six script-running steps.
- **Forgejo mode**: implemented operations (core PR I/O, #222) delegate to `pr_reviewer/forgejo_backend.py`; everything not yet implemented **fails loudly with the operation name** (reviews → #224, CI status → #225) rather than silently misbehaving. Missing `FORGEJO_API_URL` is a hard error.
- **Two function classes on purpose**: `github_enrich_api` exists separately because linked-source enrichment (releases/tags/compares of upstream dependencies) targets github.com-hosted repos regardless of where the action runs. #227 owns their degradation story.
- **#190 discipline preserved**: wrappers are thin execs — they never capture-and-echo, so gh's error-body-on-stdout behavior and every call site's existing rc-check/stdout-discard semantics are unchanged.

## Migration coverage

All ~40 call sites: `run_review.sh` (14), `action.yml` publish steps (7), `check_review_needed.sh` (5), `publish_helpers.sh` (5), `wait_for_ci.sh` (3), `resolve_finding_threads.py`, `parse_review_command.sh`. A final sweep confirms zero bare `gh pr|api` invocations outside the seam.

## Regression evidence

- The existing test suites stub `gh` via PATH; since the github backend execs identical commands, **they pass unmodified** — except two static source-grep assertions (approval guardrails, CI-status) mechanically pointed at the seam file, as the issue allows.
- New `tests/test_platform_api.sh`: 32 cases asserting every github-backend command line **byte-for-byte**, resolution logic (`auto` detection), and loud forgejo failures.
- New `tests/test_platform.py` for the Python mirror.
- Full run: all bash suites + 660 python tests pass.
