### PR TITLE
feat(tool-loop): in-conversation verdict for native_loop (5/7 of #197)

### DIFF
--- a/scripts/run_review.sh
+++ b/scripts/run_review.sh
@@ -1304,6 +1304,26 @@ The corpus lists Open Findings From the Previous Review. Answer EVERY one: inclu
   log "Carry-forward active: $(jq 'length' previous-findings.json) open finding(s) from the previous review"
 fi
 
+PRIMARY_OK=0
+# native_loop in-conversation verdict (#205): when the tool loop produced its
+# own verdict (final turn, full reasoning history preserved), it wrote the
+# response to ai-response.primary.json. Parse it and skip the separate review
+# call. A parse failure (degraded/oversized/garbled verdict) falls through to
+# the standard corpus review below, so this only ever adds capability.
+NATIVE_VERDICT_USED=0
+if [[ "$(printf '%s' "$TOOL_MODE" | tr '[:upper:]' '[:lower:]')" == "native_loop" ]] \
+  && [[ "$(jq -r '.native_loop_verdict_produced // false' tool-harness.json 2>/dev/null)" == "true" ]] \
+  && [ -s ai-response.primary.json ]; then
+  log "native_loop produced an in-conversation verdict; using it and skipping the separate review call"
+  if parse_and_validate ai-response.primary.json; then
+    PRIMARY_OK=1
+    NATIVE_VERDICT_USED=1
+  else
+    log "native_loop verdict did not parse; falling back to the standard review call"
+  fi
+fi
+
+if [ "$NATIVE_VERDICT_USED" -ne 1 ]; then
 build_model_request \
   "$AI_API_FORMAT" \
   "$AI_MODEL" \
@@ -1353,6 +1373,7 @@ while [ "$ATTEMPT" -le "$AI_PRIMARY_RETRIES" ]; do
     [ "$RETRY_DELAY" -gt 120 ] && RETRY_DELAY=120
   fi
 done
+fi  # NATIVE_VERDICT_USED guard
 
 # On total model failure, either fail the step (default, preserves prior
 # behaviour) or — when on_model_failure=notice — emit a request_changes notice so

--- a/scripts/run_tool_harness.py
+++ b/scripts/run_tool_harness.py
@@ -888,6 +888,37 @@ NATIVE_LOOP_SYSTEM = (
     "reply with a short plain-text summary of the key evidence found."
 )
 
+# Closing turn for the in-conversation verdict (#205). NATIVE_LOOP_SYSTEM is an
+# evidence-gatherer prompt, so the verdict turn swaps to the reviewer prompt and
+# re-injects the full corpus (the loop only saw the compact planning context).
+_VERDICT_CLOSING_INSTRUCTION = (
+    "You have finished gathering evidence (the tool calls and their results "
+    "above). Below is the full review corpus for this PR. Using your "
+    "investigation together with this corpus, produce the final review verdict "
+    "now in the exact output format specified in your instructions. Do not "
+    "issue any further tool calls.\n\n"
+)
+
+
+def resolve_review_system_prompt():
+    """Resolve the reviewer system prompt for the native-loop verdict turn.
+
+    Mirrors run_review.sh's resolve_system_prompt (SYSTEM_PROMPT env, then
+    SYSTEM_PROMPT_FILE, then the bundled default) so the in-conversation verdict
+    is graded under the same reviewer instructions as the standard review call.
+    """
+    inline = os.getenv("SYSTEM_PROMPT", "")
+    if inline.strip():
+        return inline
+    prompt_file = os.getenv("SYSTEM_PROMPT_FILE", "").strip()
+    if prompt_file and Path(prompt_file).is_file():
+        return Path(prompt_file).read_text(encoding="utf-8")
+    default = _SCRIPTS_DIR / "default_system_prompt.txt"
+    try:
+        return default.read_text(encoding="utf-8")
+    except OSError:
+        return ""
+
 
 def run_native_loop(
     repo,
@@ -1017,6 +1048,53 @@ def run_native_loop(
         if outcome.error:
             result["native_loop_error"] = outcome.error
         return False
+
+    # ── In-conversation verdict (#205, Option 1) ─────────────────────────────
+    # The loop's final turn produces the review verdict itself — preserving the
+    # multi-hop reasoning trajectory — instead of flattening evidence into the
+    # corpus for a separate review call. Swap NATIVE_LOOP_SYSTEM (evidence
+    # gatherer) for the reviewer prompt, re-inject the full corpus the loop never
+    # saw (it ran on the compact planning context), drop tools, and force a
+    # strict-JSON verdict. The response is written where the standard review call
+    # writes it; run_review.sh consumes it and skips that call. If the verdict is
+    # degraded/oversized/garbled it simply fails to parse downstream and
+    # run_review.sh falls back to the standard corpus review — so this only adds
+    # capability. OpenAI only: an Anthropic verdict turn after trailing
+    # tool_result (user-role) blocks would create adjacent user turns (a 400),
+    # and native_loop runs on the OpenAI primary in practice.
+    if api_format == "openai":
+        try:
+            review_system = resolve_review_system_prompt()
+            corpus_file = Path("review-corpus.truncated.md")
+            verdict_corpus = (
+                corpus_file.read_text(encoding="utf-8", errors="replace")
+                if corpus_file.is_file()
+                else ""
+            )
+            if review_system and verdict_corpus:
+                conversation.system = review_system
+                conversation.add_user(_VERDICT_CLOSING_INSTRUCTION + verdict_corpus)
+                temp_raw = os.getenv("AI_TEMPERATURE", "").strip()
+                temperature = float(temp_raw) if temp_raw else None
+                rf = os.getenv("AI_RESPONSE_FORMAT", "off").strip().lower()
+                response_format = rf if rf in ("json_object", "json_schema") else None
+                verdict_payload = conversation.to_request_payload(
+                    api_format,
+                    model,
+                    stream=stream,
+                    max_tokens=env_int_bounded("AI_MAX_TOKENS", 8192, 256, 200000),
+                    temperature=temperature,
+                    verdict_turn=True,
+                    keep_full_history_on_verdict=True,
+                    response_format=response_format,
+                )
+                verdict_response = post_fn(verdict_payload)
+                Path("ai-response.primary.json").write_text(
+                    json.dumps(verdict_response), encoding="utf-8"
+                )
+                result["native_loop_verdict_produced"] = True
+        except Exception as exc:  # noqa: BLE001 — never let it break evidence output
+            result["native_loop_verdict_error"] = str(exc)
 
     result["mode"] = "native_loop"
     result["rounds"] = outcome.rounds

--- a/tests/test_run_native_loop_wiring.py
+++ b/tests/test_run_native_loop_wiring.py
@@ -275,3 +275,90 @@ def test_native_loop_degrades_writes_nothing(monkeypatch, tmp_path):
     # No output files: the caller (main) falls through to the planner path.
     assert not (tmp_path / "tool-harness.json").exists()
     assert not (tmp_path / "tool-harness.md").exists()
+
+
+def _run_capturing(monkeypatch, tmp_path, api_format, responses):
+    """Like _run but records every payload sent, for the verdict-turn tests."""
+    queue = list(responses)
+    payloads = []
+
+    def fake_request(base_url, fmt, payload, api_key, timeout_sec):
+        payloads.append(payload)
+        assert queue, "model called more times than scripted"
+        return queue.pop(0)
+
+    monkeypatch.setattr(rth, "run_chat_request", fake_request)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("EFFECTIVE_SCOPE", "full")
+    monkeypatch.setenv("AI_STREAM", "false")
+    result = {
+        "mode": "plan_execute_once",
+        "planned_request_count": 0,
+        "executed_request_count": 0,
+        "tool_results": [],
+    }
+    handled = rth.run_native_loop(
+        "owner/repo", "http://model.local/v1", api_format, "mock-model", "key",
+        "# PR Corpus\nbumps kubelet image in machineconfig.yaml.j2",
+        {"owner/repo"}, ["talos.dev"], str(tmp_path),
+        12000, 15, 4, 45, 400, result,
+    )
+    return handled, result, payloads
+
+
+def test_native_loop_emits_in_conversation_verdict(monkeypatch, tmp_path):
+    """#205: after gathering evidence the loop produces the verdict itself —
+    drops tools, forces strict JSON, re-injects the full corpus, and writes the
+    response where the standard review call would (run_review.sh consumes it)."""
+    monkeypatch.setenv("AI_RESPONSE_FORMAT", "json_object")
+    (tmp_path / "review-corpus.truncated.md").write_text(
+        "# Full corpus\nthe complete unified diff lives here\n", encoding="utf-8"
+    )
+    (tmp_path / "machineconfig.yaml.j2").write_text(
+        "install: factory.talos.dev/installer:v1.13.4\n", encoding="utf-8"
+    )
+    verdict_json = '{"verdict": "approve", "review_markdown": "LGTM", "findings": []}'
+    handled, result, payloads = _run_capturing(
+        monkeypatch, tmp_path, "openai",
+        [
+            _openai_call("c1", "read_file", '{"path": "machineconfig.yaml.j2"}'),
+            _openai_text("Evidence gathered: Talos v1.13.4."),  # ends the loop
+            {"choices": [{"finish_reason": "stop", "message": {"content": verdict_json}}]},
+        ],
+    )
+    assert handled is True
+    assert result.get("native_loop_verdict_produced") is True
+
+    # Written where the standard primary review call writes its response.
+    resp = json.loads((tmp_path / "ai-response.primary.json").read_text())
+    assert "approve" in resp["choices"][0]["message"]["content"]
+
+    # The verdict turn (final call) dropped tools, forced strict JSON, and
+    # re-injected the full corpus the loop never saw on a closing user turn.
+    verdict_payload = payloads[-1]
+    assert "tools" not in verdict_payload
+    assert verdict_payload.get("response_format", {}).get("type") == "json_object"
+    user_text = "\n".join(
+        m.get("content") or "" for m in verdict_payload["messages"] if m["role"] == "user"
+    )
+    assert "the complete unified diff lives here" in user_text
+
+
+def test_native_loop_skips_verdict_for_anthropic(monkeypatch, tmp_path):
+    """Anthropic native_loop keeps the standard corpus review: a verdict turn
+    after trailing tool_result (user-role) blocks would make adjacent user
+    turns (a 400). No verdict is produced and no primary response is written."""
+    (tmp_path / "review-corpus.truncated.md").write_text("# Full corpus\n", encoding="utf-8")
+    (tmp_path / "machineconfig.yaml.j2").write_text("install: v1.13.4\n", encoding="utf-8")
+    handled, result, payloads = _run_capturing(
+        monkeypatch, tmp_path, "anthropic",
+        [
+            {"content": [{"type": "tool_use", "id": "c1", "name": "read_file",
+                          "input": {"path": "machineconfig.yaml.j2"}}],
+             "stop_reason": "tool_use"},
+            {"content": [{"type": "text", "text": "done"}], "stop_reason": "end_turn"},
+        ],
+    )
+    assert handled is True
+    assert result.get("native_loop_verdict_produced") is not True
+    assert not (tmp_path / "ai-response.primary.json").exists()


### PR DESCRIPTION
Closes #205. **Option 1** (your call): the native loop's final turn produces the review verdict itself, preserving the multi-hop reasoning trajectory, instead of flattening evidence into the corpus for a separate review call.

## Why
This is the lever for the founding use case. Today the loop gathers evidence, the results get folded into the corpus, and a **separate** review call re-derives the verdict — throwing away the reasoning trajectory that connected the hops (read machineconfig → search → fetch matrix → reason). Option 1 keeps the verdict **in-conversation**, so the model reasons forward from its own chain.

## How
- **`run_native_loop`**: after a non-degraded loop, swap `NATIVE_LOOP_SYSTEM` (an evidence-gatherer prompt — "reply with a plain-text summary") for the **reviewer system prompt**, re-inject the **full review corpus** the loop never saw (it runs on the compact planning context, missing the full diff), **drop tools**, and force a strict-JSON verdict via the #202 mechanism (`verdict_turn=True, keep_full_history_on_verdict=True` — first wired here). Streams (on #259) so the long verdict generation doesn't 524. Writes the response to `ai-response.primary.json` and sets `native_loop_verdict_produced`.
- **`run_review.sh`**: when the loop produced a verdict, parse it and **skip the separate review call**. A degraded/oversized/garbled verdict simply fails to parse → falls back to the standard corpus review. **So this only ever adds capability.** Downstream (`verdict_policy`, carry-forward, completeness, enforcement) is unchanged.
- **OpenAI only**: an Anthropic verdict turn after trailing `tool_result` (user-role) blocks would create adjacent user turns (a 400). `native_loop` runs on the OpenAI primary in practice; Anthropic keeps the standard corpus review.

## Corpus completeness (the subtlety I flagged)
The loop only ever saw the compact planning context, so a naive verdict would have **less** context than today (no full diff). The verdict turn re-injects the full corpus (`review-corpus.truncated.md`, the pre-harness build — full diff/standards, tool results already in-conversation), so net context ≈ today's review call + the reasoning deltas.

## Tests / validation
Verdict turn drops tools + forces JSON + re-injects the corpus + writes the primary response; Anthropic path is skipped; smoke (25) + 838 suite green on Python 3.14. **The real validation is the #207 eval on home-ops#7462** (does in-conversation verdict move the capability pass rate?) — to run on the GPU endpoint when you're ready.
