### PR TITLE
feat(tool-loop): risk/route-adaptive loop budgets (#197 §2)

### DIFF
--- a/pr_reviewer/tool_loop.py
+++ b/pr_reviewer/tool_loop.py
@@ -73,6 +73,35 @@ class LoopBudgets:
     truncated_result_bytes: int = 2000
 
 
+def adaptive_loop_budgets(
+    max_rounds: int,
+    max_tool_calls: int,
+    wall_clock_sec: float,
+    *,
+    review_route: str = "legacy",
+    risk_flag_count: int = 0,
+) -> "LoopBudgets":
+    """Right-size the loop budget to PR risk (#197 §2: spend research where risk is).
+
+    A native round is one model turn, so the default headroom is 2× the
+    configured rounds (capped at 8). When auto-routing sent the PR to the FAST
+    tier — which only happens for a low-risk PR, since the route keys off
+    ``risk_flags`` — a shallow loop is enough; don't burn the full research
+    budget thrashing a trivial diff. A risk flag forces full depth even on the
+    fast route (guards a mis-route). Smart/legacy (routing off) keep full depth.
+    """
+    rounds = min(max(max_rounds, 1) * 2, 8)
+    calls = max_tool_calls
+    if (review_route or "legacy").strip().lower() == "fast" and risk_flag_count == 0:
+        rounds = min(rounds, 2)
+        calls = min(calls, 3)
+    return LoopBudgets(
+        max_tool_calls=calls,
+        max_rounds=rounds,
+        wall_clock_sec=float(wall_clock_sec),
+    )
+
+
 @dataclass
 class ExecutedCall:
     tool: str

--- a/scripts/run_review.sh
+++ b/scripts/run_review.sh
@@ -1010,6 +1010,9 @@ if [[ -n "$SMART_BASE_URL" && -n "$SMART_MODEL" ]]; then
 fi
 
 resolve_review_route
+# Export so the native-loop harness can right-size loop depth by route (#197 §2):
+# the fast route only fires on low-risk PRs, which get a shallower loop.
+export REVIEW_ROUTE
 if [[ "$REVIEW_ROUTE" == "fast" ]]; then
   AI_BASE_URL="$FAST_BASE_URL"
   AI_MODEL="$FAST_MODEL"

--- a/scripts/run_tool_harness.py
+++ b/scripts/run_tool_harness.py
@@ -1067,6 +1067,17 @@ def resolve_review_system_prompt():
         return ""
 
 
+def _classification_risk_flag_count():
+    """Count risk_flags in classification.json (0 if unavailable). Used to keep
+    full loop depth on a risk-flagged PR even if it was routed to the fast tier."""
+    try:
+        data = json.loads(Path("classification.json").read_text(encoding="utf-8"))
+        flags = data.get("risk_flags")
+        return len(flags) if isinstance(flags, list) else 0
+    except Exception:
+        return 0
+
+
 def run_native_loop(
     repo,
     base_url,
@@ -1102,7 +1113,10 @@ def run_native_loop(
         WEB_SEARCH_SCHEMA,
         Conversation,
     )
-    from pr_reviewer.tool_loop import LoopBudgets, drive_tool_loop  # noqa: PLC0415
+    from pr_reviewer.tool_loop import (  # noqa: PLC0415
+        adaptive_loop_budgets,
+        drive_tool_loop,
+    )
 
     # web_search is advertised only when a search endpoint is configured.
     search_url = os.getenv("SEARCH_URL", "").strip()
@@ -1133,13 +1147,16 @@ def run_native_loop(
 
     max_rounds = env_int_bounded("TOOL_MAX_ROUNDS", 3, 1, 6)
     wall_clock = env_int_bounded("TOOL_LOOP_WALL_CLOCK_SEC", 120, 10, 900)
-    budgets = LoopBudgets(
-        max_tool_calls=max_requests,
-        # A native round is one model turn (often a single call), unlike the
-        # planner's batched rounds — give the chain headroom: 2× rounds,
-        # bounded by the catalogue cap of 6 plus repair slack.
-        max_rounds=min(max_rounds * 2, 8),
-        wall_clock_sec=float(wall_clock),
+    # Right-size the loop to PR risk (#197 §2): the fast route only fires on
+    # low-risk PRs, so they get a shallow loop; risk-flagged / smart-routed PRs
+    # get full depth. REVIEW_ROUTE is exported by run_review.sh; standalone runs
+    # default to legacy (full depth).
+    budgets = adaptive_loop_budgets(
+        max_rounds,
+        max_requests,
+        wall_clock,
+        review_route=os.getenv("REVIEW_ROUTE", "legacy"),
+        risk_flag_count=_classification_risk_flag_count(),
     )
 
     # Stream loop turns by default (mirrors AI_STREAM for the review call) so

--- a/tests/test_native_tool_loop.py
+++ b/tests/test_native_tool_loop.py
@@ -15,9 +15,37 @@ from pr_reviewer.tool_loop import (
     STOP_REQUEST_ERROR,
     STOP_WALL_CLOCK,
     LoopBudgets,
+    adaptive_loop_budgets,
     drive_tool_loop,
     extract_tool_calls,
 )
+
+
+class TestAdaptiveLoopBudgets:
+    """Risk/route-adaptive loop depth (#197 §2)."""
+
+    def test_default_headroom_doubles_rounds_capped_at_8(self):
+        b = adaptive_loop_budgets(3, 4, 120.0)
+        assert b.max_rounds == 6  # 3 * 2
+        assert b.max_tool_calls == 4
+        assert adaptive_loop_budgets(6, 4, 120.0).max_rounds == 8  # capped
+
+    def test_fast_route_low_risk_is_shallow(self):
+        b = adaptive_loop_budgets(3, 8, 120.0, review_route="fast", risk_flag_count=0)
+        assert b.max_rounds == 2
+        assert b.max_tool_calls == 3
+
+    def test_fast_route_with_risk_flag_keeps_full_depth(self):
+        # A risk flag forces full depth even if the PR was routed to fast.
+        b = adaptive_loop_budgets(3, 8, 120.0, review_route="fast", risk_flag_count=1)
+        assert b.max_rounds == 6
+        assert b.max_tool_calls == 8
+
+    def test_smart_and_legacy_keep_full_depth(self):
+        for route in ("smart", "legacy", "", None):
+            b = adaptive_loop_budgets(3, 8, 120.0, review_route=route, risk_flag_count=0)
+            assert b.max_rounds == 6
+            assert b.max_tool_calls == 8
 
 
 def openai_tool_call_response(calls, content=None):


### PR DESCRIPTION
Part of the 1.3.0 harness-completeness gate (#265). Covers two #265 items that collapse into one mechanism — **per-route loop depth** and **adaptive budget by risk** — because the route is itself risk-derived.

## What
Spend research effort proportional to PR risk instead of a flat cap:
- **Fast route → shallow loop** (≤2 rounds, ≤3 calls). The fast route only fires on low-risk PRs (routing keys off `risk_flags`/`pr_kind`), so a shallow loop is enough — the eval showed the model otherwise thrashes the full budget on trivial diffs.
- **Risk flag → full depth even on the fast route** (mis-route guard, read from `classification.json`).
- **Smart / legacy → full depth** (2× configured rounds, capped at 8 — unchanged).

## How
- `adaptive_loop_budgets(...)` in `tool_loop.py` — pure function, unit-tested.
- `run_native_loop` reads `REVIEW_ROUTE` + `classification.json` `risk_flags`.
- `run_review.sh` exports `REVIEW_ROUTE` (resolved before the harness runs) so the harness can see it; standalone runs default to `legacy` (full depth).

## Tests
4 budget cases (default headroom + cap, fast-shallow, risk-override-on-fast, smart/legacy full). **859 suite + smoke (25) green on Python 3.14.**

Checks off per-route loop depth + adaptive-budget-by-risk on #265. Relates to #197 §2.
