### PR TITLE
Add Forgejo compare support for precheck

### DIFF
--- a/pr_reviewer/forgejo_backend.py
+++ b/pr_reviewer/forgejo_backend.py
@@ -28,6 +28,7 @@ import re
 import subprocess
 import sys
 from typing import Any
+from urllib.parse import quote
 
 
 # ---------------------------------------------------------------------------
@@ -457,6 +458,35 @@ def fetch_issue(repo_full_name: str, issue_number: int) -> dict[str, Any] | None
     }
 
 
+def compare_commits(repo_full_name: str, spec: str) -> dict[str, Any] | None:
+    """Return compare metadata for ``base...head``.
+
+    Forgejo/Gitea expose the compare endpoint at
+    ``/repos/{owner}/{repo}/compare/{base}...{head}``. Callers use failure as
+    a fail-closed signal for incremental review scope, so return ``None`` on
+    any non-200 response or malformed payload rather than fabricating data.
+    """
+    owner, repo = _parse_repo(repo_full_name)
+
+    if _is_forgejo_mode():
+        status_code, body_text = _curl(
+            "GET",
+            f"{FORGEJO_API_URL}/api/v1/repos/{owner}/{repo}/compare/{quote(spec, safe='')}",
+        )
+        if status_code != 200:
+            return None
+        data = _json_decode(body_text)
+        if not isinstance(data, dict):
+            return None
+        return data
+
+    status_code, body_text = _gh("api", f"repos/{owner}/{repo}/compare/{spec}")
+    if status_code != 0 or not body_text.strip():
+        return None
+    data = _json_decode(body_text)
+    return data if isinstance(data, dict) else None
+
+
 # ---------------------------------------------------------------------------
 # PR Files (for classifier)
 # ---------------------------------------------------------------------------
@@ -627,6 +657,10 @@ def main() -> None:
     p_status.add_argument("repo")
     p_status.add_argument("sha")
 
+    p_compare = sub.add_parser("compare")
+    p_compare.add_argument("repo")
+    p_compare.add_argument("spec")
+
     args = parser.parse_args()
 
     if args.command == "get-pr-metadata":
@@ -650,6 +684,12 @@ def main() -> None:
     elif args.command == "commit-status":
         result = get_commit_status(args.repo, args.sha)
         print(json.dumps(result, indent=2) if result else "null")
+    elif args.command == "compare":
+        result = compare_commits(args.repo, args.spec)
+        if result is None:
+            print("null")
+            sys.exit(1)
+        print(json.dumps(result, indent=2))
     else:
         parser.print_help()
         sys.exit(1)

--- a/scripts/platform_api.sh
+++ b/scripts/platform_api.sh
@@ -155,7 +155,7 @@ platform_compare() {
   # $1=repo $2=base...head spec [extra gh api flags, e.g. --jq] → compare
   # object (or the --jq projection) on stdout
   if _platform_is_forgejo; then
-    _forgejo_unimplemented "compare"   # lands with #223 (incremental scope)
+    _forgejo_py compare "$1" "$2"
   else
     local repo="$1" spec="$2"
     shift 2

--- a/tests/test_forgejo_backend.py
+++ b/tests/test_forgejo_backend.py
@@ -446,6 +446,49 @@ class TestFetchIssue(unittest.TestCase):
         self.assertIsNone(result)
 
 
+class TestCompareCommits(unittest.TestCase):
+    """Forgejo compare support backs fail-closed incremental scope checks."""
+
+    _COMPARE = {
+        "html_url": "https://forgejo.example.com/misospace/pr-reviewer-action/compare/abc...def",
+        "total_commits": 1,
+        "commits": [{"sha": "def"}],
+        "files": [{"filename": "README.md"}],
+    }
+
+    @_PATCH_FORGEJO
+    def test_forgejo_compare_uses_api_endpoint(self, mock_curl):
+        url_map = {
+            f"{FORGEJO_BASE}/api/v1/repos/misospace/pr-reviewer-action/compare/abc...def": (200, json.dumps(self._COMPARE)),
+        }
+        mock_curl.side_effect = _make_curl_mock(url_map)
+
+        with _forgejo_env_patch():
+            result = fb.compare_commits("misospace/pr-reviewer-action", "abc...def")
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result["total_commits"], 1)
+        mock_curl.assert_called_once()
+        self.assertIn("/compare/abc...def", mock_curl.call_args[0][1])
+
+    @_PATCH_FORGEJO
+    def test_forgejo_compare_failure_returns_none(self, mock_curl):
+        mock_curl.side_effect = _make_curl_mock({})
+
+        with _forgejo_env_patch():
+            result = fb.compare_commits("misospace/pr-reviewer-action", "missing...head")
+
+        self.assertIsNone(result)
+
+    def test_github_compare_uses_gh_api(self):
+        with patch.object(fb, "FORGEJO_API_URL", ""), \
+             patch.object(fb, "_gh", return_value=(0, json.dumps(self._COMPARE))) as mock_gh:
+            result = fb.compare_commits("misospace/pr-reviewer-action", "abc...def")
+
+        mock_gh.assert_called_once_with("api", "repos/misospace/pr-reviewer-action/compare/abc...def")
+        self.assertEqual(result["commits"][0]["sha"], "def")
+
+
 class TestListPrFiles(unittest.TestCase):
     """Test list_pr_files with Forgejo fixtures."""
 

--- a/tests/test_platform_api.sh
+++ b/tests/test_platform_api.sh
@@ -129,6 +129,8 @@ check "forgejo without FORGEJO_API_URL fails loudly" \
 RESULT="$(run_seam forgejo "" 'platform_graphql -f query=Q')"
 check "unimplemented forgejo op names itself" \
   "$(echo "$RESULT" | grep -c "not yet implemented")" "1"
+RESULT="$(run_seam forgejo "" '_forgejo_py(){ echo "forgejo $*"; }; platform_compare o/r aaa...bbb' "https://forgejo.example.com")"
+check "forgejo compare uses backend cli" "$RESULT" "forgejo compare o/r aaa...bbb"
 RESULT="$(run_seam forgejo "" 'platform_check_runs o/r abc')"
 check "forgejo check_runs returns empty structure (exit 0)" \
   "$( (export PLATFORM=forgejo; unset _PLATFORM_API_SOURCED; source "$SEAM"; platform_check_runs o/r abc >/dev/null 2>&1 && echo 0 || echo 1) )" "0"


### PR DESCRIPTION
$Fixes #223\n\n## Summary\n- add Forgejo/Gitea compare endpoint support to the backend CLI\n- route platform_compare through the Forgejo backend instead of failing unimplemented\n- cover Forgejo/GitHub compare behavior and platform seam wiring in tests\n\n## Tests\n- python3 -m unittest tests.test_forgejo_backend\n- bash tests/test_platform_api.sh