### PR TITLE
ci: add actionlint to catch workflow/action.yml bugs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,6 +45,9 @@ jobs:
             .github/workflows/*.yaml \
             examples/*.yml
 
+      - name: Lint GitHub Actions workflows
+        uses: rhysd/actionlint@914e7df21a07ef503a81201c76d2b11c789d3fca # v1.7.12
+
       - name: Check shell scripts
         run: |
           set -euo pipefail


### PR DESCRIPTION
Refs #252

Add `rhysd/actionlint` (v1.7.12) as a CI step in the validate job. Catches shell quoting issues, expression syntax errors, deprecated features, and other workflow pitfalls that the existing Ruby YAML linter misses.

Verified locally with actionlint 1.7.12 — all current workflows and action.yml pass clean.