### PR TITLE
feat(tool-loop): tool-surface expansion — read_file ranges, git_log, git_blame (#197 §3)

### DIFF
--- a/pr_reviewer/conversation.py
+++ b/pr_reviewer/conversation.py
@@ -86,7 +86,9 @@ TOOL_SCHEMAS: list[dict[str, Any]] = [
         "description": (
             "Read a file from the workspace. Path-traversal and sensitive "
             "files (.env, .pem, credentials, id_rsa, …) are blocked. Output "
-            "is truncated to ~12 KB."
+            "is truncated to ~12 KB. For a large file, pass offset/limit to "
+            "read a line window (also the way to expand context around a "
+            "diff hunk) instead of blowing the cap."
         ),
         "parameters": {
             "type": "object",
@@ -94,6 +96,64 @@ TOOL_SCHEMAS: list[dict[str, Any]] = [
                 "path": {
                     "type": "string",
                     "description": "Path relative to the workspace root.",
+                },
+                "offset": {
+                    "type": "integer",
+                    "description": "Optional 1-based first line to read.",
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Optional max number of lines to read from offset.",
+                },
+            },
+            "required": ["path"],
+            "additionalProperties": False,
+        },
+    },
+    {
+        "name": "git_log",
+        "description": (
+            "Read-only recent commit history (oneline: hash date author "
+            "subject), optionally scoped to a path. No file content — use "
+            "git_blame for line-level authorship."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Optional path to scope history to.",
+                },
+                "max_count": {
+                    "type": "integer",
+                    "description": "Optional max commits (1–100, default 20).",
+                },
+            },
+            "required": [],
+            "additionalProperties": False,
+        },
+    },
+    {
+        "name": "git_blame",
+        "description": (
+            "Read-only line-level authorship for a tracked file (who last "
+            "changed each line, and in which commit). Pass start/end to blame "
+            "a line range. Sensitive files are blocked like read_file."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Path relative to the workspace root.",
+                },
+                "start": {
+                    "type": "integer",
+                    "description": "Optional 1-based first line of the range.",
+                },
+                "end": {
+                    "type": "integer",
+                    "description": "Optional last line of the range (with start).",
                 },
             },
             "required": ["path"],

--- a/scripts/run_tool_harness.py
+++ b/scripts/run_tool_harness.py
@@ -84,6 +84,16 @@ def env_int_bounded(name, default_value, min_value, max_value):
     return min(max_value, value)
 
 
+def _opt_int(value):
+    """Coerce an optional tool arg to int, tolerating model string/None forms."""
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
 def normalize_api_format(value):
     candidate = (value or "openai").strip().lower()
     if candidate in {"openai", "anthropic"}:
@@ -320,13 +330,19 @@ def fetch_url(url, allowed_hosts, request_timeout=25):
         return None
 
 
-def read_file(path, workspace_root):
-    """Read a file with path-traversal protection."""
+def _resolve_workspace_path(path, workspace_root):
+    """Resolve a workspace-relative path with traversal/symlink/sensitive guards.
+
+    Returns ``(resolved_Path, None)`` on success or ``(None, error_str)``.
+    Shared by read_file, git_log, and git_blame so they enforce the identical
+    containment + sensitive-file policy — git_blame in particular renders file
+    *content*, so it must honour the same .env/.pem/credentials blocks.
+    """
     # Reject embedded null bytes before touching the filesystem: pathlib raises
     # ValueError (not OSError) on them, and a NUL can truncate the path at the C
     # layer of an underlying syscall, so an early explicit reject is safest.
     if "\x00" in path:
-        return {"error": "Null byte in path"}
+        return None, "Null byte in path"
 
     root = Path(workspace_root).resolve()
     try:
@@ -335,26 +351,51 @@ def read_file(path, workspace_root):
         # caught by the containment check below.
         resolved = (root / path).resolve()
     except (OSError, ValueError):
-        return {"error": f"Cannot resolve path: {path}"}
+        return None, f"Cannot resolve path: {path}"
 
     # Containment via is_relative_to, NOT str.startswith: startswith wrongly
     # accepts a sibling directory whose name shares the workspace as a prefix
     # (e.g. resolving to /work/repo2 passes a /work/repo prefix test).
     if not resolved.is_relative_to(root):
-        return {"error": "Path escapes workspace root"}
+        return None, "Path escapes workspace root"
 
     if SENSITIVE_PATH_RE.search(resolved.name):
-        return {"error": f"Sensitive file blocked: {resolved.name}"}
+        return None, f"Sensitive file blocked: {resolved.name}"
 
     for deny in GH_DENY_SUBSTRINGS:
         if deny in str(resolved):
