### PR TITLE
fix(precheck): make the label no-op run distinguishable from the real review

### DIFF
--- a/scripts/check_review_needed.sh
+++ b/scripts/check_review_needed.sh
@@ -33,7 +33,8 @@ if [[ "${GITHUB_EVENT_NAME:-}" == "pull_request" && -f "${GITHUB_EVENT_PATH:-}" 
     if [[ "$added_label" == "$REREVIEW_LABEL" ]]; then
       FORCE_REVIEW=true
     else
-      echo "Label '$added_label' is not the re-review label ('$REREVIEW_LABEL') — skipping" >&2
+      echo "Label '$added_label' is not the re-review trigger ('$REREVIEW_LABEL') — reviews run on open/push, not on label adds; this run is a no-op." >&2
+      echo "::notice title=AI review: label no-op::Triggered by adding the '$added_label' label, not a code change. The PR is reviewed automatically on open/push; add the '$REREVIEW_LABEL' label only to force a re-review."
       {
         echo "should_review=false"
         echo "skip_reason=unrelated-label"


### PR DESCRIPTION
## Problem

When a non-`ai-review` label is added to a PR (e.g. `area/renovate` applied by a labeler bot), the `labeled` event spawns a workflow run that correctly short-circuits in `check_review_needed.sh` — the action only treats the `ai-review` label as a re-review trigger.

But two things make this a recurring false alarm:
1. The old log line — *"Label 'X' is not the re-review label ('ai-review') — skipping"* — reads like the **PR** is being skipped, not just this run.
2. In the Actions UI the no-op run is **indistinguishable** from the real review: same workflow name, same PR title, both report `success` (a clean skip exits 0).

Net effect: on a net-new renovate PR, the `opened`-event review runs silently for ~2 min (longer if it escalates to the smart tier), while the `area/renovate` no-op run prints "skipping" within seconds — so a maintainer concludes the PR went unreviewed and force-adds `ai-review`, producing a redundant duplicate review. (Observed live on joryirving/containers#729: the `opened` run approved at 22:44:57; a hand-added `ai-review` produced a second approval at 22:45:45.)

## Change

No behavior change. In the unrelated-label short-circuit:
- Reword the log to state plainly that **reviews run on open/push, not on label adds, and this run is a no-op**.
- Emit a `::notice::` annotation so the no-op surfaces in the run summary — making it visually distinct from the real review without opening the step.

`skip_reason=unrelated-label` output and the short-circuit logic are unchanged.

## Tests

Full sweep green: 21 shell suites (incl. `test_check_review_needed.sh`, which pins `skip_reason=unrelated-label` — unaffected) + 913 pytest @ py3.14 + smoke. No assertion pinned the log message text.
