### PR TITLE
fix(ops): default ai_max_tokens 4096 → 8192 for reasoning models

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Only three inputs are required: `github_token`, `ai_base_url`, and `ai_model`. E
 | `ai_api_format` | Primary API request/response format: `openai` or `anthropic` | No | `openai` |
 | `ai_model` | Model name for the primary analysis pass | Yes | - |
 | `ai_api_key` | Optional API key for the primary AI endpoint. OpenAI format sends `Authorization: Bearer`; Anthropic format sends `x-api-key` | No | `""` |
-| `ai_max_tokens` | Maximum completion tokens for primary and fallback final review calls. Required by Anthropic-compatible APIs | No | `4096` |
+| `ai_max_tokens` | Maximum completion tokens for primary and fallback final review calls. Required by Anthropic-compatible APIs. **Reasoning models** (those that emit a thinking channel, e.g. Gemma) need this headroom — too low a cap is spent on reasoning, leaving empty content (`finish_reason=length`) so the verdict JSON fails to parse and the review needlessly escalates; raise to `16000`+ for verbose reasoners | No | `8192` |
 | `ai_temperature` | Sampling temperature for the review model. Empty string omits the field (some newer cloud models reject non-default temperature) | No | `0.1` |
 | `ai_response_format` | Structured-output mode for OpenAI-compatible endpoints (incl. LiteLLM): `off`, `json_object`, or `json_schema` (enforces the verdict/review_markdown schema). Ignored for `anthropic`. Improves reliability with smaller local models | No | `off` |
 | `ai_tokens_param` | Token-limit field name for OpenAI-compatible requests: `max_tokens` or `max_completion_tokens` (newer OpenAI reasoning models). Ignored for `anthropic` | No | `max_tokens` |
@@ -430,7 +430,7 @@ jobs:
     ai_api_format: anthropic
     ai_model: claude-sonnet-4-5
     ai_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-    ai_max_tokens: "4096"
+    ai_max_tokens: "8192"
     publish_review_comment: "true"
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -28,9 +28,15 @@ inputs:
     required: false
     default: ""
   ai_max_tokens:
-    description: Maximum completion tokens for the primary and fallback final review calls
+    description: >-
+      Maximum completion tokens for the primary and fallback final review calls.
+      Default 8192. Reasoning models that emit a thinking channel need this
+      headroom — too low a cap is consumed by reasoning, leaving empty content
+      with finish_reason=length, so the verdict JSON fails to parse and the
+      review needlessly escalates or fails. Raise further (e.g. 16000) for
+      verbose reasoning models.
     required: false
-    default: "4096"
+    default: "8192"
   ai_temperature:
     description: >-
       Sampling temperature for the review model. Default "0.1". Set to an empty string to

--- a/scripts/model_call.sh
+++ b/scripts/model_call.sh
@@ -104,7 +104,7 @@ curl_model() {
 # build_model_request API_FORMAT MODEL SYSTEM USER CORPUS_FILE OUTPUT_FILE [STREAM]
 #
 # Reads globals (with safe defaults so the historical behaviour is preserved):
-#   AI_MAX_TOKENS     completion-token cap (default 4096)
+#   AI_MAX_TOKENS     completion-token cap (default 8192)
 #   AI_TEMPERATURE    sampling temperature; empty => omit the field entirely
 #                     (some newer cloud models reject any non-default value)
 #   AI_RESPONSE_FORMAT  OpenAI-compatible structured output: off|json_object|json_schema
@@ -121,7 +121,7 @@ build_model_request() {
   local output_file="$6"
   local stream="${7:-false}"
 
-  local max_tokens="${AI_MAX_TOKENS:-4096}"
+  local max_tokens="${AI_MAX_TOKENS:-8192}"
 
   # temperature: empty string omits the field; otherwise pass through as JSON.
   local temp_json="null"

--- a/scripts/run_review.sh
+++ b/scripts/run_review.sh
@@ -57,7 +57,7 @@ AI_BASE_URL="${AI_BASE_URL:-}"
 AI_API_FORMAT="${AI_API_FORMAT:-openai}"
 AI_MODEL="${AI_MODEL:-}"
 AI_API_KEY="${AI_API_KEY:-}"
-AI_MAX_TOKENS="${AI_MAX_TOKENS:-4096}"
+AI_MAX_TOKENS="${AI_MAX_TOKENS:-8192}"
 # Single-dash default: an explicitly empty AI_TEMPERATURE is preserved (it means
 # "omit the field"); only an unset value falls back to 0.1.
 AI_TEMPERATURE="${AI_TEMPERATURE-0.1}"
@@ -251,8 +251,8 @@ elif ! AI_FALLBACK_API_FORMAT="$(normalize_api_format "$AI_FALLBACK_API_FORMAT")
 fi
 
 if [[ ! "$AI_MAX_TOKENS" =~ ^[0-9]+$ || "$AI_MAX_TOKENS" -lt 1 ]]; then
-  error "Invalid AI_MAX_TOKENS '$AI_MAX_TOKENS'; defaulting to 4096"
-  AI_MAX_TOKENS=4096
+  error "Invalid AI_MAX_TOKENS '$AI_MAX_TOKENS'; defaulting to 8192"
+  AI_MAX_TOKENS=8192
 fi
 
 # AI_TEMPERATURE: empty means "omit the field"; otherwise must be numeric.


### PR DESCRIPTION
Closes #254.

## Problem
The default `ai_max_tokens` was **4096**. A *reasoning* model (one that emits a thinking channel, e.g. Gemma) spends that entirely on reasoning, leaving empty `content` with `finish_reason=length` → the JSON verdict fails to parse → an avoidable smart-tier escalation (or outright failure with no smart tier). Observed live on home-ops on **every** review until `ai_max_tokens` was raised to 16000 in the consumer workflow. Silently bites any consumer pointing at a reasoning model.

## Change (per the decision on #254)
Truncation *detection* already exists (`response_parser` surfaces `increase ai_max_tokens`), so the remaining call was the default bump:

- Default **4096 → 8192** across `action.yml`, `scripts/model_call.sh`, `scripts/run_review.sh` (value + the invalid-input fallback).
- Document the reasoning-model rationale in the `action.yml` input description and the README inputs table (raise to `16000`+ for verbose reasoners).

## Compatibility
Backward-compatible — any consumer that sets `ai_max_tokens` explicitly is unaffected; only the unset default changes. 806 tests pass on Python 3.14.
