### PR TITLE
fix(ci,docs): isolate labeled events from cancel-in-progress concurrency

### DIFF
--- a/.github/workflows/ai-pr-review.yaml
+++ b/.github/workflows/ai-pr-review.yaml
@@ -9,7 +9,9 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  # `labeled` events get their own group so an auto-applied label can't cancel
+  # the in-flight opened/synchronize review (see README → Forcing a re-review).
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}${{ github.event.action == 'labeled' && format('-label-{0}', github.run_id) || '' }}
   cancel-in-progress: true
 
 permissions:

--- a/README.md
+++ b/README.md
@@ -459,6 +459,17 @@ on:
     types: [opened, reopened, synchronize, ready_for_review, labeled]   # ← add `labeled`
 ```
 
+> **If your workflow uses `concurrency` with `cancel-in-progress: true`** (common), give `labeled`
+> events their own group — otherwise an auto-applied label (e.g. Renovate adding labels at PR
+> creation) spawns a `labeled` run that cancels the in-flight `opened` review, and the PR goes
+> unreviewed:
+>
+> ```yaml
+> concurrency:
+>   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}${{ github.event.action == 'labeled' && format('-label-{0}', github.run_id) || '' }}
+>   cancel-in-progress: true
+> ```
+
 Nothing else changes. The action detects the label event itself: if the added label is the `rereview_label` (default `ai-review`) it forces a fresh review and then **removes the label** so adding it again re-triggers; any other label is ignored. There's no second workflow, no command parsing, and no checkout/authorization dance — labels are inherently maintainer-only (only users with write/triage permission can apply them), and the trigger rides `pull_request`, so there's no privileged-checkout exposure.
 
 Rename the trigger label with the `rereview_label` input if `ai-review` collides with an existing label. This repository's own [`ai-pr-review.yaml`](.github/workflows/ai-pr-review.yaml) uses exactly this wiring.


### PR DESCRIPTION
Follow-up to the v1.2.9 label re-review rollout. The README's "add `labeled` to your `pull_request` types" guidance is incomplete: with a shared `concurrency` group + `cancel-in-progress: true` (a common setup), an auto-applied label at PR creation (Renovate applies several) spawns a `labeled` run that **cancels the in-flight `opened` review**, leaving the PR unreviewed. Observed live on home-ops#7507; fix verified on home-ops#7512.

No action code changes — the precheck skip is correct; the issue is purely consumer-workflow concurrency.

- **Own workflow:** `labeled` events now get their own concurrency group (`…-label-<run_id>`), so they can't cancel a real `opened`/`synchronize` review. opened/synchronize keep the shared group + `cancel-in-progress`.
- **README:** adds the concurrency caveat + snippet to *Forcing a re-review*, right after the `types:` change, so new adopters get the safe pattern.
