### PR TITLE
fix(routing): primary route gets full budget; fallback is never the smart tier

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ flowchart LR
     A -->|changed| B[Wait for CI<br/><i>optional</i>]
     B --> C[Collect context<br/>diff · issues · sources · evidence · tools]
     C --> D[Classify PR<br/>rule-based risk flags]
-    D --> E[Route & call model<br/>fast / smart / fallback]
+    D --> E[Route & call model<br/>primary / smart / fallback]
     E --> F[Validate & enforce<br/>required checks · findings · carry-forward]
     F --> G[Publish<br/>comment / native review]
 ```
@@ -234,23 +234,27 @@ Only three inputs are required: `github_token`, `ai_base_url`, and `ai_model`. E
 </details>
 
 <details>
-<summary><b>Routing & escalation</b> — fast/smart model split and escalation triggers</summary>
+<summary><b>Routing & escalation</b> — primary/smart model split and escalation triggers</summary>
 
 | Input | Description | Required | Default |
 |-------|-------------|----------|---------|
-| `review_routing_mode` | Route reviews between fast and smart models from the classification: `off` (existing primary/fallback behavior) or `auto` | No | `off` |
-| `ai_fast_model` | Fast model for low-risk reviews in `auto` mode; defaults to `ai_model` | No | `""` |
-| `ai_fast_base_url` | Base URL for the fast model; defaults to `ai_base_url` | No | `""` |
-| `ai_fast_api_format` | API format for the fast model; defaults to `ai_api_format` | No | `""` |
-| `ai_fast_api_key` | API key for the fast model; defaults to `ai_api_key` | No | `""` |
+| `review_routing_mode` | Route reviews between the primary and smart models from the classification: `off` (existing primary/fallback behavior) or `auto` | No | `off` |
+| `ai_primary_model` | Model for the primary route in `auto` mode; defaults to `ai_model` | No | `""` |
+| `ai_primary_base_url` | Base URL for the primary route model; defaults to `ai_base_url` | No | `""` |
+| `ai_primary_api_format` | API format for the primary route model; defaults to `ai_api_format` | No | `""` |
+| `ai_primary_api_key` | API key for the primary route model; defaults to `ai_api_key` | No | `""` |
+| `ai_fast_model` | Deprecated alias for `ai_primary_model` (route renamed `fast` → `primary`) | No | `""` |
+| `ai_fast_base_url` | Deprecated alias for `ai_primary_base_url` | No | `""` |
+| `ai_fast_api_format` | Deprecated alias for `ai_primary_api_format` | No | `""` |
+| `ai_fast_api_key` | Deprecated alias for `ai_primary_api_key` | No | `""` |
 | `ai_smart_model` | Smart model for high-risk reviews in `auto` mode; defaults to `ai_fallback_model` | No | `""` |
 | `ai_smart_base_url` | Base URL for the smart model; defaults to `ai_fallback_base_url` | No | `""` |
 | `ai_smart_api_format` | API format for the smart model; defaults to `ai_fallback_api_format`, then `ai_api_format` | No | `""` |
 | `ai_smart_api_key` | API key for the smart model; defaults to `ai_fallback_api_key` | No | `""` |
 | `escalate_on_risk_flags` | Comma-separated `pr_kind`/`risk_flag` names that route to the smart model in `auto` mode | No | security/priority/auth/route/file-serving/path/secret/db list |
-| `escalate_on_incomplete_required_checks` | Escalate fast reviews with unaddressed required checks to the smart model (`auto` mode) | No | `true` |
-| `escalate_on_fast_request_changes` | Escalate fast reviews whose verdict is `request_changes` (`auto` mode) | No | `true` |
-| `escalate_on_fast_low_confidence` | Escalate low-confidence fast reviews (short relative to the diff, or populated Unknowns section) (`auto` mode) | No | `true` |
+| `escalate_on_incomplete_required_checks` | Escalate primary-route reviews with unaddressed required checks to the smart model (`auto` mode) | No | `true` |
+| `escalate_on_fast_request_changes` | Escalate primary-route reviews whose verdict is `request_changes` (`auto` mode) | No | `true` |
+| `escalate_on_fast_low_confidence` | Escalate low-confidence primary-route reviews (short relative to the diff, or populated Unknowns section) (`auto` mode) | No | `true` |
 | `escalate_on_tool_or_evidence_blockers` | Escalate when evidence blockers exist or every executed tool request failed (`auto` mode) | No | `true` |
 | `escalate_on_tool_planning_failure` | Escalate when the tool-harness planning call failed (`auto` mode). Off by default: a planning failure degrades the review to no-tools, it does not signal risk | No | `false` |
 | `escalate_on_dirty_baseline` | Escalate incremental reviews whose baseline review found issues (`auto` mode) | No | `true` |
@@ -376,7 +380,7 @@ Only three inputs are required: `github_token`, `ai_base_url`, and `ai_model`. E
 | `verdict` | `approve` or `request_changes` |
 | `verdict_source` | `model`, `findings` (per `verdict_policy`), or `carry_forward` (a carried-forward blocker survived an incremental review) |
 | `required_checks` | Required-check validation status: `complete`, `incomplete`, or `none` (validation did not run) |
-| `review_route` | Model route used: `legacy` (routing off), `fast`, `smart`, or `escalated` |
+| `review_route` | Model route used: `legacy` (routing off), `primary`, `smart`, or `escalated` |
 | `escalation_reason` | Comma-separated escalation trigger names when `review_route` is `escalated` (empty otherwise) |
 | `findings` | Normalized structured findings as a JSON array (`[]` when the model produced none) |
 | `review_markdown` | Full markdown review body |
@@ -881,7 +885,7 @@ In `auto` mode, a fast review can also be **escalated after the fact**: the acti
 - `escalate_on_tool_planning_failure` (default **false**) — the harness planning call failed before any tools ran. Off by default because a planning failure means the review proceeded with less evidence (the same situation as `tool_mode: off`), not that the PR is risky; the failure is still recorded in the step summary.
 - `escalate_on_dirty_baseline` — this is an incremental review and the previous review found issues; judging whether the delta resolves them is run on the smart model.
 
-Only the **final** review is published. The fast result is kept on the runner as `ai-output.fast.json` for debugging; if the smart model fails, the fast review is published instead (never a failed run because of escalation). `review_route` reports `escalated` and `escalation_reason` lists the trigger names; both also land in the step summary and the managed metadata marker, and the published review's `_Analysis engine:_` line carries the same story in human-readable form (`— routed smart (risk match: …)` vs `— escalated (…)` vs `— fallback (primary failed)`), so you can tell a deliberate smart review from an escalation or an availability fallback at a glance. Worst case is two model calls per review — the unchanged-diff skip and incremental scope keep that bounded.
+Only the **final** review is published. The primary result is kept on the runner as `ai-output.primary.json` for debugging; if the smart model fails, the primary review is published instead (never a failed run because of escalation). `review_route` reports `escalated` and `escalation_reason` lists the trigger names; both also land in the step summary and the managed metadata marker, and the published review's `_Analysis engine:_` line carries the same story in human-readable form (`— routed smart (risk match: …)` vs `— escalated (…)` vs `— fallback (primary failed)`), so you can tell a deliberate smart review from an escalation or an availability fallback at a glance. Worst case is two model calls per review — the unchanged-diff skip and incremental scope keep that bounded.
 
 ## 💾 Token-saving with incremental reviews
 

--- a/action.yml
+++ b/action.yml
@@ -133,42 +133,59 @@ inputs:
     default: "warn"
   review_routing_mode:
     description: >-
-      Route PR reviews between fast and smart models based on the deterministic
-      classification. 'off' (default) preserves existing primary/fallback behavior.
-      'auto' sends PRs whose pr_kind or risk_flags match escalate_on_risk_flags to the
-      smart model and everything else to the fast model.
+      Route PR reviews between the primary and smart models based on the
+      deterministic classification. 'off' (default) preserves existing
+      primary/fallback behavior. 'auto' sends PRs whose pr_kind or risk_flags
+      match escalate_on_risk_flags to the smart model (when one is configured)
+      and keeps everything else on the primary model.
     required: false
     default: "off"
+  ai_primary_model:
+    description: Model for the primary review route when review_routing_mode=auto. Defaults to ai_model.
+    required: false
+    default: ""
+  ai_primary_base_url:
+    description: Base URL for the primary route model. Defaults to ai_base_url.
+    required: false
+    default: ""
+  ai_primary_api_format:
+    description: API format for the primary route model (openai or anthropic). Defaults to ai_api_format.
+    required: false
+    default: ""
+  ai_primary_api_key:
+    description: API key for the primary route model. Defaults to ai_api_key.
+    required: false
+    default: ""
   ai_fast_model:
-    description: Fast/local model for low-risk reviews when review_routing_mode=auto. Defaults to ai_model.
+    description: "Deprecated alias for ai_primary_model (the route was renamed fast -> primary)."
     required: false
     default: ""
   ai_fast_base_url:
-    description: Base URL for the fast model. Defaults to ai_base_url.
+    description: "Deprecated alias for ai_primary_base_url."
     required: false
     default: ""
   ai_fast_api_format:
-    description: API format for the fast model (openai or anthropic). Defaults to ai_api_format.
+    description: "Deprecated alias for ai_primary_api_format."
     required: false
     default: ""
   ai_fast_api_key:
-    description: API key for the fast model. Defaults to ai_api_key.
+    description: "Deprecated alias for ai_primary_api_key."
     required: false
     default: ""
   ai_smart_model:
-    description: Smarter model for high-risk reviews when review_routing_mode=auto. Defaults to ai_fallback_model; with neither set, risky PRs stay on the fast model.
+    description: "Opt-in smarter model for high-risk reviews (review_routing_mode=auto). With no smart model set, auto-routing stays on the primary model and never escalates. The fallback model is NEVER an escalation target — it only catches a primary-availability failure."
     required: false
     default: ""
   ai_smart_base_url:
-    description: Base URL for the smart model. Defaults to ai_fallback_base_url.
+    description: Base URL for the smart model. Defaults to ai_base_url.
     required: false
     default: ""
   ai_smart_api_format:
-    description: API format for the smart model (openai or anthropic). Defaults to ai_fallback_api_format, then ai_api_format.
+    description: API format for the smart model (openai or anthropic). Defaults to ai_api_format.
     required: false
     default: ""
   ai_smart_api_key:
-    description: API key for the smart model. Defaults to ai_fallback_api_key.
+    description: API key for the smart model. Defaults to ai_api_key.
     required: false
     default: ""
   escalate_on_risk_flags:
@@ -178,15 +195,15 @@ inputs:
     required: false
     default: "linked_security_issue,linked_priority_p0,linked_priority_p1,auth_changes,public_route_changes,file_serving_changes,path_handling_changes,secret_handling_changes,db_or_migration_changes"
   escalate_on_incomplete_required_checks:
-    description: Escalate a fast review to the smart model when required checks are unaddressed (review_routing_mode=auto only).
+    description: Escalate a primary-route review to the smart model when required checks are unaddressed (review_routing_mode=auto only).
     required: false
     default: "true"
   escalate_on_fast_request_changes:
-    description: Escalate a fast review to the smart model when the fast verdict is request_changes (review_routing_mode=auto only).
+    description: Escalate a primary-route review to the smart model when its verdict is request_changes (review_routing_mode=auto only).
     required: false
     default: "true"
   escalate_on_fast_low_confidence:
-    description: Escalate when the fast review is low-confidence (very short, or carries a populated Unknowns/Needs Verification section). review_routing_mode=auto only.
+    description: Escalate when the primary-route review is low-confidence (very short, or carries a populated Unknowns/Needs Verification section). review_routing_mode=auto only.
     required: false
     default: "true"
   escalate_on_tool_or_evidence_blockers:
@@ -530,7 +547,7 @@ outputs:
     description: Required-check validation status ('complete', 'incomplete', or 'none' when validation did not run)
     value: ${{ steps.review.outputs.required_checks }}
   review_route:
-    description: Model route used for this review ('legacy', 'fast', 'smart', or 'escalated')
+    description: Model route used for this review ('legacy', 'primary', 'smart', or 'escalated')
     value: ${{ steps.review.outputs.review_route }}
   escalation_reason:
     description: Comma-separated escalation trigger names when review_route is 'escalated' (empty otherwise)
@@ -604,6 +621,7 @@ runs:
         AI_TOKENS_PARAM: ${{ inputs.ai_tokens_param }}
         AI_FALLBACK_MODEL: ${{ inputs.ai_fallback_model }}
         REVIEW_ROUTING_MODE: ${{ inputs.review_routing_mode }}
+        AI_PRIMARY_MODEL: ${{ inputs.ai_primary_model || inputs.ai_fast_model }}
         AI_FAST_MODEL: ${{ inputs.ai_fast_model }}
         AI_SMART_MODEL: ${{ inputs.ai_smart_model }}
         ESCALATE_ON_RISK_FLAGS: ${{ inputs.escalate_on_risk_flags }}
@@ -697,6 +715,10 @@ runs:
         VALIDATE_REQUIRED_CHECKS: ${{ inputs.validate_required_checks }}
         REQUIRED_CHECK_VALIDATION_MODE: ${{ inputs.required_check_validation_mode }}
         REVIEW_ROUTING_MODE: ${{ inputs.review_routing_mode }}
+        AI_PRIMARY_BASE_URL: ${{ inputs.ai_primary_base_url || inputs.ai_fast_base_url }}
+        AI_PRIMARY_MODEL: ${{ inputs.ai_primary_model || inputs.ai_fast_model }}
+        AI_PRIMARY_API_FORMAT: ${{ inputs.ai_primary_api_format || inputs.ai_fast_api_format }}
+        AI_PRIMARY_API_KEY: ${{ inputs.ai_primary_api_key || inputs.ai_fast_api_key }}
         AI_FAST_BASE_URL: ${{ inputs.ai_fast_base_url }}
         AI_FAST_MODEL: ${{ inputs.ai_fast_model }}
         AI_FAST_API_FORMAT: ${{ inputs.ai_fast_api_format }}

--- a/pr_reviewer/tool_loop.py
+++ b/pr_reviewer/tool_loop.py
@@ -83,25 +83,27 @@ def adaptive_loop_budgets(
     max_tool_calls: int,
     wall_clock_sec: float,
     *,
-    review_route: str = "legacy",
+    review_route: str = "primary",
     risk_flag_count: int = 0,
 ) -> "LoopBudgets":
-    """Right-size the loop budget to PR risk (#197 §2: spend research where risk is).
+    """Right-size the loop budget. A native round is one model turn, so the
+    headroom is 2× the configured rounds (capped at 8); the configured tool-call
+    budget is used as-is.
 
-    A native round is one model turn, so the default headroom is 2× the
-    configured rounds (capped at 8). When auto-routing sent the PR to the FAST
-    tier — which only happens for a low-risk PR, since the route keys off
-    ``risk_flags`` — a shallow loop is enough; don't burn the full research
-    budget thrashing a trivial diff. A risk flag forces full depth even on the
-    fast route (guards a mis-route). Smart/legacy (routing off) keep full depth.
+    The budget is the SAME on every route — the route selects the MODEL, never
+    the tool budget. An earlier version shallow-capped the primary route (then
+    misnamed "fast") on low-risk PRs to "save budget on a trivial diff", but the
+    loop already self-limits (it stops as soon as the model stops calling
+    tools), so the cap never saved cost on trivial PRs — it only starved the
+    PRs that genuinely need a multi-hop chain (e.g. reading a deployed version,
+    then verifying it against a host platform's compatibility matrix). The
+    primary model is fully capable; don't ration its evidence-gathering.
+    ``review_route``/``risk_flag_count`` are retained for signature stability
+    and possible future heuristics.
     """
     rounds = min(max(max_rounds, 1) * 2, 8)
-    calls = max_tool_calls
-    if (review_route or "legacy").strip().lower() == "fast" and risk_flag_count == 0:
-        rounds = min(rounds, 2)
-        calls = min(calls, 3)
     return LoopBudgets(
-        max_tool_calls=calls,
+        max_tool_calls=max_tool_calls,
         max_rounds=rounds,
         wall_clock_sec=float(wall_clock_sec),
     )

--- a/scripts/check_review_needed.sh
+++ b/scripts/check_review_needed.sh
@@ -200,8 +200,8 @@ compute_config_hash() {
   if [[ -n "${REVIEW_ROUTING_MODE:-}" ]]; then
     parts+=("routing_mode:${REVIEW_ROUTING_MODE}")
   fi
-  if [[ -n "${AI_FAST_MODEL:-}" ]]; then
-    parts+=("fast_model:${AI_FAST_MODEL}")
+  if [[ -n "${AI_PRIMARY_MODEL:-${AI_FAST_MODEL:-}}" ]]; then
+    parts+=("primary_model:${AI_PRIMARY_MODEL:-${AI_FAST_MODEL}}")
   fi
   if [[ -n "${AI_SMART_MODEL:-}" ]]; then
     parts+=("smart_model:${AI_SMART_MODEL}")

--- a/scripts/run_review.sh
+++ b/scripts/run_review.sh
@@ -105,6 +105,11 @@ VERDICT_POLICY="${VERDICT_POLICY:-model}"
 VALIDATE_REQUIRED_CHECKS="${VALIDATE_REQUIRED_CHECKS:-auto}"
 REQUIRED_CHECK_VALIDATION_MODE="${REQUIRED_CHECK_VALIDATION_MODE:-warn}"
 REVIEW_ROUTING_MODE="${REVIEW_ROUTING_MODE:-off}"
+AI_PRIMARY_BASE_URL="${AI_PRIMARY_BASE_URL:-}"
+AI_PRIMARY_MODEL="${AI_PRIMARY_MODEL:-}"
+AI_PRIMARY_API_FORMAT="${AI_PRIMARY_API_FORMAT:-}"
+AI_PRIMARY_API_KEY="${AI_PRIMARY_API_KEY:-}"
+# ai_fast_* — deprecated aliases for ai_primary_* (route renamed fast -> primary)
 AI_FAST_BASE_URL="${AI_FAST_BASE_URL:-}"
 AI_FAST_MODEL="${AI_FAST_MODEL:-}"
 AI_FAST_API_FORMAT="${AI_FAST_API_FORMAT:-}"
@@ -309,6 +314,10 @@ case "$(printf '%s' "$REVIEW_ROUTING_MODE" | tr '[:upper:]' '[:lower:]')" in
     ;;
 esac
 
+if [[ -n "$AI_PRIMARY_API_FORMAT" ]] && ! AI_PRIMARY_API_FORMAT="$(normalize_api_format "$AI_PRIMARY_API_FORMAT")"; then
+  error "Invalid AI_PRIMARY_API_FORMAT '$AI_PRIMARY_API_FORMAT'; expected openai or anthropic"
+  exit 1
+fi
 if [[ -n "$AI_FAST_API_FORMAT" ]] && ! AI_FAST_API_FORMAT="$(normalize_api_format "$AI_FAST_API_FORMAT")"; then
   error "Invalid AI_FAST_API_FORMAT '$AI_FAST_API_FORMAT'; expected openai or anthropic"
   exit 1
@@ -952,11 +961,11 @@ fi
 section_timer_end
 
 # ── Model routing (#159) ─────────────────────────────────────────────
-# With review_routing_mode=auto, low-risk PRs go to the fast model and PRs
-# whose pr_kind or risk_flags match ESCALATE_ON_RISK_FLAGS go straight to the
-# smart model. The fast config defaults to the primary model; the smart config
-# defaults to the fallback model. Routing only rebinds which model the
-# existing retry/fallback machinery talks to — that machinery is unchanged.
+# With review_routing_mode=auto, most PRs run on the PRIMARY model and PRs whose
+# pr_kind or risk_flags match ESCALATE_ON_RISK_FLAGS go to the smart model when
+# one is configured. Routing only rebinds which model the existing retry/fallback
+# machinery talks to — that machinery is unchanged. (The primary model is fully
+# capable; the route is not a "fast/dumb" lane, and it gets the full tool budget.)
 resolve_review_route() {
   REVIEW_ROUTE="legacy"
   ROUTE_REASON="routing off"
@@ -986,38 +995,45 @@ resolve_review_route() {
       REVIEW_ROUTE="smart"
       ROUTE_REASON="risk match: ${matched}"
     else
-      REVIEW_ROUTE="fast"
+      REVIEW_ROUTE="primary"
       ROUTE_REASON="risk match: ${matched}, but no smart model configured"
     fi
   else
-    REVIEW_ROUTE="fast"
+    REVIEW_ROUTE="primary"
     ROUTE_REASON="no escalation flags matched"
   fi
 }
 
-# Fast defaults to the primary config; smart defaults to the fallback config.
-FAST_BASE_URL="${AI_FAST_BASE_URL:-$AI_BASE_URL}"
-FAST_MODEL="${AI_FAST_MODEL:-$AI_MODEL}"
-FAST_API_FORMAT="${AI_FAST_API_FORMAT:-$AI_API_FORMAT}"
-FAST_API_KEY="${AI_FAST_API_KEY:-$AI_API_KEY}"
-SMART_BASE_URL="${AI_SMART_BASE_URL:-$AI_FALLBACK_BASE_URL}"
-SMART_MODEL="${AI_SMART_MODEL:-$AI_FALLBACK_MODEL}"
-SMART_API_FORMAT="${AI_SMART_API_FORMAT:-${AI_FALLBACK_API_FORMAT:-$AI_API_FORMAT}}"
-SMART_API_KEY="${AI_SMART_API_KEY:-$AI_FALLBACK_API_KEY}"
+# The primary route is the default model (ai_model). ai_primary_* overrides it;
+# ai_fast_* is the deprecated alias for those overrides.
+PRIMARY_BASE_URL="${AI_PRIMARY_BASE_URL:-${AI_FAST_BASE_URL:-$AI_BASE_URL}}"
+PRIMARY_MODEL="${AI_PRIMARY_MODEL:-${AI_FAST_MODEL:-$AI_MODEL}}"
+PRIMARY_API_FORMAT="${AI_PRIMARY_API_FORMAT:-${AI_FAST_API_FORMAT:-$AI_API_FORMAT}}"
+PRIMARY_API_KEY="${AI_PRIMARY_API_KEY:-${AI_FAST_API_KEY:-$AI_API_KEY}}"
+# Smart is an OPT-IN quality tier resolved ONLY from ai_smart_*. It deliberately
+# does NOT borrow the fallback model: the fallback exists solely to catch a
+# primary-availability failure, never as an escalation target. With no
+# ai_smart_model set there is no smart lane — auto-routing stays on the primary
+# model and nothing escalates. The endpoint/format/key default to the primary's
+# (a smart model usually shares the endpoint); ai_smart_model alone is the gate.
+SMART_MODEL="${AI_SMART_MODEL}"
+SMART_BASE_URL="${AI_SMART_BASE_URL:-$AI_BASE_URL}"
+SMART_API_FORMAT="${AI_SMART_API_FORMAT:-$AI_API_FORMAT}"
+SMART_API_KEY="${AI_SMART_API_KEY:-$AI_API_KEY}"
 SMART_MODEL_RESOLVED=""
-if [[ -n "$SMART_BASE_URL" && -n "$SMART_MODEL" ]]; then
+if [[ -n "$SMART_MODEL" ]]; then
   SMART_MODEL_RESOLVED=1
 fi
 
 resolve_review_route
-# Export so the native-loop harness can right-size loop depth by route (#197 §2):
-# the fast route only fires on low-risk PRs, which get a shallower loop.
+# Exported for the native-loop harness; the loop budget is the same on every
+# route (the route selects the model, not the tool budget — see adaptive_loop_budgets).
 export REVIEW_ROUTE
-if [[ "$REVIEW_ROUTE" == "fast" ]]; then
-  AI_BASE_URL="$FAST_BASE_URL"
-  AI_MODEL="$FAST_MODEL"
-  AI_API_FORMAT="$FAST_API_FORMAT"
-  AI_API_KEY="$FAST_API_KEY"
+if [[ "$REVIEW_ROUTE" == "primary" ]]; then
+  AI_BASE_URL="$PRIMARY_BASE_URL"
+  AI_MODEL="$PRIMARY_MODEL"
+  AI_API_FORMAT="$PRIMARY_API_FORMAT"
+  AI_API_KEY="$PRIMARY_API_KEY"
 elif [[ "$REVIEW_ROUTE" == "smart" ]]; then
   AI_BASE_URL="$SMART_BASE_URL"
   AI_MODEL="$SMART_MODEL"
@@ -1434,7 +1450,7 @@ annotate_analysis_engine() {
       ;;
     primary)
       case "${REVIEW_ROUTE:-legacy}" in
-        fast) engine="$engine — fast route" ;;
+        primary) engine="$engine — primary route" ;;
         smart) engine="$engine — routed smart (${ROUTE_REASON:-risk match})" ;;
       esac
       ;;
@@ -1483,28 +1499,29 @@ else
 fi
 
 # ── Escalation (#160) ────────────────────────────────────────────────
-# When the fast route produced this review and a configured trigger fires
+# When the primary route produced this review and a configured trigger fires
 # (request_changes, unaddressed required checks, low confidence, blocker
-# signals), re-run the review on the smart model and publish only that
-# result. The fast output is kept as ai-output.fast.json for debugging. A
-# smart-model failure keeps the fast review — strictly better than failing.
+# signals), re-run the review on the smart model and publish only that result.
+# Escalation requires a configured smart model (ai_smart_model) — it NEVER
+# escalates to the fallback. The primary output is kept as ai-output.primary.json
+# for debugging. A smart-model failure keeps the primary review.
 ESCALATION_REASONS=""
 maybe_escalate_review() {
   [[ "$REVIEW_ROUTING_MODE" == "auto" ]] || return 0
-  [[ "${REVIEW_ROUTE:-legacy}" == "fast" ]] || return 0
+  [[ "${REVIEW_ROUTE:-legacy}" == "primary" ]] || return 0
   [[ -n "$SMART_MODEL_RESOLVED" ]] || return 0
   if [[ "$SMART_BASE_URL" == "$AI_BASE_URL" && "$SMART_MODEL" == "$AI_MODEL" ]]; then
     return 0  # nothing distinct to escalate to
   fi
-  # If the fast primary failed and the fallback produced this review, and the
-  # smart config is that same fallback (the default mapping), escalating would
-  # just re-call the model that already reviewed this corpus.
+  # Defensive: if the primary failed and the fallback produced this review, and
+  # the operator explicitly set ai_smart_model to that same fallback, escalating
+  # would just re-call the model that already reviewed this corpus.
   if [[ "${PRIMARY_OK:-0}" -ne 1 && "$SMART_BASE_URL" == "$AI_FALLBACK_BASE_URL" && "$SMART_MODEL" == "$AI_FALLBACK_MODEL" ]]; then
     log "Skipping escalation: the fallback model that produced this review is the smart model"
     return 0
   fi
 
-  # Decide on the RAW fast output, before verdict policy / completeness
+  # Decide on the RAW primary output, before verdict policy / completeness
   # validation / enforcement mutate it.
   local decision
   decision="$(PYTHONPATH="${SCRIPT_DIR}/.." python3 -c "
@@ -1521,17 +1538,17 @@ escalate, reasons = should_escalate(
 print('yes ' + ','.join(reasons) if escalate else 'no')
 " 2>/dev/null || echo no)"
   if [[ "$decision" == "no" || -z "$decision" ]]; then
-    log "No escalation triggers fired; keeping the fast review"
+    log "No escalation triggers fired; keeping the primary review"
     return 0
   fi
   ESCALATION_REASONS="${decision#yes }"
   log "Escalating to smart model $SMART_MODEL ($ESCALATION_REASONS)"
 
-  cp ai-output.json ai-output.fast.json
+  cp ai-output.json ai-output.primary.json
 
   local escalated_user
   escalated_user="$USER_MESSAGE
-This is an ESCALATED review: a faster preliminary review was judged insufficient (${ESCALATION_REASONS}). Review thoroughly and address every required check explicitly."
+This is an ESCALATED review: a preliminary review was judged insufficient (${ESCALATION_REASONS}). Review thoroughly and address every required check explicitly."
 
   build_model_request \
     "$SMART_API_FORMAT" \
@@ -1562,10 +1579,10 @@ This is an ESCALATED review: a faster preliminary review was judged insufficient
     log "Smart model succeeded; publishing the escalated review"
   else
     # parse_and_validate only rewrites ai-output.json on success, but restore
-    # defensively so a partial write can never replace the fast review.
-    cp ai-output.fast.json ai-output.json
+    # defensively so a partial write can never replace the primary review.
+    cp ai-output.primary.json ai-output.json
     ESCALATION_REASONS=""
-    log "Smart model failed after escalation; publishing the fast review"
+    log "Smart model failed after escalation; publishing the primary review"
   fi
 }
 maybe_escalate_review

--- a/tests/test_native_tool_loop.py
+++ b/tests/test_native_tool_loop.py
@@ -22,30 +22,30 @@ from pr_reviewer.tool_loop import (
 
 
 class TestAdaptiveLoopBudgets:
-    """Risk/route-adaptive loop depth (#197 §2)."""
+    """Loop depth is route-independent: 2× the configured rounds (capped at 8)
+    plus the configured tool-call budget, on every route. The route selects the
+    MODEL, never the tool budget — the primary model is fully capable and is no
+    longer shallow-capped (the loop self-limits when the model stops calling
+    tools)."""
 
-    def test_default_headroom_doubles_rounds_capped_at_8(self):
+    def test_headroom_doubles_rounds_capped_at_8(self):
         b = adaptive_loop_budgets(3, 4, 120.0)
         assert b.max_rounds == 6  # 3 * 2
         assert b.max_tool_calls == 4
         assert adaptive_loop_budgets(6, 4, 120.0).max_rounds == 8  # capped
 
-    def test_fast_route_low_risk_is_shallow(self):
-        b = adaptive_loop_budgets(3, 8, 120.0, review_route="fast", risk_flag_count=0)
-        assert b.max_rounds == 2
-        assert b.max_tool_calls == 3
-
-    def test_fast_route_with_risk_flag_keeps_full_depth(self):
-        # A risk flag forces full depth even if the PR was routed to fast.
-        b = adaptive_loop_budgets(3, 8, 120.0, review_route="fast", risk_flag_count=1)
+    def test_primary_route_is_not_shallowed(self):
+        # Was capped to 2 rounds / 3 calls; now gets the full configured budget.
+        b = adaptive_loop_budgets(3, 8, 120.0, review_route="primary", risk_flag_count=0)
         assert b.max_rounds == 6
         assert b.max_tool_calls == 8
 
-    def test_smart_and_legacy_keep_full_depth(self):
-        for route in ("smart", "legacy", "", None):
+    def test_every_route_gets_the_same_budget(self):
+        # incl. the deprecated "fast" value and risk_flag_count (now ignored).
+        for route in ("primary", "smart", "legacy", "fast", "", None):
             b = adaptive_loop_budgets(3, 8, 120.0, review_route=route, risk_flag_count=0)
-            assert b.max_rounds == 6
-            assert b.max_tool_calls == 8
+            assert b.max_rounds == 6, route
+            assert b.max_tool_calls == 8, route
 
 
 def openai_tool_call_response(calls, content=None):

--- a/tests/test_review_escalation.sh
+++ b/tests/test_review_escalation.sh
@@ -40,8 +40,10 @@ ACTION="$(cat "$ROOT_DIR/action.yml")"
 
 echo "=== Escalation gating ==="
 check_contains "escalation requires auto routing" "$SRC" '[[ "$REVIEW_ROUTING_MODE" == "auto" ]] || return 0'
-check_contains "escalation requires the fast route" "$SRC" '[[ "${REVIEW_ROUTE:-legacy}" == "fast" ]] || return 0'
+check_contains "escalation requires the primary route" "$SRC" '[[ "${REVIEW_ROUTE:-legacy}" == "primary" ]] || return 0'
 check_contains "escalation requires a smart model" "$SRC" '[[ -n "$SMART_MODEL_RESOLVED" ]] || return 0'
+check_contains "smart resolves ONLY from ai_smart_model (fallback is not the smart tier)" "$SRC" 'SMART_MODEL="${AI_SMART_MODEL}"'
+check_contains "smart gating keys off the smart model alone" "$SRC" 'if [[ -n "$SMART_MODEL" ]]; then'
 check_contains "no-op when smart equals the active fast config" "$SRC" 'nothing distinct to escalate to'
 check_contains "no-op when the fallback already produced the review on the smart config" "$SRC" 'the fallback model that produced this review is the smart model'
 check_contains "step summary reads smart-response usage when escalated" "$SRC" 'usage_file="ai-response.smart.json"'
@@ -50,10 +52,10 @@ echo ""
 echo "=== Decision and publication contracts ==="
 check_contains "decision made by pr_reviewer.escalation" "$SRC" "from pr_reviewer.escalation import should_escalate"
 check_contains "decision runs on the raw fast output (before mutation)" "$SRC" "before verdict policy / completeness"
-check_contains "fast output preserved as ai-output.fast.json" "$SRC" "cp ai-output.json ai-output.fast.json"
+check_contains "primary output preserved as ai-output.primary.json" "$SRC" "cp ai-output.json ai-output.primary.json"
 check_contains "escalated prompt names the reasons" "$SRC" "ESCALATED review"
-check_contains "smart failure restores the fast review" "$SRC" "cp ai-output.fast.json ai-output.json"
-check_contains "smart failure publishes the fast review" "$SRC" "publishing the fast review"
+check_contains "smart failure restores the primary review" "$SRC" "cp ai-output.primary.json ai-output.json"
+check_contains "smart failure publishes the primary review" "$SRC" "publishing the primary review"
 check_contains "route becomes escalated on success" "$SRC" 'REVIEW_ROUTE="escalated"'
 check "escalation_reason output emitted" "$(grep -c '^echo "escalation_reason=' "$RUN_REVIEW")" "1"
 # Escalation must be decided before the enforcement wrapper runs.

--- a/tests/test_review_routing.sh
+++ b/tests/test_review_routing.sh
@@ -73,9 +73,9 @@ check "off mode is legacy" "$(route_for off auth_changes "" 1)" "legacy"
 check "default-ish empty mode handled upstream (off)" "$(route_for off app_code "" 1)" "legacy"
 
 echo ""
-echo "=== Test: auto + low risk → fast ==="
-check "app_code with no flags routes fast" "$(route_for auto app_code "" 1)" "fast"
-check "renovate digest routes fast" "$(route_for auto renovate_digest_only "" 1)" "fast"
+echo "=== Test: auto + low risk → primary ==="
+check "app_code with no flags routes primary" "$(route_for auto app_code "" 1)" "primary"
+check "renovate digest routes primary" "$(route_for auto renovate_digest_only "" 1)" "primary"
 
 echo ""
 echo "=== Test: auto + risky pr_kind → smart ==="
@@ -90,21 +90,21 @@ check "app_code with path_handling_changes flag routes smart" \
   "$(route_for auto app_code "other_flag,path_handling_changes" 1)" "smart"
 
 echo ""
-echo "=== Test: smart route without smart config stays fast ==="
-check "risky PR without smart model stays fast" "$(route_for auto auth_changes "" "")" "fast"
+echo "=== Test: risky PR without smart config stays primary ==="
+check "risky PR without smart model stays primary" "$(route_for auto auth_changes "" "")" "primary"
 
 echo ""
 echo "=== Test: custom escalation list ==="
-check "custom list: kind not in list routes fast" \
-  "$(route_for auto auth_changes "" 1 "db_or_migration_changes")" "fast"
+check "custom list: kind not in list routes primary" \
+  "$(route_for auto auth_changes "" 1 "db_or_migration_changes")" "primary"
 check "custom list: matching kind routes smart" \
   "$(route_for auto db_or_migration_changes "" 1 "db_or_migration_changes")" "smart"
 
 echo ""
 echo "=== Test: wiring ==="
 RUN_REVIEW="$(cat "$ROOT_DIR/scripts/run_review.sh")"
-check_contains "fast config defaults to primary" "$RUN_REVIEW" 'FAST_MODEL="${AI_FAST_MODEL:-$AI_MODEL}"'
-check_contains "smart config defaults to fallback" "$RUN_REVIEW" 'SMART_MODEL="${AI_SMART_MODEL:-$AI_FALLBACK_MODEL}"'
+check_contains "primary route config defaults to ai_model (ai_fast_* alias)" "$RUN_REVIEW" 'PRIMARY_MODEL="${AI_PRIMARY_MODEL:-${AI_FAST_MODEL:-$AI_MODEL}}"'
+check_contains "smart resolves ONLY from ai_smart_model (not the fallback)" "$RUN_REVIEW" 'SMART_MODEL="${AI_SMART_MODEL}"'
 check "review_route output emitted" "$(grep -c '^echo "review_route=' "$ROOT_DIR/scripts/run_review.sh")" "1"
 check "precheck fingerprints routing mode" "$(grep -c 'routing_mode:' "$ROOT_DIR/scripts/check_review_needed.sh")" "1"
 check "precheck fingerprints escalate flags" "$(grep -c 'escalate_flags:' "$ROOT_DIR/scripts/check_review_needed.sh")" "1"
@@ -137,8 +137,8 @@ check "legacy primary stays unannotated" \
   "$(REVIEW_ROUTE=legacy annotate_analysis_engine "$BASE" primary)" "$BASE"
 check "routing-off default stays unannotated" \
   "$(REVIEW_ROUTE= annotate_analysis_engine "$BASE" primary)" "$BASE"
-check "fast route annotated" \
-  "$(REVIEW_ROUTE=fast annotate_analysis_engine "$BASE" primary)" "$BASE — fast route"
+check "primary route annotated" \
+  "$(REVIEW_ROUTE=primary annotate_analysis_engine "$BASE" primary)" "$BASE — primary route"
 check "smart route carries the risk reason" \
   "$(REVIEW_ROUTE=smart ROUTE_REASON="risk match: auth_changes" annotate_analysis_engine "$BASE" primary)" \
   "$BASE — routed smart (risk match: auth_changes)"
@@ -149,8 +149,8 @@ check "escalated carries trigger names" \
   "$BASE — escalated (fast_low_confidence)"
 # The step-summary usage-file branch greps the engine string for "fallback";
 # only the fallback origin may introduce that word.
-check "fast annotation does not claim fallback" \
-  "$(case "$(REVIEW_ROUTE=fast annotate_analysis_engine "$BASE" primary)" in *fallback*) echo yes;; *) echo no;; esac)" "no"
+check "primary annotation does not claim fallback" \
+  "$(case "$(REVIEW_ROUTE=primary annotate_analysis_engine "$BASE" primary)" in *fallback*) echo yes;; *) echo no;; esac)" "no"
 
 echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="


### PR DESCRIPTION
The `auto` router was starving exactly the PRs that need the most depth — a renovate k8s bump that should verify the Talos↔Kubernetes compatibility matrix kept getting routed to the shallow lane and punting ("verification required") instead of doing the chain. Three related fixes:

## 1. Fallback ≠ smart
`SMART_*` now resolves **only** from `ai_smart_*` — it no longer defaults to `ai_fallback_*`. With **no `ai_smart_model` configured, there is no smart lane**: auto-routing stays on the primary model and **nothing escalates**. The fallback model goes back to its one job — catching a primary *availability* failure — and is never a quality-escalation target.

## 2. The primary route is no longer shallow-capped
`adaptive_loop_budgets` gave the route only 2 rounds / 3 calls on low-risk PRs. But the loop **already self-limits** (it stops as soon as the model stops calling tools), so the cap never saved cost on trivial PRs — it only strangled the multi-hop chains that needed 6–8 calls. **Every route now gets the full configured budget; the route selects the model, not the tool budget.** The primary model is fully capable (a 26B is GPT-4-class) — it shouldn't be rationed.

## 3. Rename `fast` → `primary`
It's the **primary** model, not a dumb-quick lane — the name baked in the wrong assumption. Covers the `REVIEW_ROUTE` value, the `review_route` output, the engine annotation (`— primary route`), and the budget logic. The model-override inputs `ai_fast_*` → **`ai_primary_*`**, with `ai_fast_*` kept as **accepted deprecated aliases** (zero breakage). `ai-output.fast.json` → `ai-output.primary.json`.

## Tests
Adaptive-budget tests now assert route-independent full budget (incl. the deprecated `fast` value); escalation wiring asserts the primary route + smart-resolves-only-from-`ai_smart_model`. **904 tests + 25 smoke + routing/escalation/scope shell suites green** (Python 3.14).

## Impact
This is the missing piece for the founding use case: with the primary route un-starved + the V3 prompt + the AGENTS.md recipe (already deployed), the capable primary model can actually run read-config → search-matrix → fetch → cite. Suggest **1.3.1**; renovate auto-bumps the fleet pins (no manual re-fanout).
