### PR TITLE
feat(tool-loop): keep tools on verdict turn for cache-prefix reuse (#263 Part 3)

### DIFF
--- a/pr_reviewer/conversation.py
+++ b/pr_reviewer/conversation.py
@@ -822,16 +822,18 @@ class Conversation:
         response_format: str | None = None,
         tokens_param: str = "max_tokens",
         cache_prefix: bool = False,
+        keep_tools_on_verdict: bool = False,
     ) -> dict[str, Any]:
         """Render the conversation as a wire-ready request body.
 
         Parameters mirror the bash ``build_model_request`` in
         ``scripts/model_call.sh`` so the loop driver can drop in with
         minimal reshuffling. ``verdict_turn=True`` triggers the
-        ``ai_response_format`` switch: ``tools`` is dropped, and the prior
-        conversation is either carried through (default off — see
-        ``keep_full_history_on_verdict``) or collapsed into a single system
-        note via :meth:`_verdict_transcript_note`.
+        ``ai_response_format`` switch: ``tools`` is dropped by default on the
+        verdict turn (set ``keep_tools_on_verdict=True`` to preserve them for
+        cache-prefix reuse — see #263 Part 3). The prior conversation is either
+        carried through (default off — see ``keep_full_history_on_verdict``) or
+        collapsed into a single system note via :meth:`_verdict_transcript_note`.
         """
         if api_format == "anthropic":
             return self._to_anthropic_payload(
@@ -843,6 +845,7 @@ class Conversation:
                 keep_full_history_on_verdict=keep_full_history_on_verdict,
                 response_format=response_format,
                 cache_prefix=cache_prefix,
+                keep_tools_on_verdict=keep_tools_on_verdict,
             )
         return self._to_openai_payload(
             model=model,
@@ -853,6 +856,7 @@ class Conversation:
             keep_full_history_on_verdict=keep_full_history_on_verdict,
             response_format=response_format,
             tokens_param=tokens_param,
+            keep_tools_on_verdict=keep_tools_on_verdict,
         )
 
     def _to_openai_payload(
@@ -866,6 +870,7 @@ class Conversation:
         keep_full_history_on_verdict: bool,
         response_format: str | None,
         tokens_param: str = "max_tokens",
+        keep_tools_on_verdict: bool = False,
     ) -> dict[str, Any]:
         system = self.system
         messages = self._render_openai_messages()
@@ -896,15 +901,18 @@ class Conversation:
             payload["temperature"] = temperature
         if stream:
             payload["stream_options"] = {"include_usage": True}
-        # The closing turn drops tools UNCONDITIONALLY — that is the
-        # verdict-turn contract. response_format is a separate, optional
-        # add-on (the bash build_model_request supports json_object and
-        # json_schema; we mirror its shapes).
+        # The closing turn drops tools by default (the verdict-turn contract).
+        # With keep_tools_on_verdict=True (#263 Part 3), tools are retained so
+        # the cached prefix survives — the response_format enforces JSON output.
+        # Most backends support both; some reject them together, in which case
+        # the caller should keep this off. Default False preserves current behaviour.
         if verdict_turn:
             if response_format == "json_object":
                 payload["response_format"] = {"type": "json_object"}
             elif response_format == "json_schema":
                 payload["response_format"] = _OPENAI_VERDICT_JSON_SCHEMA
+            if keep_tools_on_verdict:
+                payload["tools"] = [_tool_to_openai(s) for s in self.tool_schemas]
         else:
             payload["tools"] = [_tool_to_openai(s) for s in self.tool_schemas]
         return payload
@@ -920,6 +928,7 @@ class Conversation:
         keep_full_history_on_verdict: bool,
         response_format: str | None,
         cache_prefix: bool = False,
+        keep_tools_on_verdict: bool = False,
     ) -> dict[str, Any]:
         system = self.system
         messages = self._render_anthropic_messages()
@@ -942,6 +951,11 @@ class Conversation:
         if temperature is not None:
             payload["temperature"] = temperature
         if not verdict_turn:
+            payload["tools"] = [_tool_to_anthropic(s) for s in self.tool_schemas]
+        elif keep_tools_on_verdict:
+            # #263 Part 3: retain tools on the verdict turn so the cached prefix
+            # survives. Anthropic has no response_format — the system prompt
+            # already carries JSON-output instructions (from the reviewer prompt).
             payload["tools"] = [_tool_to_anthropic(s) for s in self.tool_schemas]
         # Anthropic has no response_format; the closing-turn contract relies
         # on the system prompt to request JSON. response_format is silently

