### PR TITLE
feat(tool-loop): pure-code harness optimizations — telemetry, anthropic cache_control, parallel exec (#265)

### DIFF
--- a/pr_reviewer/conversation.py
+++ b/pr_reviewer/conversation.py
@@ -770,6 +770,7 @@ class Conversation:
         keep_full_history_on_verdict: bool = False,
         response_format: str | None = None,
         tokens_param: str = "max_tokens",
+        cache_prefix: bool = False,
     ) -> dict[str, Any]:
         """Render the conversation as a wire-ready request body.
 
@@ -790,6 +791,7 @@ class Conversation:
                 verdict_turn=verdict_turn,
                 keep_full_history_on_verdict=keep_full_history_on_verdict,
                 response_format=response_format,
+                cache_prefix=cache_prefix,
             )
         return self._to_openai_payload(
             model=model,
@@ -866,6 +868,7 @@ class Conversation:
         verdict_turn: bool,
         keep_full_history_on_verdict: bool,
         response_format: str | None,
+        cache_prefix: bool = False,
     ) -> dict[str, Any]:
         system = self.system
         messages = self._render_anthropic_messages()
@@ -893,6 +896,21 @@ class Conversation:
         # on the system prompt to request JSON. response_format is silently
         # ignored to keep the call sites uniform between the two APIs.
         _ = response_format
+        # Anthropic prompt caching is opt-in (#263 Part 2): unlike OpenAI's
+        # automatic prefix cache, it caches nothing unless cache_control markers
+        # are present. Mark the stable prefix — the system block and the tools
+        # block (the two large turn-invariant pieces) — so the multi-turn loop
+        # reuses them. The growing messages tail stays uncached.
+        if cache_prefix:
+            if system:
+                payload["system"] = [
+                    {"type": "text", "text": system, "cache_control": {"type": "ephemeral"}}
+                ]
+            if payload.get("tools"):
+                payload["tools"][-1] = {
+                    **payload["tools"][-1],
+                    "cache_control": {"type": "ephemeral"},
+                }
         return payload
 
 

--- a/pr_reviewer/tool_loop.py
+++ b/pr_reviewer/tool_loop.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 
 import json
 import time
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from typing import Any, Callable
 
@@ -184,6 +185,7 @@ def drive_tool_loop(
     temperature: float = 0.0,
     stream: bool = False,
     tokens_param: str = "max_tokens",
+    cache_prefix: bool = False,
     time_fn: Callable[[], float] = time.monotonic,
 ) -> LoopOutcome:
     """Run the agentic loop until the model stops or a budget hits.
@@ -223,6 +225,7 @@ def drive_tool_loop(
             max_tokens=max_tokens,
             temperature=temperature,
             tokens_param=tokens_param,
+            cache_prefix=cache_prefix,
         )
         try:
             response = post_fn(payload)
