### PR TITLE
feat(eval): agentic-capability scoring + home-ops#7462 scenario (#207)

### DIFF
--- a/evals/corpus-agentic.json
+++ b/evals/corpus-agentic.json
@@ -1,0 +1,38 @@
+{
+  "benchmark_corpus": [
+    {
+      "number": 7462,
+      "repo_full_name": "joryirving/home-ops",
+      "url": "https://github.com/joryirving/home-ops/pull/7462",
+      "title": "fix(container): update kubernetes group (v1.36.1 -> v1.36.2)",
+      "known_findings": [],
+      "expected_evidence": {
+        "description": "The founding use case (#203 acceptance criterion). With NO Talos-specific prompting, steering, or evidence provider, the reviewer must notice the bumped kubelet image runs on a host platform visible in the repo, chain read_file -> extract the deployed Talos version -> web_fetch that version's published support matrix (host talos.dev is already allowlisted), and cite the matrix as evidence for the verdict instead of a pattern-reasoned 'patch bump, low risk' rubber stamp. Capability altitude only: nothing here is given to the reviewer as a prompt; this block is the GRADER's expected concrete evidence.",
+        "checks": [
+          {
+            "id": "read_machineconfig",
+            "type": "tool_call",
+            "tool": "read_file",
+            "args_contains": { "path": ["machineconfig"] }
+          },
+          {
+            "id": "fetched_support_matrix",
+            "type": "tool_call",
+            "tool": "web_fetch",
+            "args_contains": { "url": ["talos.dev", "support-matrix"] }
+          },
+          {
+            "id": "cited_matrix_in_review",
+            "type": "review_mentions",
+            "any_of": ["support matrix", "support-matrix", "talos.dev", "compatibility matrix"]
+          }
+        ]
+      }
+    }
+  ],
+  "metadata": {
+    "created_at": "2026-06-12T00:00:00Z",
+    "description": "Agentic-capability eval corpus for #207. home-ops#7462 is the canonical live fixture for the #203 acceptance criterion (Talos<->k8s support-matrix chain). Run with --modes native_loop plan_execute tools_off --runs-per-mode 10 and read mode_summary[*].capability_pass_rate; a single run is noise at the fast tier. The fixture PR is intentionally left OPEN. Keep prompts at capability altitude ('verify against the host platform's published compatibility matrix'), never recipe altitude ('check talos.dev') — only THIS grader names the concrete evidence.",
+    "issue_refs": [197, 203, 207]
+  }
+}

--- a/scripts/eval_harness.py
+++ b/scripts/eval_harness.py
@@ -82,6 +82,11 @@ class ReviewRun:
     review_markdown: str = ""
     error: str | None = None
     model_used: str = ""
+    # Structured trace from tool-harness.json: each is {tool, args, status}.
+    # Populated for native_loop (and any harness mode that emits tool_calls);
+    # the capability checker grades the agentic evidence chain against it.
+    tool_calls: list[dict[str, Any]] = field(default_factory=list)
+    tool_stop_reason: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -94,6 +99,8 @@ class ReviewRun:
             "verdict": self.verdict,
             "findings_count": len(self.findings),
             "findings": self.findings,
+            "tool_calls": self.tool_calls,
+            "tool_stop_reason": self.tool_stop_reason,
             "error": self.error,
             "model_used": self.model_used,
         }
