### PR TITLE
Fix auto platform detection for Forgejo API URL

### DIFF
--- a/pr_reviewer/platform.py
+++ b/pr_reviewer/platform.py
@@ -20,11 +20,14 @@ def resolve_platform() -> str:
     """Resolve PLATFORM (github|forgejo|auto) to a concrete backend name.
 
     Mirrors ``platform_resolve`` in scripts/platform_api.sh: ``auto`` maps to
-    forgejo when GITHUB_SERVER_URL names a non-github.com host (Forgejo
-    Actions runners populate it with the instance URL), github otherwise.
+    forgejo when FORGEJO_API_URL is set or GITHUB_SERVER_URL names a
+    non-github.com host (Forgejo Actions runners populate it with the
+    instance URL), github otherwise.
     """
     platform = os.environ.get("PLATFORM", "github").strip().lower() or "github"
     if platform == "auto":
+        if os.environ.get("FORGEJO_API_URL", "").strip():
+            return "forgejo"
         server = os.environ.get("GITHUB_SERVER_URL", "").rstrip("/")
         if server and server != "https://github.com":
             return "forgejo"

--- a/scripts/platform_api.sh
+++ b/scripts/platform_api.sh
@@ -13,9 +13,9 @@
 #   forgejo – operations via pr_reviewer/forgejo_backend.py (curl /api/v1).
 #             Requires FORGEJO_API_URL. Implemented per-operation across the
 #             1.4.x line; unimplemented operations fail loudly, never silently.
-#   auto    – resolved here: forgejo when GITHUB_SERVER_URL is set to a
-#             non-github.com host (Forgejo Actions runners populate it with
-#             the instance URL), github otherwise.
+#   auto    – resolved here: forgejo when FORGEJO_API_URL is set or when
+#             GITHUB_SERVER_URL names a non-github.com host (Forgejo Actions
+#             runners populate it with the instance URL), github otherwise.
 #
 # Two function classes:
 #   platform_*       – the repo under review; switches on PLATFORM.
@@ -40,10 +40,15 @@ _PLATFORM_API_SOURCED=1
 _PLATFORM_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 platform_resolve() {
-  # Normalise PLATFORM, resolving `auto` from GITHUB_SERVER_URL.
+  # Normalize PLATFORM, resolving `auto` from explicit Forgejo config or host.
   local p="${PLATFORM:-github}"
   p="$(printf '%s' "$p" | tr '[:upper:]' '[:lower:]')"
   if [[ "$p" == "auto" ]]; then
+    if [[ -n "${FORGEJO_API_URL:-}" ]]; then
+      p="forgejo"
+      printf '%s' "$p"
+      return 0
+    fi
     local server="${GITHUB_SERVER_URL:-}"
     if [[ -n "$server" && "$server" != "https://github.com" && "$server" != "https://github.com/" ]]; then
       p="forgejo"

--- a/scripts/resolve_finding_threads.py
+++ b/scripts/resolve_finding_threads.py
@@ -49,22 +49,15 @@ for _p in (str(_SCRIPTS_DIR), str(_ACTION_ROOT)):
 
 from build_review_comments import FINDING_MARKER_PREFIX, finding_fingerprint  # noqa: E402
 from pr_reviewer.carry_forward import load_carried_findings  # noqa: E402
-from pr_reviewer.platform import PlatformUnsupported, gh_argv  # noqa: E402
+from pr_reviewer.platform import PlatformUnsupported, gh_argv, resolve_platform  # noqa: E402
 
 
 def _resolve_platform() -> str:
-    """Resolve effective platform from PLATFORM env var and FORGEJO_API_URL.
-
-    Returns 'github' or 'forgejo'. Mirrors the shell resolve_platform() in
-    publish_helpers.sh so both degrade consistently.
-    """
-    platform = os.environ.get("PLATFORM", "auto").lower()
-    if platform in ("github", "forgejo"):
-        return platform
-    # auto (default) or unknown → detect from FORGEJO_API_URL
-    if os.environ.get("FORGEJO_API_URL", "").strip():
-        return "forgejo"
-    return "github"
+    """Resolve effective platform using the shared Python seam."""
+    try:
+        return resolve_platform()
+    except ValueError:
+        return "github"
 
 
 def _is_github_platform() -> bool:

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -37,8 +37,16 @@ class TestResolvePlatform(unittest.TestCase):
         with _env(PLATFORM="auto", GITHUB_SERVER_URL="https://forgejo.example.com"):
             self.assertEqual(resolve_platform(), "forgejo")
 
+    def test_auto_forgejo_api_url_wins(self):
+        with _env(
+            PLATFORM="auto",
+            FORGEJO_API_URL="https://forgejo.example.com",
+            GITHUB_SERVER_URL="https://github.com",
+        ):
+            self.assertEqual(resolve_platform(), "forgejo")
+
     def test_auto_no_server_is_github(self):
-        with _env(PLATFORM="auto", GITHUB_SERVER_URL=""):
+        with _env(PLATFORM="auto", GITHUB_SERVER_URL="", FORGEJO_API_URL=""):
             self.assertEqual(resolve_platform(), "github")
 
     def test_invalid_raises(self):

--- a/tests/test_platform_api.sh
+++ b/tests/test_platform_api.sh
@@ -34,10 +34,11 @@ export PATH="$TMP/bin:$PATH"
 
 # Run a snippet in a clean subshell with controlled env; echoes stdout.
 run_seam() {
-  local platform="$1" server="$2" snippet="$3"
+  local platform="$1" server="$2" snippet="$3" forgejo_api_url="${4:-}"
   (
     export PLATFORM="$platform"
     if [[ -n "$server" ]]; then export GITHUB_SERVER_URL="$server"; else unset GITHUB_SERVER_URL; fi
+    if [[ -n "$forgejo_api_url" ]]; then export FORGEJO_API_URL="$forgejo_api_url"; else unset FORGEJO_API_URL; fi
     unset _PLATFORM_API_SOURCED
     # shellcheck disable=SC1090
     source "$SEAM"
@@ -52,6 +53,7 @@ check "explicit forgejo" "$(run_seam forgejo "" 'platform_resolve')" "forgejo"
 check "auto + github.com server → github" "$(run_seam auto "https://github.com" 'platform_resolve')" "github"
 check "auto + no server → github" "$(run_seam auto "" 'platform_resolve')" "github"
 check "auto + custom host → forgejo" "$(run_seam auto "https://forgejo.example.com" 'platform_resolve')" "forgejo"
+check "auto + FORGEJO_API_URL → forgejo" "$(run_seam auto "https://github.com" 'platform_resolve' "https://forgejo.example.com")" "forgejo"
 check "case-insensitive" "$(run_seam GITHUB "" 'platform_resolve')" "github"
 RESULT="$(run_seam gitlab "" 'platform_resolve')"
 check "invalid platform errors" "$(echo "$RESULT" | grep -c "unsupported PLATFORM")" "1"


### PR DESCRIPTION
Fixes #221

This keeps the platform abstraction's `auto` mode consistent with the documented action input behavior by resolving to Forgejo when `FORGEJO_API_URL` is provided, even on a github.com server URL.

Changes:
- updates the shell platform seam to honor `FORGEJO_API_URL` in `auto` mode before host fallback
- updates the Python platform seam to match the shell behavior
- routes finding-thread platform detection through the shared Python seam instead of a local duplicate
- adds regression coverage for `FORGEJO_API_URL`-driven auto detection

Validation:
- `python3 -m pytest tests/test_platform.py tests/test_resolve_finding_threads.py -q`
- `bash tests/test_platform_api.sh`
