### PR TITLE
feat(tool-loop): steer reviewers to structured forge APIs over HTML pages

### DIFF
--- a/pr_reviewer/conversation.py
+++ b/pr_reviewer/conversation.py
@@ -55,9 +55,12 @@ TOOL_SCHEMAS: list[dict[str, Any]] = [
     {
         "name": "gh_api",
         "description": (
-            "Read-only GitHub REST API call. Path must start with one of "
-            "repos/, issues/, search/, releases/, git/ and target an "
-            "allowlisted repo. Use for PR/issue/release/commit lookups."
+            "Read-only GitHub REST API call returning structured JSON. Path "
+            "must start with repos/, issues/, search/, releases/, git/ and "
+            "target an allowlisted repo. Prefer this over web_fetch for "
+            "anything on github.com: releases (repos/o/r/releases/tags/TAG) "
+            "and version diffs (repos/o/r/compare/BASE...HEAD) — it avoids the "
+            "HTML pages that often 404."
         ),
         "parameters": {
             "type": "object",
@@ -100,8 +103,12 @@ TOOL_SCHEMAS: list[dict[str, Any]] = [
     {
         "name": "web_fetch",
         "description": (
-            "Fetch a URL whose host appears in the action's allowlist. "
-            "Output is truncated to ~10 KB of decoded text."
+            "Fetch a URL whose host is allowlisted; output truncated to ~10 KB "
+            "of decoded text. Prefer a structured API endpoint over an HTML "
+            "release/compare page (HTML often 404s or is JS-rendered): for "
+            "github.com use gh_api; for a Gitea/Forgejo host fetch its "
+            "/api/v1/... JSON (e.g. .../releases/tags/TAG or "
+            ".../compare/BASE...HEAD), not the web page."
         ),
         "parameters": {
             "type": "object",

--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -51,6 +51,15 @@ class TestToolSchemas:
         # The allowlist in scripts/run_tool_harness.py (ALLOWED_COMMANDS).
         assert set(enum) == {"git_status_short", "git_diff_stat", "git_diff_name_only"}
 
+    def test_structured_api_steering_present(self):
+        # Guards the gh_api-over-web_fetch steering: the model should reach for
+        # the structured API (gh_api / a forge's /api/v1) rather than scraping
+        # HTML release/compare pages that 404. Forge-agnostic.
+        desc = {s["name"]: s["description"].lower() for s in TOOL_SCHEMAS}
+        assert "compare" in desc["gh_api"]
+        assert "gh_api" in desc["web_fetch"]
+        assert "/api/v1" in desc["web_fetch"]
+
 
 class TestWebSearchGating:
     """web_search is opt-in: advertised only when the conversation carries it."""


### PR DESCRIPTION
## Problem

The native tool loop sometimes `web_fetch`es an HTML release/compare page (e.g. `github.com/o/r/releases/tag/X`) — which 404s or is JS-rendered — and only then falls back to the structured API. Observed on a real review (`web_fetch` → 404, then GitHub compare metadata succeeded). A wasted call and a flakier path.

## Fix (guidance only, forge-agnostic)

Sharpen the two tool descriptions so the model reaches for **structured JSON** first:

- **`gh_api`** — "prefer over `web_fetch` for anything on github.com," and names the two endpoints reviewers actually want: `repos/o/r/releases/tags/TAG` and `repos/o/r/compare/BASE...HEAD`.
- **`web_fetch`** — "prefer a structured endpoint over an HTML release/compare page": github.com → `gh_api`; a **Gitea/Forgejo** host → its `/api/v1/...` JSON (releases/compare), not the web page.

No behavior change — this is guidance, not a host block — so it's safe for every consumer (some may legitimately scrape GitHub HTML). The forge-agnostic framing (GitHub *and* Gitea/Forgejo, no hardcoded hosts) keeps it useful regardless of where a given consumer's upstreams live. A regression test locks the steering into the schemas.

Deliberately **not** added: a `forge_api` tool or a `github.com` web_fetch block — over-engineered for the payoff, and the steering covers it.
