### PR TITLE
feat(tool-loop): stream native-loop turns w/ non-streamed fallback (4/7 of #197)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -318,11 +318,13 @@ inputs:
       evidence tools in a single planning round before the final review. plan_execute_loop
       re-plans after seeing each round's results (up to tool_max_rounds), so the model can
       dig further based on what it found; tool_max_requests is the total budget across rounds.
-      native_loop uses the model's native tool-calling API (non-streaming): the model holds
+      native_loop uses the model's native tool-calling API: the model holds
       the tool schemas and decides each next call from the previous result, enabling the
       multi-hop chains the planner modes cannot express; a model that never emits a tool
-      call degrades automatically to the plan_execute_loop path. Budgets reuse
-      tool_max_requests and tool_max_rounds, plus tool_loop_wall_clock_sec.
+      call degrades automatically to the plan_execute_loop path. Loop turns stream by
+      default (controlled by ai_stream) so long turns don't time out behind a short-idle
+      proxy; a stream that can't be reassembled is retried non-streamed for that turn.
+      Budgets reuse tool_max_requests and tool_max_rounds, plus tool_loop_wall_clock_sec.
     required: false
     default: "off"
   tool_loop_wall_clock_sec:
@@ -344,7 +346,7 @@ inputs:
     required: false
     default: "3"
   tool_planning_timeout_sec:
-    description: Timeout in seconds for the model planning call used by tool harness. Non-streaming, so set generously for local models with slow prompt eval.
+    description: Timeout in seconds for the model planning call used by tool harness. Set generously for local models with slow prompt eval; native_loop streams turns by default (ai_stream) to avoid short-idle-proxy timeouts.
     required: false
     default: "60"
   tool_planning_max_context_bytes:

--- a/pr_reviewer/tool_loop.py
+++ b/pr_reviewer/tool_loop.py
@@ -3,8 +3,15 @@
 Drives an agentic exchange against a tool-capable model: send the corpus +
 tool schemas, execute the tool calls the model returns, append the results,
 and repeat until the model stops calling tools or a budget runs out.
-Non-streaming requests only (streaming arrives in 4/7 on top of
-``pr_reviewer.sse_reassembler``).
+
+Each turn can be streamed (``stream=True``): the injected ``post_fn`` is
+responsible for reassembling the SSE deltas (via
+``pr_reviewer.sse_reassembler``) back into the non-streaming response shape
+this module parses, so the driver itself stays format-agnostic. Streaming
+restores the long-request timeout protection (Cloudflare's 100s edge timer
+etc.) that a blocking POST through a proxy loses on long thinking-model
+turns; the non-streamed request stays available as the per-turn fallback
+the transport falls back to when a stream can't be reassembled (#204).
 
 The module is deliberately I/O-free: the HTTP POST and the tool execution
 are injected callables, so the whole loop is unit-testable against scripted
@@ -175,12 +182,15 @@ def drive_tool_loop(
     budgets: LoopBudgets | None = None,
     max_tokens: int = 1024,
     temperature: float = 0.0,
+    stream: bool = False,
     time_fn: Callable[[], float] = time.monotonic,
 ) -> LoopOutcome:
     """Run the agentic loop until the model stops or a budget hits.
 
     ``post_fn`` takes a wire-ready request payload and returns the parsed
-    response JSON (raising on transport failure). ``execute_fn`` takes
+    response JSON (raising on transport failure). When ``stream`` is set the
+    payload carries ``stream: true`` and ``post_fn`` owns SSE reassembly,
+    handing back the same non-streaming response shape. ``execute_fn`` takes
     ``(tool_name, args)`` and returns the executor result dict
     ``{"tool", "status", "result"}`` — in production this is
     ``run_tool_harness.execute_tool_request`` with allowlists/caps bound in.
@@ -208,7 +218,7 @@ def drive_tool_loop(
         payload = conversation.to_request_payload(
             api_format,
             model,
-            stream=False,
+            stream=stream,
             max_tokens=max_tokens,
             temperature=temperature,
         )

--- a/scripts/run_tool_harness.py
+++ b/scripts/run_tool_harness.py
@@ -197,6 +197,15 @@ def run_chat_request(base_url, api_format, payload, api_key, timeout_sec):
     if api_format == "anthropic":
         curl_args.extend(["-H", f"anthropic-version: {os.getenv('ANTHROPIC_VERSION', '2023-06-01')}"])
 
+    # Streaming keeps bytes flowing so proxies with a short idle/read timeout
+    # (Cloudflare's 100s edge timer etc.) don't 524 a long thinking-model turn.
+    # --no-buffer flushes each SSE chunk; the body is reassembled below.
+    streaming = bool(payload.get("stream"))
+    if streaming:
+        curl_args.append("--no-buffer")
+        if api_format == "anthropic":
+            curl_args.extend(["-H", "Accept: text/event-stream"])
+
     # The API key goes through a 0600 curl --config file rather than argv, so
     # it never appears in /proc/<pid>/cmdline or `ps` output on shared runners.
     auth_config_path = None
@@ -238,6 +247,13 @@ def run_chat_request(base_url, api_format, payload, api_key, timeout_sec):
             + (f": {stderr}" if stderr else "")
         )
 
+    if streaming:
+        # SSE deltas → the non-streaming response shape the loop parses. The
+        # reassembler also surfaces a JSON error body returned mid-"stream"
+        # (some servers reply 200 + an error object instead of events).
+        from pr_reviewer.sse_reassembler import reassemble_sse  # noqa: PLC0415
+
+        return reassemble_sse(completed.stdout, api_format)
     return json.loads(completed.stdout)
 
 
@@ -929,8 +945,32 @@ def run_native_loop(
         wall_clock_sec=float(wall_clock),
     )
 
+    # Stream loop turns by default (mirrors AI_STREAM for the review call) so
+    # long thinking-model turns don't 524 behind a short-idle proxy (#204).
+    stream = os.getenv("AI_STREAM", "true").strip().lower() == "true"
+
     def post_fn(payload):
-        return run_chat_request(base_url, api_format, payload, api_key, planning_timeout)
+        # Per-turn fallback: a streamed turn that can't be reassembled — a
+        # truncated/garbled SSE body (transport raise) or a 200 error object
+        # (error key) — is retried once non-streamed before the loop gives up.
+        try:
+            response = run_chat_request(
+                base_url, api_format, payload, api_key, planning_timeout
+            )
+            if not (payload.get("stream") and response.get("error")):
+                return response
+        except Exception:
+            if not payload.get("stream"):
+                raise
+        print(
+            "  native loop: streamed turn unusable; retrying non-streamed",
+            file=sys.stderr,
+        )
+        fallback = {k: v for k, v in payload.items() if k != "stream_options"}
+        fallback["stream"] = False
+        return run_chat_request(
+            base_url, api_format, fallback, api_key, planning_timeout
+        )
 
     def execute_fn(tool_name, args):
         normalized_name, normalized_args = normalize_tool_request(
@@ -957,6 +997,7 @@ def run_native_loop(
         model=model,
         budgets=budgets,
         max_tokens=planning_max_tokens,
+        stream=stream,
     )
 
     if outcome.degraded:

--- a/tests/test_run_native_loop_wiring.py
+++ b/tests/test_run_native_loop_wiring.py
@@ -119,6 +119,151 @@ def test_native_loop_two_hops_writes_outputs(monkeypatch, tmp_path):
     assert "v1.36.2" in md
 
 
+def _make_sse_line(data):
+    return f"data: {json.dumps(data)}"
+
+
+def test_run_chat_request_streams_and_reassembles(monkeypatch):
+    """A streamed payload sends --no-buffer and the SSE body is reassembled
+    into the non-streaming response shape the loop driver parses (#204)."""
+    import types
+
+    sse = "\n".join(
+        [
+            _make_sse_line(
+                {
+                    "id": "c1",
+                    "model": "m",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {
+                                "role": "assistant",
+                                "tool_calls": [
+                                    {
+                                        "index": 0,
+                                        "id": "call_abc",
+                                        "type": "function",
+                                        "function": {
+                                            "name": "read_file",
+                                            "arguments": '{"path":',
+                                        },
+                                    }
+                                ],
+                            },
+                        }
+                    ],
+                }
+            ),
+            _make_sse_line(
+                {
+                    "id": "c1",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {
+                                "tool_calls": [
+                                    {
+                                        "index": 0,
+                                        "function": {"arguments": ' "a.txt"}'},
+                                    }
+                                ]
+                            },
+                        }
+                    ],
+                }
+            ),
+            _make_sse_line(
+                {
+                    "id": "c1",
+                    "choices": [{"index": 0, "delta": {}, "finish_reason": "tool_calls"}],
+                }
+            ),
+            "data: [DONE]",
+        ]
+    )
+
+    captured = {}
+
+    def fake_safe_run(args, timeout_sec):
+        captured["args"] = args
+        return types.SimpleNamespace(returncode=0, stdout=sse, stderr="")
+
+    monkeypatch.setattr(rth, "safe_run", fake_safe_run)
+
+    payload = {"model": "m", "stream": True, "stream_options": {"include_usage": True}}
+    parsed = rth.run_chat_request("http://model.local/v1", "openai", payload, "", 30)
+
+    assert "--no-buffer" in captured["args"]
+    msg = parsed["choices"][0]["message"]
+    assert parsed["choices"][0]["finish_reason"] == "tool_calls"
+    assert msg["tool_calls"][0]["function"]["name"] == "read_file"
+    # arguments reassembled across deltas, kept as a JSON string (#233 contract)
+    assert msg["tool_calls"][0]["function"]["arguments"] == '{"path": "a.txt"}'
+
+
+def test_native_loop_falls_back_to_non_streamed_turn(monkeypatch, tmp_path):
+    """A streamed turn that can't be reassembled is retried non-streamed,
+    covering both triggers: a 200 error body and a transport raise (#204)."""
+    monkeypatch.setenv("AI_STREAM", "true")
+    monkeypatch.setenv("EFFECTIVE_SCOPE", "full")
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "machineconfig.yaml.j2").write_text(
+        "install: factory.talos.dev/installer:v1.13.4\n", encoding="utf-8"
+    )
+
+    seen = []
+    fallback_payloads = []
+
+    def fake_request(base_url, api_format, payload, api_key, timeout_sec):
+        streamed = bool(payload.get("stream"))
+        seen.append(streamed)
+        if streamed:
+            # Turn 1 streamed → garbled 200 error body; turn 2 streamed → raise.
+            if sum(1 for s in seen if s) == 1:
+                return {"error": {"message": "garbled stream"}}
+            raise RuntimeError("connection reset mid-stream")
+        fallback_payloads.append(payload)
+        # Non-streamed fallback: turn 1 reads the machineconfig, turn 2 stops.
+        if len(fallback_payloads) == 1:
+            return _openai_call("c1", "read_file", '{"path": "machineconfig.yaml.j2"}')
+        return _openai_text("Reviewed via non-streamed fallback.")
+
+    monkeypatch.setattr(rth, "run_chat_request", fake_request)
+
+    result = {
+        "mode": "plan_execute_once",
+        "planned_request_count": 0,
+        "executed_request_count": 0,
+        "tool_results": [],
+    }
+    handled = rth.run_native_loop(
+        "owner/repo",
+        "http://model.local/v1",
+        "openai",
+        "mock-model",
+        "key",
+        "# PR Corpus\nbumps kubelet image in machineconfig.yaml.j2",
+        {"owner/repo"},
+        ["talos.dev"],
+        str(tmp_path),
+        12000,
+        15,
+        4,
+        45,
+        400,
+        result,
+    )
+    # Both fallback triggers fired (error body then raise), each retried
+    # non-streamed, and the tool call executed for real on the fallback turn.
+    assert handled is True
+    assert result["mode"] == "native_loop"
+    assert result["planned_request_count"] == 1
+    assert seen == [True, False, True, False]
+    # The non-streamed fallback request drops the streaming-only stream_options.
+    assert all("stream_options" not in p and p["stream"] is False for p in fallback_payloads)
+
+
 def test_native_loop_degrades_writes_nothing(monkeypatch, tmp_path):
     handled, result = _run(
         monkeypatch,


### PR DESCRIPTION
Closes #204. Part of #197 §1 (item 4/7 — composes 1/7 SSE reassembly + 3/7 loop driver).

## Problem
The native tool-calling loop (#240) sent every turn as a **blocking, non-streamed** POST. Long thinking-model turns through a short-idle proxy (Cloudflare's 100s edge timer etc.) 524 mid-generation. Invisible until now only because shipped consumers run `plan_execute_loop`, whose synthesis call already honors `ai_stream`. **This gates the home-ops `native_loop` rollout** (#253 / the Talos chain).

## Change
- **`drive_tool_loop`** gains a `stream` flag threaded into `to_request_payload`. The injected `post_fn` owns SSE reassembly, so the driver stays format-agnostic. Default `False` → every existing call site and test is unchanged.
- **`run_chat_request`** streams when the payload sets `stream`: adds `--no-buffer` (+ `Accept: text/event-stream` for Anthropic) and reassembles the body via `sse_reassembler.reassemble_sse` (#201) into the non-streaming shape the loop parses. The reassembler also surfaces a `200 + error-object` body.
- **`run_native_loop`** streams by default (honors `AI_STREAM`, already wired in the review step's env) with a **per-turn non-streamed fallback** when a stream can't be reassembled — a transport raise *or* a surfaced error body — dropping `stream_options` on the retry.
- **`action.yml`** docs corrected (native_loop is no longer described as "non-streaming").

Matches the issue spec: streaming is the timeout fix (bytes keep the connection alive); non-streamed remains the fallback when reassembly fails mid-conversation.

## Tests
New: transport-level streaming reassembly, and the two-trigger per-turn fallback (error body, then transport raise). Full suite **808 passing** on Python 3.14.
