### PR TITLE
feat(tool-loop): read-only MCP tools in the native loop (#245)

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,8 @@ Only three inputs are required: `github_token`, `ai_base_url`, and `ai_model`. E
 | `tool_failure_enforcement` | Force `request_changes` when tool harness planning fails | No | `false` |
 | `tool_min_successful_requests` | Minimum successful tool requests required when `tool_failure_enforcement=true` | No | `0` |
 | `tool_enable_for_forks` | Allow tool harness on cross-repository PRs | No | `false` |
+| `tool_mcp_servers` | Allowlist of read-only MCP servers for `tool_mode: native_loop`, as a newline/comma list of `name=url`. Read-verb tools are advertised as `mcp__<name>__<tool>`; write-verb tools are refused. Empty = off. Fork-gated like the rest of the harness | No | `""` |
+| `tool_mcp_token` | Optional bearer token sent to every configured MCP server | No | `""` |
 
 </details>
 

--- a/action.yml
+++ b/action.yml
@@ -408,7 +408,9 @@ inputs:
       newline/comma list of name=url (e.g. konflate=https://konflate.example/mcp).
       Their read-verb tools (list/get/read/…) are advertised as
       mcp_<name>_<tool>; write-verb tools are refused. Empty = off (default).
-      Fork-gated like the rest of the harness (tool_enable_for_forks).
+      Fork-gated like the rest of the harness (tool_enable_for_forks). Only
+      host-bearing http(s) URLs are accepted (HTTPS recommended); other schemes
+      are dropped.
     required: false
     default: ""
   tool_mcp_token:

--- a/action.yml
+++ b/action.yml
@@ -402,6 +402,19 @@ inputs:
     description: If true, allow the tool harness to run on cross-repository pull requests
     required: false
     default: "false"
+  tool_mcp_servers:
+    description: >-
+      Optional allowlist of read-only MCP servers for tool_mode=native_loop, as a
+      newline/comma list of name=url (e.g. konflate=https://konflate.example/mcp).
+      Their read-verb tools (list/get/read/…) are advertised as
+      mcp_<name>_<tool>; write-verb tools are refused. Empty = off (default).
+      Fork-gated like the rest of the harness (tool_enable_for_forks).
+    required: false
+    default: ""
+  tool_mcp_token:
+    description: Optional bearer token sent to every configured MCP server (tool_mcp_servers)
+    required: false
+    default: ""
   ai_request_timeout_sec:
     description: Timeout in seconds for the primary model API request (curl --max-time)
     required: false
@@ -585,6 +598,8 @@ runs:
         EVIDENCE_BLOCKER_ENFORCEMENT: ${{ inputs.evidence_blocker_enforcement }}
         EVIDENCE_ENABLE_FOR_FORKS: ${{ inputs.evidence_enable_for_forks }}
         TOOL_MODE: ${{ inputs.tool_mode }}
+        TOOL_MCP_SERVERS: ${{ inputs.tool_mcp_servers }}
+        TOOL_MCP_TOKEN: ${{ inputs.tool_mcp_token }}
         TOOL_LOOP_WALL_CLOCK_SEC: ${{ inputs.tool_loop_wall_clock_sec }}
         TOOL_MAX_REQUESTS: ${{ inputs.tool_max_requests }}
         TOOL_MAX_ROUNDS: ${{ inputs.tool_max_rounds }}
@@ -686,6 +701,8 @@ runs:
         EVIDENCE_BLOCKER_ENFORCEMENT: ${{ inputs.evidence_blocker_enforcement }}
         EVIDENCE_ENABLE_FOR_FORKS: ${{ inputs.evidence_enable_for_forks }}
         TOOL_MODE: ${{ inputs.tool_mode }}
+        TOOL_MCP_SERVERS: ${{ inputs.tool_mcp_servers }}
+        TOOL_MCP_TOKEN: ${{ inputs.tool_mcp_token }}
         TOOL_LOOP_WALL_CLOCK_SEC: ${{ inputs.tool_loop_wall_clock_sec }}
         TOOL_MAX_REQUESTS: ${{ inputs.tool_max_requests }}
         TOOL_MAX_ROUNDS: ${{ inputs.tool_max_rounds }}

--- a/pr_reviewer/mcp_client.py
+++ b/pr_reviewer/mcp_client.py
@@ -1,0 +1,225 @@
+"""Read-only MCP tool client for the native tool-calling loop (#245).
+
+Lets the loop call read-only tools from an *allowlisted* set of MCP servers, so
+a reviewer can pull host-specific pre-rendered evidence the built-in tools can't
+produce (e.g. konflate's post-kustomize/Helm rendered Kubernetes diff).
+
+Security posture (hard requirements from #245):
+
+* **Allowlist only** — a server is used only if explicitly listed; no discovery.
+* **Read-only** — a tool is advertised only if its name begins with a read verb
+  (``READ_ONLY_VERBS``); anything else (create/update/delete/…) is default-denied,
+  both at advertise time and again at call time.
+* **Namespaced** — advertised as ``mcp__<server>__<tool>`` so MCP names can never
+  shadow a built-in tool, and the harness can route by prefix.
+* **Bounded / untrusted** — results are treated as untrusted corpus text by the
+  caller (masked + capped like web_fetch); args come only from the model.
+
+The HTTP transport is an injected callable (``post_fn``) so the whole module is
+unit-testable against a scripted MCP server with no network — mirroring
+``forgejo_backend``'s ``_curl``-patch pattern.
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.request
+from typing import Any, Callable
+
+MCP_PREFIX = "mcp__"
+_PROTOCOL_VERSION = "2024-11-05"
+
+# A tool is relayed only when its name starts with one of these read verbs.
+# Default-deny: an unrecognised verb (create/update/delete/set/run/exec/…) is
+# never advertised or called, even if the server lists it.
+READ_ONLY_VERBS = frozenset(
+    {"list", "get", "read", "search", "fetch", "describe", "show", "find",
+     "lookup", "query", "head", "stat", "summary", "diff", "status", "view"}
+)
+
+
+def is_read_only_tool(name: str) -> bool:
+    """True if a tool name begins with an allowlisted read verb."""
+    if not isinstance(name, str) or not name:
+        return False
+    head = name.strip().lower().replace("-", "_").split("_", 1)[0]
+    return head in READ_ONLY_VERBS
+
+
+def namespaced_name(server: str, tool: str) -> str:
+    return f"{MCP_PREFIX}{server}__{tool}"
+
+
+def split_namespaced(name: str) -> tuple[str, str] | None:
+    """``mcp__server__tool`` → ``(server, tool)``; None if not MCP-namespaced."""
+    if not name.startswith(MCP_PREFIX):
+        return None
+    rest = name[len(MCP_PREFIX):]
+    server, sep, tool = rest.partition("__")
+    if not sep or not server or not tool:
+        return None
+    return server, tool
+
+
+def _default_post(url, payload, session_id, token, timeout):
+    """POST one JSON-RPC message; return (result_dict_or_None, session_id, error).
+
+    Handles a plain ``application/json`` body or an SSE (``text/event-stream``)
+    framing — MCP streamable-HTTP may use either. The session id is read from
+    the ``Mcp-Session-Id`` response header (set on initialize).
+    """
+    headers = {
+        "Content-Type": "application/json",
+        "Accept": "application/json, text/event-stream",
+        "User-Agent": "ai-pr-reviewer/1.0",
+    }
+    if session_id:
+        headers["Mcp-Session-Id"] = session_id
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    req = urllib.request.Request(
+        url, data=json.dumps(payload).encode("utf-8"), headers=headers, method="POST"
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            new_session = resp.headers.get("Mcp-Session-Id") or session_id
+            body = resp.read().decode("utf-8", errors="replace")
+    except Exception as exc:  # noqa: BLE001 — surfaced to the caller as an error
+        return None, session_id, str(exc)
+    return _parse_jsonrpc(body), new_session, None
+
+
+def _parse_jsonrpc(body: str):
+    """Extract the JSON-RPC object from a plain or SSE-framed body."""
+    text = body.strip()
+    if not text:
+        return None
+    # SSE framing: pull the last `data:` line (the response message).
+    if "data:" in text and not text.startswith("{"):
+        for line in reversed(text.splitlines()):
+            line = line.strip()
+            if line.startswith("data:"):
+                text = line[len("data:"):].strip()
+                break
+    try:
+        return json.loads(text)
+    except (json.JSONDecodeError, ValueError):
+        return None
+
+
+class McpToolset:
+    """An initialized connection to one allowlisted MCP server."""
+
+    def __init__(self, server: str, url: str, token: str = "", *, timeout: int = 20,
+                 post_fn: Callable | None = None):
+        self.server = server
+        self.url = url
+        self.token = token
+        self.timeout = timeout
+        # Runtime lookup of the default so tests can monkeypatch _default_post.
+        self._post = post_fn or _default_post
+        self._session_id: str | None = None
+        self.schemas: list[dict[str, Any]] = []
+        self._tool_names: set[str] = set()
+
+    def _rpc(self, method, params=None, *, msg_id=None):
+        payload = {"jsonrpc": "2.0", "method": method}
+        if msg_id is not None:
+            payload["id"] = msg_id
+        if params is not None:
+            payload["params"] = params
+        result, self._session_id, error = self._post(
+            self.url, payload, self._session_id, self.token, self.timeout
+        )
+        return result, error
+
+    def connect(self) -> str | None:
+        """initialize → tools/list → build namespaced read-only schemas.
+
+        Returns None on success, or an error string (the server is then skipped).
+        """
+        init, error = self._rpc(
+            "initialize",
+            {"protocolVersion": _PROTOCOL_VERSION, "capabilities": {},
+             "clientInfo": {"name": "ai-pr-reviewer", "version": "1.0"}},
+            msg_id=1,
+        )
+        if error or not isinstance(init, dict) or "result" not in init:
+            return f"initialize failed: {error or 'no result'}"
+        # Best-effort initialized notification (no id, no response expected).
+        self._rpc("notifications/initialized")
+
+        listed, error = self._rpc("tools/list", {}, msg_id=2)
+        if error or not isinstance(listed, dict):
+            return f"tools/list failed: {error or 'no result'}"
+        tools = (listed.get("result") or {}).get("tools")
+        if not isinstance(tools, list):
+            return "tools/list returned no tools array"
+
+        for tool in tools:
+            if not isinstance(tool, dict):
+                continue
+            name = tool.get("name")
+            if not isinstance(name, str) or not is_read_only_tool(name):
+                continue  # default-deny non-read-verb tools
+            schema = tool.get("inputSchema")
+            if not isinstance(schema, dict):
+                schema = {"type": "object", "properties": {}, "additionalProperties": True}
+            self._tool_names.add(name)
+            self.schemas.append({
+                "name": namespaced_name(self.server, name),
+                "description": (
+                    f"[MCP:{self.server}] {tool.get('description') or name} "
+                    "(read-only external evidence)"
+                ),
+                "parameters": schema,
+            })
+        return None
+
+    def call(self, tool: str, args: dict[str, Any]) -> dict[str, Any]:
+        """Call a relayed read-only tool; returns the executor result shape.
+
+        Re-checks the read-only allowlist at call time (defence in depth) and
+        refuses any tool not surfaced by connect().
+        """
+        if tool not in self._tool_names or not is_read_only_tool(tool):
+            return {"error": f"MCP tool not allowed: {tool}"}
+        result, error = self._rpc(
+            "tools/call", {"name": tool, "arguments": args or {}}, msg_id=3
+        )
+        if error:
+            return {"error": f"MCP call failed: {error}"}
+        if not isinstance(result, dict) or "result" not in result:
+            rpc_err = (result or {}).get("error") if isinstance(result, dict) else None
+            return {"error": f"MCP error: {rpc_err or 'no result'}"}
+        return {"content": _render_content(result["result"])}
+
+
+def _render_content(result: Any) -> str:
+    """Flatten an MCP tools/call result into plain text for the corpus."""
+    if isinstance(result, dict):
+        blocks = result.get("content")
+        if isinstance(blocks, list):
+            parts = []
+            for block in blocks:
+                if isinstance(block, dict) and isinstance(block.get("text"), str):
+                    parts.append(block["text"])
+            if parts:
+                return "\n".join(parts)
+    return json.dumps(result, ensure_ascii=False)
+
+
+def parse_server_specs(raw: str) -> list[tuple[str, str]]:
+    """Parse ``tool_mcp_servers`` (newline/comma list of ``name=url``)."""
+    specs: list[tuple[str, str]] = []
+    if not raw:
+        return specs
+    for item in raw.replace("\n", ",").split(","):
+        item = item.strip()
+        if not item or "=" not in item:
+            continue
+        name, _, url = item.partition("=")
+        name, url = name.strip(), url.strip()
+        if name and url:
+            specs.append((name, url))
+    return specs

--- a/pr_reviewer/mcp_client.py
+++ b/pr_reviewer/mcp_client.py
@@ -23,6 +23,7 @@ unit-testable against a scripted MCP server with no network — mirroring
 from __future__ import annotations
 
 import json
+import urllib.parse
 import urllib.request
 from typing import Any, Callable
 
@@ -209,8 +210,26 @@ def _render_content(result: Any) -> str:
     return json.dumps(result, ensure_ascii=False)
 
 
+def is_safe_server_url(url: str) -> bool:
+    """Only http(s) URLs with a host reach urlopen.
+
+    The URL is operator-set (not model/PR-controlled), but validating the scheme
+    is cheap defence-in-depth against a misconfigured ``tool_mcp_servers`` value
+    becoming an SSRF/LFI vector (file://, gopher://, …). HTTPS is recommended;
+    plain http is permitted for internal/cluster MCP servers.
+    """
+    try:
+        parsed = urllib.parse.urlparse(url)
+    except ValueError:
+        return False
+    return parsed.scheme in ("http", "https") and bool(parsed.hostname)
+
+
 def parse_server_specs(raw: str) -> list[tuple[str, str]]:
-    """Parse ``tool_mcp_servers`` (newline/comma list of ``name=url``)."""
+    """Parse ``tool_mcp_servers`` (newline/comma list of ``name=url``).
+
+    Entries that are malformed or whose URL is not a host-bearing http(s) URL
+    are silently dropped (see :func:`is_safe_server_url`)."""
     specs: list[tuple[str, str]] = []
     if not raw:
         return specs
@@ -220,6 +239,6 @@ def parse_server_specs(raw: str) -> list[tuple[str, str]]:
             continue
         name, _, url = item.partition("=")
         name, url = name.strip(), url.strip()
-        if name and url:
+        if name and url and is_safe_server_url(url):
             specs.append((name, url))
     return specs

--- a/pr_reviewer/mcp_client.py
+++ b/pr_reviewer/mcp_client.py
@@ -218,6 +218,13 @@ def is_safe_server_url(url: str) -> bool:
     becoming an SSRF/LFI vector (file://, gopher://, …). HTTPS is recommended;
     plain http is permitted for internal/cluster MCP servers.
     """
+    # Raw control characters / null bytes are never legitimate in a URL and
+    # signal corruption or injection; reject them up front (a NUL also raises
+    # later at the socket layer). Percent-encoded sequences (%00, %2f, …) are
+    # valid URL encoding and are left intact — they ride in the HTTP path to the
+    # remote server, not a local file read, so they are not an LFI vector here.
+    if any(ord(ch) < 0x20 or ord(ch) == 0x7f for ch in url):
+        return False
     try:
         parsed = urllib.parse.urlparse(url)
     except ValueError:

--- a/scripts/run_tool_harness.py
+++ b/scripts/run_tool_harness.py
@@ -1147,6 +1147,11 @@ def run_native_loop(
         adaptive_loop_budgets,
         drive_tool_loop,
     )
+    from pr_reviewer.mcp_client import (  # noqa: PLC0415
+        McpToolset,
+        parse_server_specs,
+        split_namespaced,
+    )
 
     # web_search is advertised only when a search endpoint is configured.
     search_url = os.getenv("SEARCH_URL", "").strip()
@@ -1154,6 +1159,30 @@ def run_native_loop(
     tool_schemas = list(TOOL_SCHEMAS)
     if search_url:
         tool_schemas.append(WEB_SEARCH_SCHEMA)
+
+    # Read-only MCP tools (#245), allowlisted via TOOL_MCP_SERVERS. Fork-gating
+    # happens upstream in run_review.sh (the env is blanked on fork PRs unless
+    # tool_enable_for_forks), so reaching here means MCP is permitted. A server
+    # that fails to connect is logged and skipped — never breaks the loop.
+    mcp_routes = {}
+    for srv_name, srv_url in parse_server_specs(os.getenv("TOOL_MCP_SERVERS", "")):
+        toolset = McpToolset(
+            srv_name, srv_url, os.getenv("TOOL_MCP_TOKEN", ""), timeout=request_timeout
+        )
+        try:
+            connect_error = toolset.connect()
+        except Exception as exc:  # noqa: BLE001 — never let MCP break the harness
+            connect_error = str(exc)
+        if connect_error:
+            print(f"  MCP server '{srv_name}' skipped: {connect_error}", file=sys.stderr)
+            continue
+        tool_schemas.extend(toolset.schemas)
+        for schema in toolset.schemas:
+            mcp_routes[schema["name"]] = toolset
+        print(
+            f"  MCP server '{srv_name}': {len(toolset.schemas)} read-only tool(s) advertised",
+            file=sys.stderr,
+        )
 
     # One stable system for the whole review (#263): reviewer prompt + tool-use
     # preamble, used for both the loop and the verdict turn so the cached prefix
@@ -1239,6 +1268,21 @@ def run_native_loop(
         return response
 
     def execute_fn(tool_name, args):
+        # Route mcp__server__tool to the MCP client; everything else falls
+        # through to the built-in read-only executor unchanged. MCP output is
+        # masked + capped exactly like built-in tool output (untrusted corpus).
+        if split_namespaced(tool_name):
+            toolset = mcp_routes.get(tool_name)
+            if toolset is None:
+                return {"tool": tool_name, "status": "error",
+                        "result": {"error": f"Unknown MCP tool: {tool_name}"}}
+            _, bare_tool = split_namespaced(tool_name)
+            res = toolset.call(bare_tool, args if isinstance(args, dict) else {})
+            if res.get("error"):
+                return {"tool": tool_name, "status": "error", "result": {"error": res["error"]}}
+            text, _ = mask_and_truncate(res.get("content", ""), max_response_bytes)
+            return {"tool": tool_name, "status": "ok", "result": {"content": text}}
+
         normalized_name, normalized_args = normalize_tool_request(
             {"tool": tool_name, "args": args}
         )

--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -108,10 +108,18 @@ def test_namespacing_round_trip():
 def test_parse_server_specs():
     assert parse_server_specs("") == []
     assert parse_server_specs("konflate=https://k/mcp") == [("konflate", "https://k/mcp")]
-    assert parse_server_specs("a=http://a,\n b=http://b ") == [
-        ("a", "http://a"), ("b", "http://b")
+    assert parse_server_specs("a=http://a/x,\n b=https://b/y ") == [
+        ("a", "http://a/x"), ("b", "https://b/y")
     ]
     assert parse_server_specs("garbage,nourl=") == []  # no url → dropped
+
+
+def test_parse_server_specs_rejects_unsafe_urls():
+    # SSRF/LFI hardening: only host-bearing http(s) URLs survive.
+    assert parse_server_specs("x=file:///etc/passwd") == []
+    assert parse_server_specs("x=gopher://evil/") == []
+    assert parse_server_specs("x=https:///nohost") == []
+    assert parse_server_specs("ok=https://k/mcp, bad=file:///x") == [("ok", "https://k/mcp")]
 
 
 def test_parse_jsonrpc_plain_and_sse():

--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -122,6 +122,16 @@ def test_parse_server_specs_rejects_unsafe_urls():
     assert parse_server_specs("ok=https://k/mcp, bad=file:///x") == [("ok", "https://k/mcp")]
 
 
+def test_parse_server_specs_rejects_raw_control_chars():
+    # Raw NUL / control chars are never valid in a URL — rejected as hygiene.
+    # (Percent-encoded %00/%2f are valid encoding and ride in the HTTP path; not
+    # an LFI here, so they are NOT rejected.)
+    assert parse_server_specs("x=https://h/a\x00b") == []
+    assert parse_server_specs("x=https://h/a\tb") == []
+    assert parse_server_specs("x=https://\x00evil/p") == []
+    assert parse_server_specs("ok=https://h/a%00b") == [("ok", "https://h/a%00b")]
+
+
 def test_parse_jsonrpc_plain_and_sse():
     assert _parse_jsonrpc('{"jsonrpc":"2.0","id":1,"result":{}}')["id"] == 1
     sse = 'event: message\ndata: {"jsonrpc":"2.0","id":2,"result":{"ok":true}}\n\n'

--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -1,0 +1,122 @@
+"""Unit tests for pr_reviewer.mcp_client (#245) — no network (stubbed transport)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from pr_reviewer.mcp_client import (
+    McpToolset,
+    is_read_only_tool,
+    namespaced_name,
+    parse_server_specs,
+    split_namespaced,
+    _parse_jsonrpc,
+)
+
+
+def _stub(tools, *, fail_initialize=False, call_text="rendered diff"):
+    """A scripted MCP transport (post_fn) — no network."""
+    def post(url, payload, session_id, token, timeout):
+        method = payload.get("method")
+        if method == "initialize":
+            if fail_initialize:
+                return None, session_id, "connection refused"
+            return {"jsonrpc": "2.0", "id": 1, "result": {"capabilities": {}}}, "sess-1", None
+        if method == "notifications/initialized":
+            return None, session_id, None
+        if method == "tools/list":
+            return {"jsonrpc": "2.0", "id": 2, "result": {"tools": tools}}, session_id, None
+        if method == "tools/call":
+            name = payload["params"]["name"]
+            return (
+                {"jsonrpc": "2.0", "id": 3,
+                 "result": {"content": [{"type": "text", "text": f"{call_text}:{name}"}]}},
+                session_id, None,
+            )
+        return None, session_id, "unknown method"
+    return post
+
+
+_KONFLATE_TOOLS = [
+    {"name": "list_pull_requests", "description": "list PRs",
+     "inputSchema": {"type": "object", "properties": {}}},
+    {"name": "get_pr_diff", "description": "rendered diff",
+     "inputSchema": {"type": "object", "properties": {"number": {"type": "integer"}}}},
+    {"name": "delete_pr", "description": "DANGER", "inputSchema": {"type": "object"}},
+    {"name": "update_config", "description": "DANGER", "inputSchema": {"type": "object"}},
+]
+
+
+# ── read-only filter ──────────────────────────────────────────────────────────
+def test_is_read_only_tool():
+    for ok in ("list_pull_requests", "get_pr_diff", "read_file", "search-x", "diff", "status"):
+        assert is_read_only_tool(ok)
+    for bad in ("delete_pr", "update_config", "create_x", "set_y", "run_z", "exec_q", ""):
+        assert not is_read_only_tool(bad)
+
+
+def test_connect_advertises_only_read_only_namespaced():
+    ts = McpToolset("konflate", "http://x/mcp", post_fn=_stub(_KONFLATE_TOOLS))
+    assert ts.connect() is None
+    names = {s["name"] for s in ts.schemas}
+    assert names == {
+        "mcp__konflate__list_pull_requests",
+        "mcp__konflate__get_pr_diff",
+    }
+    # write-verb tools are default-denied (never advertised)
+    assert not any("delete" in n or "update" in n for n in names)
+    # schema carries the server's inputSchema + an [MCP:...] description tag
+    diff = next(s for s in ts.schemas if s["name"].endswith("get_pr_diff"))
+    assert diff["parameters"]["properties"] == {"number": {"type": "integer"}}
+    assert "[MCP:konflate]" in diff["description"]
+
+
+def test_call_renders_text_content():
+    ts = McpToolset("konflate", "http://x/mcp", post_fn=_stub(_KONFLATE_TOOLS))
+    ts.connect()
+    res = ts.call("get_pr_diff", {"number": 7462})
+    assert res == {"content": "rendered diff:get_pr_diff"}
+
+
+def test_call_refuses_non_advertised_or_write_tool():
+    ts = McpToolset("konflate", "http://x/mcp", post_fn=_stub(_KONFLATE_TOOLS))
+    ts.connect()
+    # never surfaced (write verb) → refused at call time without hitting the server
+    assert "not allowed" in ts.call("delete_pr", {})["error"]
+    # not in the catalogue at all → refused
+    assert "not allowed" in ts.call("get_secrets", {})["error"]
+
+
+def test_connect_failure_returns_error_and_no_schemas():
+    ts = McpToolset("dead", "http://x/mcp", post_fn=_stub([], fail_initialize=True))
+    err = ts.connect()
+    assert err and "initialize failed" in err
+    assert ts.schemas == []
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+def test_namespacing_round_trip():
+    assert namespaced_name("konflate", "get_pr_diff") == "mcp__konflate__get_pr_diff"
+    assert split_namespaced("mcp__konflate__get_pr_diff") == ("konflate", "get_pr_diff")
+    assert split_namespaced("read_file") is None
+    assert split_namespaced("mcp__nosep") is None
+
+
+def test_parse_server_specs():
+    assert parse_server_specs("") == []
+    assert parse_server_specs("konflate=https://k/mcp") == [("konflate", "https://k/mcp")]
+    assert parse_server_specs("a=http://a,\n b=http://b ") == [
+        ("a", "http://a"), ("b", "http://b")
+    ]
+    assert parse_server_specs("garbage,nourl=") == []  # no url → dropped
+
+
+def test_parse_jsonrpc_plain_and_sse():
+    assert _parse_jsonrpc('{"jsonrpc":"2.0","id":1,"result":{}}')["id"] == 1
+    sse = 'event: message\ndata: {"jsonrpc":"2.0","id":2,"result":{"ok":true}}\n\n'
+    assert _parse_jsonrpc(sse)["result"] == {"ok": True}
+    assert _parse_jsonrpc("") is None
+    assert _parse_jsonrpc("not json") is None

--- a/tests/test_run_native_loop_wiring.py
+++ b/tests/test_run_native_loop_wiring.py
@@ -444,3 +444,41 @@ def test_native_loop_accumulates_token_usage(monkeypatch, tmp_path):
     assert u["completion_tokens"] == 60
     assert u["cached_prompt_tokens"] == 340
     assert u["cache_hit_ratio"] == round(340 / 450, 3)
+
+
+def test_native_loop_advertises_and_routes_mcp_tool(monkeypatch, tmp_path):
+    """#245: an allowlisted read-only MCP tool is advertised in the loop request
+    and routed to the MCP client; its result folds into the harness output."""
+    import pr_reviewer.mcp_client as mcp
+
+    monkeypatch.setenv("TOOL_MCP_SERVERS", "konflate=http://x/mcp")
+    tools = [{"name": "get_pr_diff", "description": "rendered diff",
+              "inputSchema": {"type": "object", "properties": {"number": {"type": "integer"}}}}]
+
+    def mcp_post(url, payload, session_id, token, timeout):
+        method = payload.get("method")
+        if method == "initialize":
+            return {"result": {"capabilities": {}}}, "s1", None
+        if method == "tools/list":
+            return {"result": {"tools": tools}}, session_id, None
+        if method == "tools/call":
+            return ({"result": {"content": [{"type": "text", "text": "version: v1.36.1 -> v1.36.2"}]}},
+                    session_id, None)
+        return None, session_id, None
+
+    monkeypatch.setattr(mcp, "_default_post", mcp_post)
+    handled, result, payloads = _run_capturing(
+        monkeypatch, tmp_path, "openai",
+        [
+            _openai_call("c1", "mcp__konflate__get_pr_diff", '{"number": 7462}'),
+            _openai_text("done"),
+        ],
+    )
+    assert handled is True
+    # advertised in the (first) loop request
+    advertised = [t["function"]["name"] for t in payloads[0]["tools"]]
+    assert "mcp__konflate__get_pr_diff" in advertised
+    # executed + folded into the harness trace
+    harness = json.loads((tmp_path / "tool-harness.json").read_text())
+    mcp_calls = [tc for tc in harness.get("tool_calls", []) if tc["tool"] == "mcp__konflate__get_pr_diff"]
+    assert mcp_calls and mcp_calls[0]["status"] == "ok"


### PR DESCRIPTION
Closes #245. The last umbrella piece of the 1.3.0 harness gate (#265): `tool_mode: native_loop` can call **read-only** tools from an **allowlisted** set of MCP servers — host-specific pre-rendered evidence the built-in tools can't produce (motivating case: konflate's rendered post-kustomize/Helm Kubernetes diff). `drive_tool_loop` is already tool-agnostic, so the loop driver is unchanged.

## How
- **`pr_reviewer/mcp_client.py`** — `initialize` → `tools/list` over streamable-HTTP (`Mcp-Session-Id`, SSE- or JSON-framed), advertise read-only tools namespaced `mcp__<server>__<tool>`, call them, render content to text. The HTTP transport is injected → **fully unit-testable with no network**.
- **`run_native_loop`** merges MCP schemas into the advertised `tools` and routes `mcp__`-prefixed calls to the client; everything else falls through unchanged. MCP output is masked + capped like any built-in result (untrusted corpus).
- **Inputs** `tool_mcp_servers` (`name=url` allowlist; empty = off) + `tool_mcp_token`.

## Security (#245 hard requirements)
- **Allowlist-only** — no discovery, no defaults.
- **Read-only by default-deny** — only read-verb names (`list`/`get`/`read`/…) are advertised, and re-checked at call time; write verbs (`delete_`/`update_`/…) refused even if the server lists them.
- **Fork-gated for free** — the whole harness is skipped on fork PRs unless `tool_enable_for_forks`, so MCP inherits it.
- **Bounded + untrusted** — args come only from the model; output masked + capped.

## Acceptance criteria
- [x] `tool_mcp_servers` empty → behavior unchanged (feature off).
- [x] Allowlisted read-only tools advertised + callable; results fold into the corpus.
- [x] Non-allowlisted / write-verb tool refused.
- [x] Fork PR + `tool_enable_for_forks=false` → harness (incl. MCP) not run.
- [x] Unit tests with a stubbed MCP transport (no network).
- [ ] **Live konflate `/mcp` round-trip — to validate with you on the real endpoint.**

8 client unit tests + a wiring test (advertised + routed + folded into the harness trace). **874 suite + smoke (25) green on Python 3.14.** Part of #197.