-            return {"error": f"Path denied: {deny}"}
+            return None, f"Path denied: {deny}"
+
+    return resolved, None
+
+
+def read_file(path, workspace_root, offset=None, limit=None):
+    """Read a file, optionally a 1-based line window, with path protection.
+
+    ``offset``/``limit`` let the model read a slice of a large file without
+    blowing the response cap — and cover diff-context expansion ("show me N
+    lines around this hunk") without a separate tool.
+    """
+    resolved, err = _resolve_workspace_path(path, workspace_root)
+    if err:
+        return {"error": err}
 
     try:
         content = resolved.read_text(encoding="utf-8", errors="replace")
-        return {"content": content[:12000]}
     except Exception as exc:
         return {"error": str(exc)}
+
+    if offset is None and limit is None:
+        return {"content": content[:12000]}
+
+    lines = content.splitlines(keepends=True)
+    start = max((offset or 1) - 1, 0)
+    end = start + limit if limit is not None else len(lines)
+    window = "".join(lines[start:end])
+    return {
+        "content": window[:12000],
+        "range": {"offset": start + 1, "lines": len(lines[start:end]), "total_lines": len(lines)},
+    }
 
 
 def git_grep(pattern, workspace_root, request_timeout=15):
@@ -374,6 +415,62 @@ def git_grep(pattern, workspace_root, request_timeout=15):
     except subprocess.TimeoutExpired:
         return {"error": f"git grep timed out after {request_timeout}s"}
     except Exception as exc:
+        return {"error": str(exc)}
+
+
+def git_log(path, workspace_root, max_count=20, request_timeout=15):
+    """Read-only recent commit history (oneline), optionally scoped to a path.
+
+    No patch (`-p`) — subjects/metadata only, not file content. A path is run
+    as a ``-- <path>`` pathspec so it can't be read as a flag, and git keeps it
+    inside the repo regardless; the sensitive/containment guard is applied for
+    consistency with the content-bearing tools.
+    """
+    args = [
+        "git", "log", f"-n{max_count}", "--no-color",
+        "--date=short", "--pretty=format:%h %ad %an %s",
+    ]
+    if path:
+        resolved, err = _resolve_workspace_path(path, workspace_root)
+        if err:
+            return {"error": err}
+        args += ["--", str(resolved)]
+    try:
+        result = subprocess.run(
+            args, cwd=workspace_root, capture_output=True, text=True, timeout=request_timeout
+        )
+        if result.returncode != 0:
+            return {"error": f"git log failed: {result.stderr.strip()}"}
+        return {"log": result.stdout.strip().splitlines()[:max_count]}
+    except subprocess.TimeoutExpired:
+        return {"error": f"git log timed out after {request_timeout}s"}
+    except Exception as exc:
+        return {"error": str(exc)}
+
+
+def git_blame(path, workspace_root, start=None, end=None, request_timeout=15):
+    """Read-only line-level authorship for a tracked file (optional L range).
+
+    git blame renders file *content*, so the sensitive/containment guard is
+    mandatory — a committed .env/.pem must not be readable through blame.
+    """
+    resolved, err = _resolve_workspace_path(path, workspace_root)
+    if err:
+        return {"error": err}
+    args = ["git", "blame", "-w"]
+    if start is not None and end is not None:
+        args += ["-L", f"{int(start)},{int(end)}"]
+    args += ["--", str(resolved)]
+    try:
+        result = subprocess.run(
+            args, cwd=workspace_root, capture_output=True, text=True, timeout=request_timeout
+        )
+        if result.returncode != 0:
+            return {"error": f"git blame failed: {result.stderr.strip()}"}
+        return {"blame": result.stdout}
+    except subprocess.TimeoutExpired:
+        return {"error": f"git blame timed out after {request_timeout}s"}
+    except (ValueError, Exception) as exc:  # int() on a bad range → clean error
         return {"error": str(exc)}
 
 