--- a/scripts/run_tool_harness.py
+++ b/scripts/run_tool_harness.py
@@ -1391,7 +1391,8 @@ def run_native_loop(
     # corpus for a separate review call. The system prompt is already the unified
     # reviewer+tools prompt (set above, #263) — no swap, so the cached prefix
     # survives. We re-inject the full corpus the loop never saw (it ran on the
-    # compact planning context), drop tools, and force a strict-JSON verdict. The
+    # compact planning context), keep tools for cache-prefix reuse (#263 Part 3),
+    # and force a strict-JSON verdict via response_format. The
     # response is written where the standard review call writes it; run_review.sh
     # consumes it and skips that call. If the verdict is degraded/oversized/
     # garbled it simply fails to parse downstream and run_review.sh falls back to
@@ -1425,6 +1426,7 @@ def run_native_loop(
                     response_format=response_format,
                     tokens_param=tokens_param,
                     cache_prefix=True,
+                    keep_tools_on_verdict=True,
                 )
                 verdict_response = post_fn(verdict_payload)
                 Path("ai-response.primary.json").write_text(

--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -516,6 +516,72 @@ class TestOpenAIPayload:
         assert any(m["role"] == "tool" for m in payload["messages"])
         assert payload["response_format"] == {"type": "json_object"}
 
+    def test_verdict_turn_keep_tools_on_verdict(self):
+        """#263 Part 3: keep tools on the verdict turn for cache-prefix reuse."""
+        c = Conversation(system="reviewer")
+        c.add_user("review me")
+        c.add_assistant_tool_calls(
+            [{"id": "call_1", "name": "read_file", "arguments": "{}"}]
+        )
+        c.add_tool_result("call_1", "ok")
+
+        payload = c.to_request_payload(
+            "openai",
+            "gpt-4o",
+            verdict_turn=True,
+            response_format="json_schema",
+            keep_full_history_on_verdict=True,
+            keep_tools_on_verdict=True,
+        )
+        # Tools are retained on the verdict turn.
+        assert "tools" in payload
+        assert len(payload["tools"]) == len(c.tool_schemas)
+        # response_format still present (JSON enforcement).
+        assert payload["response_format"]["type"] == "json_schema"
+        # History preserved.
+        assert any(m["role"] == "tool" for m in payload["messages"])
+
+    def test_verdict_turn_keep_tools_on_verdict_anthropic(self):
+        """#263 Part 3: Anthropic verdict turn with tools retained."""
+        c = Conversation(system="reviewer")
+        c.add_user("review me")
+        c.add_assistant_tool_calls(
+            [{"id": "call_1", "name": "read_file", "arguments": "{}"}]
+        )
+        c.add_tool_result("call_1", "ok")
+
+        payload = c.to_request_payload(
+            "anthropic",
+            "claude-3-5-sonnet",
+            verdict_turn=True,
+            keep_full_history_on_verdict=True,
+            keep_tools_on_verdict=True,
+            cache_prefix=True,
+        )
+        # Tools retained on Anthropic verdict turn.
+        assert "tools" in payload
+        # cache_control markers present on system and last tool.
+        if isinstance(payload["system"], list):
+            assert any(
+                b.get("cache_control", {}).get("type") == "ephemeral"
+                for b in payload["system"]
+            )
+
+    def test_verdict_turn_drops_tools_by_default(self):
+        """Default: tools dropped on verdict turn even with keep_full_history."""
+        c = Conversation(system="reviewer")
+        c.add_user("review me")
+
+        payload = c.to_request_payload(
+            "openai",
+            "gpt-4o",
+            verdict_turn=True,
+            response_format="json_schema",
+            keep_full_history_on_verdict=True,
+        )
+        # Default: tools dropped.
+        assert "tools" not in payload
+
     def test_no_system_prompt_omits_system_message(self):
         c = Conversation()
         c.add_user("hi")

--- a/tests/test_run_native_loop_wiring.py
+++ b/tests/test_run_native_loop_wiring.py
@@ -450,10 +450,11 @@ def test_native_loop_emits_in_conversation_verdict(monkeypatch, tmp_path):
     resp = json.loads((tmp_path / "ai-response.primary.json").read_text())
     assert "approve" in resp["choices"][0]["message"]["content"]
 
-    # The verdict turn (final call) dropped tools, forced strict JSON, and
-    # re-injected the full corpus the loop never saw on a closing user turn.
+    # The verdict turn (final call) keeps tools for cache-prefix reuse (#263 Part 3),
+    # forces strict JSON via response_format, and re-injects the full corpus
+    # the loop never saw on a closing user turn.
     verdict_payload = payloads[-1]
-    assert "tools" not in verdict_payload
+    assert "tools" in verdict_payload
     assert verdict_payload.get("response_format", {}).get("type") == "json_object"
     user_text = "\n".join(
         m.get("content") or "" for m in verdict_payload["messages"] if m["role"] == "user"


### PR DESCRIPTION
Fixes #263

## Summary

Part 3 of #263: keep `tools` present on the verdict turn so the cached prefix survives. Tool schemas render near the top of the prompt; dropping them invalidates the cache from that point onward.

## Changes

- **`conversation.py`**: Add `keep_tools_on_verdict: bool = False` parameter to `to_request_payload()`, `_to_openai_payload()`, and `_to_anthropic_payload()`. When True, tools are retained alongside `response_format` on the verdict turn.

- **`run_tool_harness.py`**: Enable `keep_tools_on_verdict=True` for the in-conversation verdict turn. The stable system prompt (Part 1) + tools (Part 3) means the full cached prefix survives across loop and verdict turns.

- **Tests**: 3 new unit tests (OpenAI, Anthropic, default behavior) + updated wiring test to expect tools on the verdict turn.

## Backend Compatibility

Most OpenAI-compatible backends support both `tools` + `response_format`. Some reject them together — when that happens, set `keep_tools_on_verdict=False` (the default). The primary deployment target (llama.cpp) supports this combination.

## Cache Impact

With Parts 1 + 2 + 3 all implemented:
- **System prompt**: stable across loop and verdict (no swap at token 0)
- **Tools**: present on every turn (prefix preserved)  
- **Anthropic**: `cache_control` markers on system + tools blocks

The verdict turn (the largest prefill) now reuses the cached prefix from loop turns instead of re-running from scratch.