@@ -249,42 +252,67 @@ def drive_tool_loop(
         conversation.add_assistant_tool_calls(calls)
         outcome.tool_calls_issued += len(calls)
 
-        for call in calls:
+        # Decide each call's disposition SEQUENTIALLY — dedup (seen_keys) and
+        # the budget counter are stateful and must stay deterministic and
+        # call-ordered. Only the to-run executions are then fanned out
+        # concurrently: the executor is read-only and a round's calls are
+        # independent (the model emitted them together). Results are applied in
+        # the original call order to preserve the open-call contract.
+        plan: list[tuple[str, str, Any]] = []  # (call_id, kind, data) in order
+        to_execute: dict[int, tuple[str, dict[str, Any]]] = {}
+        for idx, call in enumerate(calls):
             call_id = call["id"]
-            # Arguments arrive as an opaque JSON string (#233 contract);
-            # parse here, and on failure answer with a repairable error
-            # instead of crashing the loop — weak models misquote JSON.
+            # Arguments arrive as an opaque JSON string (#233 contract); parse
+            # here, and on failure answer with a repairable error instead of
+            # crashing the loop — weak models misquote JSON.
             try:
                 args = json.loads(call["arguments"]) if call["arguments"] else {}
                 if not isinstance(args, dict):
                     raise ValueError("arguments must be a JSON object")
             except (json.JSONDecodeError, ValueError) as exc:
-                conversation.add_tool_result(
-                    call_id,
-                    {"error": f"Invalid tool arguments (not a JSON object): {exc}"},
-                    is_error=True,
+                plan.append(
+                    (call_id, "error",
+                     {"error": f"Invalid tool arguments (not a JSON object): {exc}"})
                 )
                 continue
 
             key = _request_key(call["name"], args)
             if key in seen_keys:
-                # Free synthetic answer: doesn't execute, doesn't burn budget.
-                conversation.add_tool_result(
-                    call_id, {"note": _DUPLICATE_NOTE}, is_error=True
-                )
+                plan.append((call_id, "dup", {"note": _DUPLICATE_NOTE}))
                 continue
 
             if calls_executed >= budgets.max_tool_calls:
-                conversation.add_tool_result(
-                    call_id, {"error": _BUDGET_NOTE}, is_error=True
-                )
+                plan.append((call_id, "budget", {"error": _BUDGET_NOTE}))
                 continue
 
             seen_keys.add(key)
             calls_executed += 1
-            result = execute_fn(call["name"], args)
+            to_execute[idx] = (call["name"], args)
+            plan.append((call_id, "exec", idx))
+
+        # Fan out the executions (read-only, independent within a round).
+        results_by_idx: dict[int, dict[str, Any]] = {}
+        if len(to_execute) == 1:
+            (only_idx, (name, args)), = to_execute.items()
+            results_by_idx[only_idx] = execute_fn(name, args)
+        elif to_execute:
+            with ThreadPoolExecutor(max_workers=min(len(to_execute), 8)) as pool:
+                futures = {
+                    pool.submit(execute_fn, name, args): i
+                    for i, (name, args) in to_execute.items()
+                }
+                for fut in futures:
+                    results_by_idx[futures[fut]] = fut.result()
+
+        # Apply results in call order (synthetic refusals inline).
+        for call_id, kind, data in plan:
+            if kind != "exec":
+                conversation.add_tool_result(call_id, data, is_error=True)
+                continue
+            name, args = to_execute[data]
+            result = results_by_idx[data]
             outcome.executed.append(
-                ExecutedCall(tool=call["name"], args=args, result=result)
+                ExecutedCall(tool=name, args=args, result=result)
             )
             conversation.add_tool_result(
                 call_id,

--- a/scripts/run_tool_harness.py
+++ b/scripts/run_tool_harness.py
@@ -94,6 +94,36 @@ def _opt_int(value):
         return None
 
 
+def _accumulate_usage(acc, response, api_format):
+    """Fold a turn's token usage into the loop accumulator (telemetry).
+
+    Tolerant: a response without a usage block (or with odd values) is skipped.
+    Captures cached prompt tokens where the backend reports them — that's the
+    prompt-cache-effectiveness signal for native_loop.
+    """
+    usage = response.get("usage") if isinstance(response, dict) else None
+    if not isinstance(usage, dict):
+        return
+
+    def _int(v):
+        try:
+            return int(v or 0)
+        except (TypeError, ValueError):
+            return 0
+
+    acc["requests"] += 1
+    if api_format == "anthropic":
+        acc["prompt_tokens"] += _int(usage.get("input_tokens"))
+        acc["completion_tokens"] += _int(usage.get("output_tokens"))
+        acc["cached_prompt_tokens"] += _int(usage.get("cache_read_input_tokens"))
+    else:
+        acc["prompt_tokens"] += _int(usage.get("prompt_tokens"))
+        acc["completion_tokens"] += _int(usage.get("completion_tokens"))
+        details = usage.get("prompt_tokens_details")
+        if isinstance(details, dict):
+            acc["cached_prompt_tokens"] += _int(details.get("cached_tokens"))
+
+
 def normalize_api_format(value):
     candidate = (value or "openai").strip().lower()
     if candidate in {"openai", "anthropic"}:
@@ -1154,28 +1184,42 @@ def run_native_loop(
         else "max_tokens"
     )
 
+    # Token/cost telemetry: accumulate per-turn usage across the whole loop so
+    # the harness output can report tokens spent + prompt-cache effectiveness
+    # (cached_prompt_tokens) — observability for cost and for tuning caching.
+    usage_acc = {
+        "requests": 0,
+        "prompt_tokens": 0,
+        "completion_tokens": 0,
+        "cached_prompt_tokens": 0,
+    }
+
     def post_fn(payload):
         # Per-turn fallback: a streamed turn that can't be reassembled — a
         # truncated/garbled SSE body (transport raise) or a 200 error object
         # (error key) — is retried once non-streamed before the loop gives up.
+        response = None
         try:
             response = run_chat_request(
                 base_url, api_format, payload, api_key, planning_timeout
             )
-            if not (payload.get("stream") and response.get("error")):
-                return response
+            usable = not (payload.get("stream") and response.get("error"))
         except Exception:
             if not payload.get("stream"):
                 raise
-        print(
-            "  native loop: streamed turn unusable; retrying non-streamed",
-            file=sys.stderr,
-        )
-        fallback = {k: v for k, v in payload.items() if k != "stream_options"}
-        fallback["stream"] = False
-        return run_chat_request(
-            base_url, api_format, fallback, api_key, planning_timeout
-        )
+            usable = False
+        if not usable:
+            print(
+                "  native loop: streamed turn unusable; retrying non-streamed",
+                file=sys.stderr,
+            )
+            fallback = {k: v for k, v in payload.items() if k != "stream_options"}
+            fallback["stream"] = False
+            response = run_chat_request(
+                base_url, api_format, fallback, api_key, planning_timeout
+            )
+        _accumulate_usage(usage_acc, response, api_format)
+        return response
 
     def execute_fn(tool_name, args):
         normalized_name, normalized_args = normalize_tool_request(
@@ -1204,6 +1248,7 @@ def run_native_loop(
         max_tokens=planning_max_tokens,
         stream=stream,
         tokens_param=tokens_param,
+        cache_prefix=True,
     )
 
     if outcome.degraded:
@@ -1251,6 +1296,7 @@ def run_native_loop(
                     keep_full_history_on_verdict=True,
                     response_format=response_format,
                     tokens_param=tokens_param,
+                    cache_prefix=True,
                 )
                 verdict_response = post_fn(verdict_payload)
                 Path("ai-response.primary.json").write_text(
@@ -1259,6 +1305,19 @@ def run_native_loop(
                 result["native_loop_verdict_produced"] = True
         except Exception as exc:  # noqa: BLE001 — never let it break evidence output
             result["native_loop_verdict_error"] = str(exc)
+
+    # Token/cost telemetry (loop turns + the verdict turn). cache_hit_ratio is
+    # the share of prompt tokens served from the prefix cache — the empirical
+    # prompt-cache-effectiveness signal (0.0 when the backend doesn't report it).
+    prompt_tokens = usage_acc["prompt_tokens"]
+    result["usage"] = {
+        **usage_acc,
+        "cache_hit_ratio": (
+            round(usage_acc["cached_prompt_tokens"] / prompt_tokens, 3)
+            if prompt_tokens
+            else 0.0
+        ),
+    }
 
     result["mode"] = "native_loop"
     result["rounds"] = outcome.rounds

--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -128,6 +128,44 @@ class TestTokensParam:
         assert "max_completion_tokens" not in payload
 
 
+class TestAnthropicCachePrefix:
+    """Anthropic prompt caching is opt-in (#263 Part 2): cache_control markers
+    on the stable prefix (system + tools). Default off — unchanged wire shape."""
+
+    def test_default_system_is_plain_string(self):
+        payload = Conversation(system="s").to_request_payload("anthropic", "m", max_tokens=64)
+        assert payload["system"] == "s"
+        assert all("cache_control" not in t for t in payload["tools"])
+
+    def test_cache_prefix_marks_system_and_last_tool(self):
+        payload = Conversation(system="s").to_request_payload(
+            "anthropic", "m", max_tokens=64, cache_prefix=True
+        )
+        assert payload["system"] == [
+            {"type": "text", "text": "s", "cache_control": {"type": "ephemeral"}}
+        ]
+        # Exactly one tools breakpoint, on the last tool.
+        marked = [t for t in payload["tools"] if "cache_control" in t]
+        assert len(marked) == 1 and marked[0] is payload["tools"][-1]
+
+    def test_cache_prefix_is_noop_for_openai(self):
+        # OpenAI caches the prefix automatically; no markers, no shape change.
+        payload = Conversation(system="s").to_request_payload(
+            "openai", "m", max_tokens=64, cache_prefix=True
+        )
+        assert isinstance(payload["messages"][0]["content"], str)
+        assert all("cache_control" not in t for t in payload["tools"])
+
+    def test_cache_prefix_verdict_turn_marks_system_only(self):
+        # The verdict turn drops tools, so only the system block is marked.
+        payload = Conversation(system="s").to_request_payload(
+            "anthropic", "m", max_tokens=64, verdict_turn=True, cache_prefix=True
+        )
+        assert "tools" not in payload
+        assert isinstance(payload["system"], list)
+        assert payload["system"][0]["cache_control"] == {"type": "ephemeral"}
+
+
 class TestTruncateText:
     def test_no_truncation_under_limit(self):
         out, truncated = truncate_text("hello\nworld", 100)

--- a/tests/test_native_tool_loop.py
+++ b/tests/test_native_tool_loop.py
@@ -473,3 +473,36 @@ def test_hostile_tool_result_is_fenced_before_next_round():
     assert "UNTRUSTED DATA" in tool_message["content"]
     assert hostile in tool_message["content"]
     assert tool_message["content"].index("UNTRUSTED DATA") < tool_message["content"].index(hostile)
+
+
+def test_round_calls_execute_concurrently_and_in_order():
+    """A round's calls run concurrently (a Barrier(3) would deadlock/timeout if
+    they ran sequentially), and results are still applied in original call order."""
+    import threading
+
+    conv = fresh_conversation()
+    post = scripted_post(
+        [
+            openai_tool_call_response(
+                [
+                    ("c1", "read_file", '{"path": "a"}'),
+                    ("c2", "read_file", '{"path": "b"}'),
+                    ("c3", "read_file", '{"path": "c"}'),
+                ]
+            ),
+            openai_text_response("done"),
+        ]
+    )
+    barrier = threading.Barrier(3, timeout=5)
+
+    def execute(tool, args):
+        barrier.wait()  # all three must be in-flight at once, else BrokenBarrierError
+        return {"tool": tool, "status": "ok", "result": {"path": args["path"]}}
+
+    outcome = drive_tool_loop(
+        conv, post, execute, api_format="openai", model="m",
+        budgets=LoopBudgets(max_tool_calls=3),
+    )
+    assert len(outcome.executed) == 3
+    assert [e.args["path"] for e in outcome.executed] == ["a", "b", "c"]
+    assert conv.open_tool_call_ids() == set()

--- a/tests/test_run_native_loop_wiring.py
+++ b/tests/test_run_native_loop_wiring.py
@@ -414,3 +414,33 @@ def test_native_loop_honors_max_completion_tokens(monkeypatch, tmp_path):
     for payload in payloads:
         assert "max_completion_tokens" in payload
         assert "max_tokens" not in payload
+
+
+def test_native_loop_accumulates_token_usage(monkeypatch, tmp_path):
+    """Token/cost telemetry: per-turn usage (loop + verdict) is summed into
+    result['usage'], including cached prompt tokens → cache_hit_ratio."""
+    (tmp_path / "review-corpus.truncated.md").write_text("# corpus\n", encoding="utf-8")
+    (tmp_path / "machineconfig.yaml.j2").write_text("install: v1.13.4\n", encoding="utf-8")
+
+    def with_usage(resp, p, c, cached):
+        resp["usage"] = {"prompt_tokens": p, "completion_tokens": c,
+                         "prompt_tokens_details": {"cached_tokens": cached}}
+        return resp
+
+    verdict = {"choices": [{"finish_reason": "stop",
+               "message": {"content": '{"verdict":"approve","review_markdown":"ok","findings":[]}'}}]}
+    handled, result, _ = _run_capturing(
+        monkeypatch, tmp_path, "openai",
+        [
+            with_usage(_openai_call("c1", "read_file", '{"path": "machineconfig.yaml.j2"}'), 100, 20, 40),
+            with_usage(_openai_text("done"), 150, 10, 120),
+            with_usage(verdict, 200, 30, 180),
+        ],
+    )
+    assert handled is True
+    u = result["usage"]
+    assert u["requests"] == 3
+    assert u["prompt_tokens"] == 450
+    assert u["completion_tokens"] == 60
+    assert u["cached_prompt_tokens"] == 340
+    assert u["cache_hit_ratio"] == round(340 / 450, 3)


### PR DESCRIPTION
The pure-code lane of the 1.3.0 harness gate (#265) — three independent capabilities, each unit-tested to completion (no GPU dependency, zero busted-release risk).

### 1. Token/cost telemetry
`run_native_loop` accumulates per-turn usage (loop + verdict) into `result["usage"]`: `requests`, `prompt_tokens`, `completion_tokens`, `cached_prompt_tokens`, and a derived `cache_hit_ratio`. Tolerant of missing usage blocks; reads cached tokens from OpenAI `prompt_tokens_details.cached_tokens` / Anthropic `cache_read_input_tokens`. **This is the prompt-cache-effectiveness signal we lacked when measuring #264** — now we can see cache hits per run instead of inferring from wall-clock.

### 2. Anthropic `cache_control` (#263 Part 2)
Anthropic caching is opt-in, so `to_request_payload` gains `cache_prefix`; the Anthropic builder marks the stable prefix (system block + last tool) with `cache_control: {type: ephemeral}`. OpenAI is a no-op (automatic prefix cache). **Default off** → existing wire shape unchanged; `run_native_loop` turns it on for loop + verdict turns.

### 3. Parallel tool execution within a round
`drive_tool_loop` now decides each call's disposition **sequentially** (dedup + budget stay deterministic and call-ordered), then **fans out the to-run executions concurrently** (the executor is read-only and a round's calls are independent), applying results in original call order — the open-call contract is preserved. A `Barrier(3)` test proves concurrency (it would deadlock if execution were sequential); all existing dedup/budget/order tests still pass.

## Tests
New: telemetry accumulation, 4 cache_control cases (default/marked/openai-noop/verdict), concurrency-proof + order. **861 suite + smoke (25) green on Python 3.14.**

Checks off telemetry, cache Part 2, and parallel exec on #265. Relates to #197 §2 / #263.