@@ -720,12 +817,40 @@ def execute_tool_request(
             path = args.get("path", "")
             if not path:
                 raise ValueError("Missing 'path' argument")
-            res = read_file(path, workspace_root)
+            res = read_file(
+                path, workspace_root, _opt_int(args.get("offset")), _opt_int(args.get("limit"))
+            )
             if res.get("error"):
                 raise ValueError(res["error"])
             text = mask_secrets(res.get("content", ""))
             text, _ = mask_and_truncate(text, max_response_bytes)
-            tool_result["result"] = {"content": text}
+            result_payload = {"content": text}
+            if res.get("range"):
+                result_payload["range"] = res["range"]
+            tool_result["result"] = result_payload
+
+        elif tool_name == "git_log":
+            max_count = max(1, min(_opt_int(args.get("max_count")) or 20, 100))
+            res = git_log(
+                args.get("path", "") or "", workspace_root, max_count, request_timeout
+            )
+            if res.get("error"):
+                raise ValueError(res["error"])
+            text, _ = mask_and_truncate("\n".join(res.get("log", [])), max_response_bytes)
+            tool_result["result"] = {"log": text}
+
+        elif tool_name == "git_blame":
+            path = args.get("path", "")
+            if not path:
+                raise ValueError("Missing 'path' argument")
+            res = git_blame(
+                path, workspace_root,
+                _opt_int(args.get("start")), _opt_int(args.get("end")), request_timeout,
+            )
+            if res.get("error"):
+                raise ValueError(res["error"])
+            text, _ = mask_and_truncate(res.get("blame", ""), max_response_bytes)
+            tool_result["result"] = {"blame": text}
 
         elif tool_name == "git_grep":
             pattern = args.get("pattern", "")
@@ -1194,9 +1319,13 @@ def main():
                     "content": (
                         "You are a tool-planning assistant for a PR review system. "
                         "Given the user's request, determine which tools to call and with what arguments. "
-                        "Only use these tools: read_file, git_grep, gh_api, web_fetch, run_command. "
-                        "read_file: takes 'path' (workspace-relative). "
+                        "Only use these tools: read_file, git_grep, git_log, git_blame, "
+                        "gh_api, web_fetch, run_command. "
+                        "read_file: takes 'path' (workspace-relative); optional 'offset'/'limit' "
+                        "for a line window. "
                         "git_grep: takes 'pattern'. "
+                        "git_log: optional 'path', optional 'max_count' (recent commit history). "
+                        "git_blame: takes 'path'; optional 'start'/'end' lines (line authorship). "
                         "gh_api: takes 'endpoint' (e.g., repos/owner/repo/pulls/123). "
                         "web_fetch: takes 'url'. "
                         "run_command: takes 'command' as one named read-only command. "

--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -33,6 +33,8 @@ class TestToolSchemas:
             "read_file",
             "web_fetch",
             "git_grep",
+            "git_log",
+            "git_blame",
             "run_command",
         }
 

--- a/tests/test_tool_surface.py
+++ b/tests/test_tool_surface.py
@@ -1,0 +1,122 @@
+"""Tool-surface expansion (#197 §3): read_file line ranges, git_log, git_blame.
+
+Drives the executor (execute_tool_request — the native loop's execute_fn target)
+so the tests exercise the real arg-handling, security guards, and output shaping.
+git_log/git_blame run against a throwaway git repo built in tmp_path.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+import run_tool_harness as rth  # noqa: E402
+
+_REPO = "owner/repo"
+
+
+def _exec(tool, args, workspace):
+    return rth.execute_tool_request(
+        tool, args, str(workspace), {_REPO}, _REPO, ["github.com"], 12000, 15
+    )
+
+
+def _git(args, cwd):
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True, text=True)
+
+
+@pytest.fixture
+def git_repo(tmp_path):
+    """A throwaway git repo with one committed multi-line file."""
+    _git(["init", "-q"], tmp_path)
+    _git(["config", "user.email", "t@example.com"], tmp_path)
+    _git(["config", "user.name", "Tester"], tmp_path)
+    (tmp_path / "app.py").write_text("\n".join(f"line {i}" for i in range(1, 21)) + "\n", encoding="utf-8")
+    _git(["add", "app.py"], tmp_path)
+    _git(["commit", "-q", "-m", "add app.py"], tmp_path)
+    return tmp_path
+
+
+# ── read_file line ranges ────────────────────────────────────────────────────
+def test_read_file_offset_limit_returns_window(tmp_path):
+    (tmp_path / "big.txt").write_text("\n".join(f"row{i}" for i in range(1, 101)) + "\n", encoding="utf-8")
+    res = _exec("read_file", {"path": "big.txt", "offset": 10, "limit": 3}, tmp_path)
+    assert res["status"] == "ok"
+    assert res["result"]["content"] == "row10\nrow11\nrow12\n"
+    assert res["result"]["range"] == {"offset": 10, "lines": 3, "total_lines": 100}
+
+
+def test_read_file_no_range_reads_whole_file(tmp_path):
+    (tmp_path / "f.txt").write_text("a\nb\n", encoding="utf-8")
+    res = _exec("read_file", {"path": "f.txt"}, tmp_path)
+    assert res["status"] == "ok"
+    assert res["result"]["content"] == "a\nb\n"
+    assert "range" not in res["result"]
+
+
+def test_read_file_offset_string_coerced(tmp_path):
+    # Weak models emit numbers as strings; the executor coerces them.
+    (tmp_path / "f.txt").write_text("x\ny\nz\n", encoding="utf-8")
+    res = _exec("read_file", {"path": "f.txt", "offset": "2", "limit": "1"}, tmp_path)
+    assert res["status"] == "ok"
+    assert res["result"]["content"] == "y\n"
+
+
+def test_read_file_range_still_blocks_sensitive(tmp_path):
+    (tmp_path / ".env").write_text("SECRET=1\n", encoding="utf-8")
+    res = _exec("read_file", {"path": ".env", "offset": 1, "limit": 1}, tmp_path)
+    assert res["status"] == "error"
+    assert "SECRET" not in str(res["result"])
+
+
+# ── git_log ──────────────────────────────────────────────────────────────────
+def test_git_log_returns_history(git_repo):
+    res = _exec("git_log", {"path": "app.py"}, git_repo)
+    assert res["status"] == "ok"
+    assert "add app.py" in res["result"]["log"]
+
+
+def test_git_log_no_path_runs_repo_wide(git_repo):
+    res = _exec("git_log", {}, git_repo)
+    assert res["status"] == "ok"
+    assert "add app.py" in res["result"]["log"]
+
+
+def test_git_log_path_escape_blocked(git_repo):
+    res = _exec("git_log", {"path": "../../etc/passwd"}, git_repo)
+    assert res["status"] == "error"
+
+
+# ── git_blame ────────────────────────────────────────────────────────────────
+def test_git_blame_returns_authorship(git_repo):
+    res = _exec("git_blame", {"path": "app.py", "start": 1, "end": 2}, git_repo)
+    assert res["status"] == "ok"
+    assert "Tester" in res["result"]["blame"]
+    assert "line 1" in res["result"]["blame"]
+
+
+def test_git_blame_requires_path(git_repo):
+    res = _exec("git_blame", {}, git_repo)
+    assert res["status"] == "error"
+
+
+def test_git_blame_blocks_sensitive_file(git_repo):
+    # A committed secret must not be readable through blame's content rendering.
+    (git_repo / "id_rsa").write_text("PRIVATE_KEY_LINE\n", encoding="utf-8")
+    _git(["add", "id_rsa"], git_repo)
+    _git(["commit", "-q", "-m", "oops"], git_repo)
+    res = _exec("git_blame", {"path": "id_rsa"}, git_repo)
+    assert res["status"] == "error"
+    assert "PRIVATE_KEY_LINE" not in str(res["result"])
+
+
+def test_git_blame_escape_blocked(git_repo):
+    res = _exec("git_blame", {"path": "../../etc/hosts"}, git_repo)
+    assert res["status"] == "error"


### PR DESCRIPTION
Part of the 1.3.0 harness-completeness gate (#265). Three read-only additions to the native-loop tool surface (#197 §3):

- **`read_file` line ranges** — optional `offset`/`limit` (1-based window). Read a slice of a big file without blowing the ~12KB cap, and expand context around a diff hunk without a separate tool. Returns a `range` descriptor. *(this is also "diff-context expansion" from §3 — no separate tool needed.)*
- **`git_log`** — recent commit history (oneline: hash/date/author/subject), optional `path` scope + `max_count` (1–100). No patch → no file content.
- **`git_blame`** — line-level authorship for a tracked file, optional `start`/`end` range.

## Security
A shared `_resolve_workspace_path` helper enforces the identical null-byte/symlink/containment + sensitive-file (`.env`/`.pem`/credentials/`id_rsa`) guard across `read_file`, `git_log`, and `git_blame`. `git_blame` renders file **content**, so it must honor the same blocks — covered by a test (committed secret → blocked). All output is `mask_secrets`'d and capped. Advertised in `TOOL_SCHEMAS` (native loop) and the `plan_execute` planner prompt.

## Tests
11 cases via the executor (the loop's real `execute_fn` target): ranges incl. string-coercion + sensitive block; `git_log` history/scope/escape; `git_blame` authorship/range/sensitive-block/escape (git_log & git_blame run against a throwaway git repo). **849 suite + smoke (25) green on Python 3.14.**

Checks off `read_file` line ranges, `git_log`, `git_blame`, and diff-context expansion on #265.