@@ -233,6 +240,117 @@ def compute_precision_recall(
 
 
 # ---------------------------------------------------------------------------
+# Capability checks (the agentic-evidence-chain criterion, #203/#207)
+# ---------------------------------------------------------------------------
+#
+# Findings precision/recall can't express the home-ops#7462 acceptance bar —
+# "did the reviewer chain tools to consult the platform's compatibility matrix
+# and cite it?" That is a *capability* assertion on the evidence-gathering, not
+# a findings-quality score. A scenario declares it as `expected_evidence` and
+# the harness grades each run pass/fail; the bar is met as a RATE over many
+# runs (a single green run proves nothing at the fast tier's reliability).
+#
+# Check kinds (capability passes iff ALL checks pass):
+#   tool_call      — some executed tool_call matches `tool` and, for each key in
+#                    `args_contains`, that call's arg holds ALL listed substrings
+#   review_mentions — the published review markdown contains ANY of `any_of`
+# Both are substring/case-insensitive: the grader names concrete evidence (it is
+# not the reviewer), but stays loose on phrasing.
+
+
+def _arg_value(call: dict[str, Any], key: str) -> str:
+    args = call.get("args")
+    if not isinstance(args, dict):
+        return ""
+    val = args.get(key)
+    return val if isinstance(val, str) else ""
+
+
+def evaluate_capability(
+    run: ReviewRun, expected_evidence: dict[str, Any] | None
+) -> dict[str, Any] | None:
+    """Grade a run against a scenario's expected_evidence.
+
+    Returns None when the scenario declares no capability checks (so callers
+    can skip capability aggregation for ordinary findings-only PRs). Otherwise
+    returns {description, checks: [{id, type, passed, ...}], passed: bool}.
+    A run that errored fails every check (no evidence was produced).
+    """
+    if not expected_evidence:
+        return None
+    checks = expected_evidence.get("checks", [])
+    if not checks:
+        return None
+
+    results: list[dict[str, Any]] = []
+    review_lc = (run.review_markdown or "").lower()
+
+    for check in checks:
+        ctype = check.get("type")
+        cid = check.get("id", ctype or "check")
+        passed = False
+
+        if run.error:
+            passed = False
+        elif ctype == "tool_call":
+            want_tool = check.get("tool")
+            args_contains = check.get("args_contains", {})
+            for call in run.tool_calls:
+                if want_tool and call.get("tool") != want_tool:
+                    continue
+                if call.get("status") not in (None, "ok"):
+                    # A failed tool call isn't usable evidence.
+                    continue
+                ok = True
+                for key, needles in args_contains.items():
+                    hay = _arg_value(call, key).lower()
+                    needle_list = needles if isinstance(needles, list) else [needles]
+                    if not all(str(n).lower() in hay for n in needle_list):
+                        ok = False
+                        break
+                if ok:
+                    passed = True
+                    break
+        elif ctype == "review_mentions":
+            any_of = check.get("any_of", [])
+            passed = any(str(s).lower() in review_lc for s in any_of)
+
+        results.append({"id": cid, "type": ctype, "passed": passed})
+
+    return {
+        "description": expected_evidence.get("description", ""),
+        "checks": results,
+        "passed": all(c["passed"] for c in results),
+    }
+
+
+def populate_tool_trace(run: ReviewRun, repo_path: Path) -> None:
+    """Read tool-harness.json (left in the run cwd) into the ReviewRun.
+
+    The native_loop harness emits a `tool_calls` array ({tool, args, status});
+    older planner modes emit only `tool_results` (tool + status, no args), so
+    fall back to that. Either way the capability checker gets the trace it can
+    grade; absence of the file is silently fine (tools_off mode).
+    """
+    harness_file = repo_path / "tool-harness.json"
+    if not harness_file.exists():
+        return
+    try:
+        data = json.loads(harness_file.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return
+    run.tool_stop_reason = data.get("stop_reason")
+    if isinstance(data.get("tool_calls"), list):
+        run.tool_calls = data["tool_calls"]
+    elif isinstance(data.get("tool_results"), list):
+        run.tool_calls = [
+            {"tool": r.get("tool"), "args": {}, "status": r.get("status")}
+            for r in data["tool_results"]
+            if isinstance(r, dict)
+        ]
+
+
+# ---------------------------------------------------------------------------
 # Review execution (stub — to be wired with actual review scripts)
 # ---------------------------------------------------------------------------
 
@@ -311,8 +429,9 @@ def run_review_for_pr(
         if tool_mode_arg:
             env["TOOL_MODE"] = tool_mode_arg
 
-        # Run the review via run_review.sh
-        review_script = Path("/data/git/pr-reviewer-action/scripts/run_review.sh")
+        # Run the review via run_review.sh (resolved relative to this script,
+        # so the harness is not pinned to one machine's checkout path).
+        review_script = Path(__file__).resolve().parent / "run_review.sh"
         if review_script.exists():
             result = subprocess.run(
                 [str(review_script)],
@@ -339,6 +458,7 @@ def run_review_for_pr(
                     # Parse from stdout if available
                     run.review_markdown = result.stdout[:2000] if result.stdout else ""
 
+                populate_tool_trace(run, repo_path)
             else:
                 run.error = f"Review failed (exit {result.returncode}): {result.stderr[:500]}"
         else:
@@ -380,6 +500,11 @@ def generate_report(
             "recall": 0.0,
             "f1": 0.0,
             "errors": 0,
+            # Capability checks (agentic-evidence-chain criterion). Counted only
+            # for scenarios that declare expected_evidence; pass_rate is the
+            # headline number for the home-ops#7462-style regression.
+            "capability_runs": 0,
+            "capability_passes": 0,
         }
 
     report_results = []
@@ -396,8 +521,11 @@ def generate_report(
             None,
         )
         known_findings = load_known_findings(pr_entry) if pr_entry else []
+        expected_evidence = pr_entry.get("expected_evidence") if pr_entry else None
 
         mode_runs: dict[str, ReviewRun] = {}
+        # Per-mode capability tallies for THIS PR (a PR may run N times/mode).
+        pr_capability: dict[str, dict[str, int]] = {}
         for run in bm.runs:
             active_modes.add(run.mode)
             mm = mode_metrics[run.mode]
@@ -411,8 +539,27 @@ def generate_report(
             else:
                 mm["errors"] += 1
 
+            cap = evaluate_capability(run, expected_evidence)
+            if cap is not None:
+                mm["capability_runs"] += 1
+                tally = pr_capability.setdefault(run.mode, {"runs": 0, "passes": 0})
+                tally["runs"] += 1
+                if cap["passed"]:
+                    mm["capability_passes"] += 1
+                    tally["passes"] += 1
+
+            # Keep the last run's full detail for the per-PR entry; repeated
+            # runs of the same mode are summarised by the capability tally.
             mode_runs[run.mode] = run
             entry[run.mode] = run.to_dict()
+            if cap is not None:
+                entry[run.mode]["capability"] = cap
+
+        if pr_capability:
+            entry["capability_pass_rate"] = {
+                mode: round(t["passes"] / t["runs"], 4) if t["runs"] else 0.0
+                for mode, t in pr_capability.items()
+            }
 
         # Quality comparison for each mode
         for mode in active_modes:
@@ -448,6 +595,14 @@ def generate_report(
             mm["avg_tokens_input"] = 0
             mm["avg_tokens_output"] = 0
             mm["avg_wall_clock_sec"] = 0
+        # Headline agentic-capability number: fraction of capability-scored runs
+        # that closed the expected evidence chain. None when no scenario in the
+        # corpus declared expected_evidence for this mode.
+        mm["capability_pass_rate"] = (
+            round(mm["capability_passes"] / mm["capability_runs"], 4)
+            if mm["capability_runs"] > 0
+            else None
+        )
 
     report = {
         "metadata": {
@@ -525,6 +680,16 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         help="Limit to first N PRs from corpus",
     )
+    parser.add_argument(
+        "--runs-per-mode",
+        type=int,
+        default=1,
+        help=(
+            "Repeat each mode N times per PR and report capability pass RATE. "
+            "Use >=10 for the agentic-evidence-chain criterion — a single run "
+            "is noise at the fast tier's reliability (Tau2 ~68%%)."
+        ),
+    )
     return parser
 
 
@@ -556,10 +721,13 @@ def main() -> int:
     print(f"Modes: {args.modes}", file=sys.stderr)
     print(f"Model: {args.model or '(not set)'}", file=sys.stderr)
 
+    runs_per_mode = max(1, args.runs_per_mode)
+
     if args.dry_run:
         for pr in prs:
             for mode in args.modes:
-                print(f"  Would run: {pr['repo_full_name']}#{pr['number']} [{mode}]")
+                suffix = f" x{runs_per_mode}" if runs_per_mode > 1 else ""
+                print(f"  Would run: {pr['repo_full_name']}#{pr['number']} [{mode}]{suffix}")
         return 0
 
     # Execute reviews
@@ -576,20 +744,23 @@ def main() -> int:
             )
 
             for mode in args.modes:
-                run = run_review_for_pr(pr, mode, work_dir, model_config)
-                bm.runs.append(run)
-                if run.error:
-                    print(f"    [{mode}] ERROR: {run.error}", file=sys.stderr)
-                else:
-                    findings = extract_findings_from_review(run)
-                    print(
-                        f"    [{mode}] verdict={run.verdict} "
-                        f"findings={len(findings)} "
-                        f"tokens_in={run.tokens_input} "
-                        f"tokens_out={run.tokens_output} "
-                        f"wall={run.wall_clock_sec:.1f}s",
-                        file=sys.stderr,
-                    )
+                for rep in range(runs_per_mode):
+                    run = run_review_for_pr(pr, mode, work_dir, model_config)
+                    bm.runs.append(run)
+                    label = f"{mode}" if runs_per_mode == 1 else f"{mode} {rep + 1}/{runs_per_mode}"
+                    if run.error:
+                        print(f"    [{label}] ERROR: {run.error}", file=sys.stderr)
+                    else:
+                        findings = extract_findings_from_review(run)
+                        print(
+                            f"    [{label}] verdict={run.verdict} "
+                            f"findings={len(findings)} "
+                            f"tools={len(run.tool_calls)} "
+                            f"tokens_in={run.tokens_input} "
+                            f"tokens_out={run.tokens_output} "
+                            f"wall={run.wall_clock_sec:.1f}s",
+                            file=sys.stderr,
+                        )
 
             results.append(bm)
 

--- a/scripts/run_tool_harness.py
+++ b/scripts/run_tool_harness.py
@@ -908,6 +908,20 @@ def run_native_loop(
     if outcome.error:
         result["loop_error"] = outcome.error
 
+    # Additive structured trace of executed calls (tool + args + status). The
+    # existing `tool_results` array keeps its executor-result shape for
+    # downstream enforcement; this richer record is what the #207 eval harness
+    # grades capability checks against (e.g. "did a web_fetch hit the support
+    # matrix?"), without parsing the markdown.
+    result["tool_calls"] = [
+        {
+            "tool": executed.tool,
+            "args": executed.args,
+            "status": executed.result.get("status", "error"),
+        }
+        for executed in outcome.executed
+    ]
+
     md_lines = ["# Tool Harness Results", ""]
     md_lines.append(f"**Planned requests:** {outcome.tool_calls_issued}")
     md_lines.append(f"**Loop rounds:** {outcome.rounds}")

--- a/tests/test_eval_harness.py
+++ b/tests/test_eval_harness.py
@@ -18,10 +18,129 @@ from eval_harness import (
     KnownFinding,
     ReviewRun,
     compute_precision_recall,
+    evaluate_capability,
     extract_findings_from_review,
     generate_report,
     load_known_findings,
 )
+
+
+# Reusable expected_evidence block mirroring the home-ops#7462 scenario.
+TALOS_EVIDENCE = {
+    "description": "chain to the support matrix and cite it",
+    "checks": [
+        {"id": "read_machineconfig", "type": "tool_call", "tool": "read_file",
+         "args_contains": {"path": ["machineconfig"]}},
+        {"id": "fetched_support_matrix", "type": "tool_call", "tool": "web_fetch",
+         "args_contains": {"url": ["talos.dev", "support-matrix"]}},
+        {"id": "cited_matrix_in_review", "type": "review_mentions",
+         "any_of": ["support matrix", "talos.dev"]},
+    ],
+}
+
+
+def _chained_run(mode="native_loop"):
+    """A run that fully closes the Talos evidence chain."""
+    return ReviewRun(
+        mode=mode, pr_number=7462, repo_full_name="joryirving/home-ops",
+        review_markdown="Verified against the Talos support matrix: k8s v1.36 is supported.",
+        tool_calls=[
+            {"tool": "read_file", "args": {"path": "talos/main/machineconfig.yaml.j2"}, "status": "ok"},
+            {"tool": "web_fetch", "args": {"url": "https://www.talos.dev/v1.13/introduction/support-matrix/"}, "status": "ok"},
+        ],
+        tool_stop_reason="model-stopped",
+    )
+
+
+class TestEvaluateCapability:
+    def test_no_expected_evidence_returns_none(self):
+        assert evaluate_capability(_chained_run(), None) is None
+        assert evaluate_capability(_chained_run(), {"checks": []}) is None
+
+    def test_full_chain_passes(self):
+        cap = evaluate_capability(_chained_run(), TALOS_EVIDENCE)
+        assert cap["passed"] is True
+        assert all(c["passed"] for c in cap["checks"])
+
+    def test_pattern_rubber_stamp_fails(self):
+        """No tools, no citation — the current Gemma failure mode."""
+        run = ReviewRun(
+            mode="native_loop", pr_number=7462, repo_full_name="joryirving/home-ops",
+            review_markdown="Patch bump v1.36.1 -> v1.36.2, low risk. Approve.",
+            tool_calls=[],
+        )
+        cap = evaluate_capability(run, TALOS_EVIDENCE)
+        assert cap["passed"] is False
+        assert {c["id"] for c in cap["checks"] if not c["passed"]} == {
+            "read_machineconfig", "fetched_support_matrix", "cited_matrix_in_review"
+        }
+
+    def test_fetched_but_not_cited_fails(self):
+        """Gathered the evidence but didn't use it in the verdict — partial."""
+        run = _chained_run()
+        run.review_markdown = "Patch bump, looks routine, approve."
+        cap = evaluate_capability(run, TALOS_EVIDENCE)
+        assert cap["passed"] is False
+        failed = {c["id"] for c in cap["checks"] if not c["passed"]}
+        assert failed == {"cited_matrix_in_review"}
+
+    def test_wrong_url_fails_the_fetch_check(self):
+        run = _chained_run()
+        run.tool_calls[1]["args"]["url"] = "https://github.com/some/other/page"
+        cap = evaluate_capability(run, TALOS_EVIDENCE)
+        assert cap["passed"] is False
+        assert any(c["id"] == "fetched_support_matrix" and not c["passed"] for c in cap["checks"])
+
+    def test_errored_tool_call_is_not_evidence(self):
+        run = _chained_run()
+        run.tool_calls[1]["status"] = "error"
+        cap = evaluate_capability(run, TALOS_EVIDENCE)
+        assert any(c["id"] == "fetched_support_matrix" and not c["passed"] for c in cap["checks"])
+
+    def test_errored_run_fails_all_checks(self):
+        run = _chained_run()
+        run.error = "Review timed out"
+        cap = evaluate_capability(run, TALOS_EVIDENCE)
+        assert cap["passed"] is False
+        assert not any(c["passed"] for c in cap["checks"])
+
+
+class TestCapabilityRateAggregation:
+    def test_pass_rate_over_repeated_runs(self):
+        """10 native_loop runs, 7 close the chain -> rate 0.7."""
+        pr = {
+            "number": 7462, "repo_full_name": "joryirving/home-ops",
+            "url": "https://github.com/joryirving/home-ops/pull/7462",
+            "known_findings": [], "expected_evidence": TALOS_EVIDENCE,
+        }
+        corpus = BenchmarkCorpus(prs=[pr])
+        runs = [_chained_run() for _ in range(7)]
+        for _ in range(3):
+            bad = _chained_run()
+            bad.tool_calls = []
+            bad.review_markdown = "approve"
+            runs.append(bad)
+        results = [BenchmarkResult(pr_number=7462, repo_full_name="joryirving/home-ops", runs=runs)]
+
+        report = generate_report(results, corpus)
+        nl = report["mode_summary"]["native_loop"]
+        assert nl["capability_runs"] == 10
+        assert nl["capability_passes"] == 7
+        assert nl["capability_pass_rate"] == 0.7
+        assert report["per_pr_results"][0]["capability_pass_rate"]["native_loop"] == 0.7
+
+    def test_findings_only_pr_has_no_capability_rate(self):
+        pr = {
+            "number": 110, "repo_full_name": "misospace/pr-reviewer-action",
+            "url": "https://github.com/misospace/pr-reviewer-action/pull/110",
+            "known_findings": [],
+        }
+        corpus = BenchmarkCorpus(prs=[pr])
+        run = ReviewRun(mode="tools_off", pr_number=110, repo_full_name="misospace/pr-reviewer-action")
+        results = [BenchmarkResult(pr_number=110, repo_full_name="misospace/pr-reviewer-action", runs=[run])]
+        report = generate_report(results, corpus)
+        assert report["mode_summary"]["tools_off"]["capability_pass_rate"] is None
+        assert "capability_pass_rate" not in report["per_pr_results"][0]
 
 
 # ---------------------------------------------------------------------------
@@ -302,6 +421,22 @@ class TestSampleCorpus:
         for pr in corpus.prs:
             findings = load_known_findings(pr)
             assert len(findings) > 0
+
+    def test_agentic_corpus_loads_and_grades(self):
+        path = Path(__file__).parent.parent / "evals" / "corpus-agentic.json"
+        if not path.exists():
+            pytest.skip("evals/corpus-agentic.json not found")
+        corpus = BenchmarkCorpus.from_file(path)
+        assert len(corpus.prs) >= 1
+        pr = corpus.prs[0]
+        ee = pr["expected_evidence"]
+        # The scenario must be gradable: the chained run passes, rubber stamp fails.
+        chained = _chained_run()
+        assert evaluate_capability(chained, ee)["passed"] is True
+        stamp = ReviewRun(mode="native_loop", pr_number=pr["number"],
+                          repo_full_name=pr["repo_full_name"],
+                          review_markdown="patch bump, approve", tool_calls=[])
+        assert evaluate_capability(stamp, ee)["passed"] is False
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Builds on the now-merged native_loop driver (#240). Encodes the #203 acceptance criterion as a scored, repeatable eval-harness scenario.

## Why
The #207 A/B harness scored only findings precision/recall — which structurally cannot express the #203 acceptance criterion: *with no Talos-specific prompting, does the reviewer chain tools to consult the platform's published compatibility matrix and cite it?* That's a **capability assertion** on the evidence chain, and at the fast tier's reliability (Gemma-4-A4B Tau2 ≈68%) it only means something as a **pass rate over many runs**, not a single demo.

## What
- **`evaluate_capability()`** grades a run against a scenario's `expected_evidence`:
  - `tool_call` checks — some executed call matches the tool name and, per arg key, contains all listed substrings (e.g. a `web_fetch` whose `url` holds both `talos.dev` and `support-matrix`). Failed/errored calls don't count as evidence.
  - `review_mentions` checks — the published review cites any of the given phrases.
  - Capability passes iff all checks pass; an errored run fails everything.
- **`--runs-per-mode N`** repeats each mode per PR; `generate_report` aggregates a per-mode **`capability_pass_rate`** (plus a per-PR breakdown). This is the headline regression number.
- **`native_loop` emits an additive `tool_calls` array** (`{tool,args,status}`) in `tool-harness.json`, so the grader scores from structured JSON rather than parsing markdown. `populate_tool_trace` reads it back; the run path's hardcoded `/data/git/...` is replaced with a script-relative resolve.
- **`evals/corpus-agentic.json`** — home-ops#7462 as the standing regression scenario: read the machineconfig → `web_fetch` the Talos support matrix → cite it. Capability altitude only — nothing Talos-specific reaches the reviewer; only the grader names the concrete expected evidence.

## How you'll use it
```
scripts/eval_harness.py --corpus evals/corpus-agentic.json \
  --modes native_loop plan_execute tools_off --runs-per-mode 10 \
  --base-url $LITELLM_URL --model review --api-key $KEY --github-token $GH
```
Read `mode_summary[*].capability_pass_rate`. This is also the rig for the **GLM-4.7-Flash vs Gemma-4-A4B** reviewer-model A/B — same corpus, swap `--model`.

## Tests
10 new: full chain passes; the four partial-failure modes (rubber-stamp / fetched-but-not-cited / wrong-url / errored-tool) fail the right checks; errored run fails all; rate aggregation (7/10 → 0.7); findings-only PRs carry no capability rate; the shipped corpus loads and grades. Full suite green.

## Not in scope
Live-model execution still needs a real endpoint (the harness's run path remains the existing subprocess integration, now de-hardcoded but not fully exercised without a model). The scoring + scenario + rate are fully unit-tested with injected traces.

Refs #207, #203.
