### PR TITLE
fix(tool-loop): record native-loop usage on the degrade path

### DIFF
--- a/scripts/run_tool_harness.py
+++ b/scripts/run_tool_harness.py
@@ -124,6 +124,25 @@ def _accumulate_usage(acc, response, api_format):
             acc["cached_prompt_tokens"] += _int(details.get("cached_tokens"))
 
 
+def _usage_with_cache_ratio(usage_acc):
+    """Stamp the loop's accumulated usage with cache_hit_ratio for telemetry.
+
+    cache_hit_ratio is the share of prompt tokens served from the prefix cache
+    — the empirical prompt-cache-effectiveness signal (0.0 when the backend
+    doesn't report it). Shared by the completed-loop and degraded-loop paths so
+    both emit the same shape.
+    """
+    prompt_tokens = usage_acc["prompt_tokens"]
+    return {
+        **usage_acc,
+        "cache_hit_ratio": (
+            round(usage_acc["cached_prompt_tokens"] / prompt_tokens, 3)
+            if prompt_tokens
+            else 0.0
+        ),
+    }
+
+
 def normalize_api_format(value):
     candidate = (value or "openai").strip().lower()
     if candidate in {"openai", "anthropic"}:
@@ -1316,6 +1335,14 @@ def run_native_loop(
         result["native_loop_degraded"] = outcome.stop_reason
         if outcome.error:
             result["native_loop_error"] = outcome.error
+        # Record the native attempt's token usage even though we're degrading to
+        # the planner path below. Otherwise the spend on a turn that errored
+        # (stop_reason=request-error) or burned a full reasoning turn before
+        # declining tools (no-tool-calls) is invisible — and the fallback's
+        # plan_execute mode in tool-harness.json carries no record of it. Kept
+        # under a native_loop-namespaced key so it never reads as the fallback
+        # mode's own usage (which is accounted separately).
+        result["native_loop_usage"] = _usage_with_cache_ratio(usage_acc)
         return False
 
     # ── In-conversation verdict (#205, Option 1) ─────────────────────────────
@@ -1370,15 +1397,7 @@ def run_native_loop(
     # Token/cost telemetry (loop turns + the verdict turn). cache_hit_ratio is
     # the share of prompt tokens served from the prefix cache — the empirical
     # prompt-cache-effectiveness signal (0.0 when the backend doesn't report it).
-    prompt_tokens = usage_acc["prompt_tokens"]
-    result["usage"] = {
-        **usage_acc,
-        "cache_hit_ratio": (
-            round(usage_acc["cached_prompt_tokens"] / prompt_tokens, 3)
-            if prompt_tokens
-            else 0.0
-        ),
-    }
+    result["usage"] = _usage_with_cache_ratio(usage_acc)
 
     result["mode"] = "native_loop"
     result["rounds"] = outcome.rounds

--- a/tests/test_run_native_loop_wiring.py
+++ b/tests/test_run_native_loop_wiring.py
@@ -277,6 +277,70 @@ def test_native_loop_degrades_writes_nothing(monkeypatch, tmp_path):
     assert not (tmp_path / "tool-harness.md").exists()
 
 
+def _openai_text_with_usage(text, *, prompt, completion, cached=0):
+    resp = _openai_text(text)
+    resp["usage"] = {
+        "prompt_tokens": prompt,
+        "completion_tokens": completion,
+        "prompt_tokens_details": {"cached_tokens": cached},
+    }
+    return resp
+
+
+def test_native_loop_degrade_records_native_usage(monkeypatch, tmp_path):
+    """A turn that burns tokens then declines tools still records its spend.
+
+    Before the fix the no-tool-calls degrade returned without stamping usage,
+    so the (real) cost of the reasoning turn that declined tools vanished and
+    the fallback's plan_execute mode carried no record of it.
+    """
+    handled, result = _run(
+        monkeypatch,
+        tmp_path,
+        [_openai_text_with_usage(
+            "Approve.", prompt=1000, completion=400, cached=600
+        )],
+    )
+    assert handled is False
+    assert result["native_loop_degraded"] == "no-tool-calls"
+    usage = result["native_loop_usage"]
+    assert usage["prompt_tokens"] == 1000
+    assert usage["completion_tokens"] == 400
+    assert usage["cached_prompt_tokens"] == 600
+    assert usage["cache_hit_ratio"] == 0.6
+
+
+def test_native_loop_request_error_records_usage_and_error(monkeypatch, tmp_path):
+    """A first-turn transport error degrades to the planner, but the native
+    attempt's stop reason + (zeroed) usage are still recorded — no silent
+    'mode present, usage absent' tool-harness.json."""
+    def boom(base_url, api_format, payload, api_key, timeout_sec):
+        raise RuntimeError("upstream 524")
+
+    monkeypatch.setattr(rth, "run_chat_request", boom)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("EFFECTIVE_SCOPE", "full")
+    monkeypatch.setenv("AI_STREAM", "false")
+    result = {
+        "mode": "plan_execute_once",
+        "planned_request_count": 0,
+        "executed_request_count": 0,
+        "tool_results": [],
+    }
+    handled = rth.run_native_loop(
+        "owner/repo", "http://model.local/v1", "openai", "mock-model", "key",
+        "# PR Corpus\nbumps kubelet image",
+        {"owner/repo"}, ["talos.dev"], str(tmp_path),
+        12000, 15, 4, 45, 400, result,
+    )
+    assert handled is False
+    assert result["native_loop_degraded"] == "request-error"
+    assert "upstream 524" in result["native_loop_error"]
+    # Usage block is present (zeroed — the request never returned a body).
+    assert result["native_loop_usage"]["prompt_tokens"] == 0
+    assert result["native_loop_usage"]["cache_hit_ratio"] == 0.0
+
+
 def _run_capturing(monkeypatch, tmp_path, api_format, responses):
     """Like _run but records every payload sent, for the verdict-turn tests."""
     queue = list(responses)


### PR DESCRIPTION
## What

When `run_native_loop` ends with `stop_reason=request-error` (a transport error on the first turn) or `no-tool-calls`, `outcome.degraded` is `True` and the function early-returns so the caller falls back to the `plan_execute_loop` planner. That `return False` sits **before** the usage-telemetry block, so the native attempt's token spend was silently dropped — and the fallback's `plan_execute` mode in `tool-harness.json` then carried no record of it.

That's the "mode present, usage absent" symptom flagged during the Strix-Halo eval runs: the `mode` in the file is the *fallback's*, not the native loop's, and `native_loop_verdict_produced` is correctly absent because no verdict was attempted.

## Fix

- Record the native attempt's usage under a `native_loop_usage` key on the degrade path. Namespaced so it never reads as the fallback mode's own usage (which is accounted separately). This makes the otherwise-invisible double-spend visible — a weak model can burn a full reasoning turn and then decline tools, after which we re-run the planner.
- Extracted the `cache_hit_ratio` stamping into a shared `_usage_with_cache_ratio` helper used by both telemetry sites (completed loop + degrade).

## Not changed

The degrade→planner fallback behavior is intentionally unchanged: a first-turn `request-error` on the tools-bearing payload can be a payload-shape rejection that the simpler planner call (no `tools` array) survives, so falling back still has recovery value. `native_loop_degraded` already records the stop reason — this PR only closes the usage-accounting gap.

## Tests

- New: degrade-with-usage records `native_loop_usage` (prompt/completion/cached + `cache_hit_ratio`).
- New: first-turn `request-error` records `native_loop_degraded=request-error`, `native_loop_error`, and a zeroed `native_loop_usage`.
- Full suite: 878 passed; smoke: 25 passed (Python 3.14).

Relates to #265.
