### PR TITLE
Add Forgejo E2E smoke harness

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,13 +56,16 @@ jobs:
           done
 
       - name: Check Python scripts
-        run: python3 -m py_compile scripts/image_digest_analysis.py scripts/run_evidence_providers.py scripts/run_tool_harness.py tests/mock_openai_server.py tests/test_model_parsing.py tests/test_redact.py tests/test_strip_metadata_markers.py tests/test_evidence_providers.py
+        run: python3 -m py_compile scripts/image_digest_analysis.py scripts/run_evidence_providers.py scripts/run_tool_harness.py tests/mock_openai_server.py tests/test_model_parsing.py tests/test_redact.py tests/test_strip_metadata_markers.py tests/test_evidence_providers.py pr_reviewer/forgejo_backend.py
 
       - name: Verify smoke test helper is executable
         run: test -x tests/smoke_test.sh
 
       - name: Run smoke test
         run: tests/smoke_test.sh
+
+      - name: Verify Forgejo E2E smoke harness parses
+        run: bash -n tests/forgejo_e2e_smoke.sh
 
       - name: Run Python tests (auto-discover all 215)
         run: pytest tests/ -v --tb=short

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ The action works on **GitHub** and **Forgejo** (1.4.x). Set `platform: auto` (de
 | Cleanup: minimizeComment (hide outdated) | ✅ Full | ❌ Skipped (no GraphQL) |
 | Thread resolution (`resolveReviewThread`) | ✅ Full | ❌ Skipped (no GraphQL) |
 | Thread follow-up replies (`in_reply_to`) | ✅ Full | ❌ Skipped — suppression-file dedup only |
-| CI status check polling | ✅ Full | ⚠️ Partial — uses Checks API if available |
+| CI status check polling | ✅ Full | ✅ Commit-status polling (Forgejo REST) |
 | Evidence providers | ✅ Full | ✅ Full |
 | Tool harness | ✅ Full | ✅ Full |
 | Incremental reviews + carry-forward | ✅ Full | ✅ Full |
@@ -363,6 +363,8 @@ Only three inputs are required: `github_token`, `ai_base_url`, and `ai_model`. E
 |-------|-------------|----------|---------|
 | `review_scope` | Controls whether the action reviews the full PR or only changes since the last managed review. Accepted values: `auto` (default, full on first run, incremental on later safe updates), `full` (always full review), `incremental` (delta review, falls back to full if prior metadata unavailable) | No | `auto` |
 | `platform` | Target hosting platform for API capability gating and backend selection. `auto` (default) detects from `GITHUB_SERVER_URL` and `FORGEJO_API_URL`: non-github.com hosts or `FORGEJO_API_URL` set resolves to `forgejo`; otherwise `github`. Set `forgejo` or `github` explicitly to override auto-detection. On Forgejo, features requiring GitHub GraphQL (thread resolution, review minimization) degrade gracefully with a log line; the REST backend handles core PR operations. Linked-source enrichment always targets github.com. | No | `auto` |
+| `forgejo_api_url` | Base URL for the Forgejo REST backend. Optional on Forgejo Actions runners when `github.server_url` is the Forgejo instance; set it when running from another host or when `GITHUB_SERVER_URL` is unavailable. | No | `""` |
+| `forgejo_token` | Optional Forgejo API token. Defaults to `github_token` when blank; set it when the token used for GitHub-compatible operations is not valid for the Forgejo REST API. | No | `""` |
 | `skip_if_diff_unchanged` | Skip the LLM review when the current PR patch matches the last managed review fingerprint | No | `true` |
 | `force_review` | Bypass the diff-unchanged guard and review even when the fingerprint matches. Set automatically by the `rereview_label`; also drivable from `workflow_dispatch`/`repository_dispatch`. When the last managed review was not clean, a forced re-review runs at **full** scope to re-establish a clean baseline (recovers a PR wedged in *Request changes*) | No | `false` |
 | `rereview_label` | Label that, when added to a PR, forces a fresh review (add `labeled` to the workflow's `pull_request` types to enable). Self-authorizing — only write/triage can label. The label is removed after, so re-adding re-triggers | No | `ai-review` |

--- a/action.yml
+++ b/action.yml
@@ -488,6 +488,21 @@ inputs:
       always targets github.com regardless of this setting.
     required: false
     default: "auto"
+  forgejo_api_url:
+    description: >-
+      Base URL for the Forgejo instance API backend (for example,
+      https://forgejo.example.com). Optional on Forgejo Actions runners when
+      GITHUB_SERVER_URL is set; set it when running from GitHub Actions or any
+      runner that does not export the Forgejo server URL.
+    required: false
+    default: ""
+  forgejo_token:
+    description: >-
+      Optional Forgejo API token. Defaults to github_token when blank. Use this
+      when the token used for GitHub-compatible operations is not also valid for
+      the Forgejo REST API.
+    required: false
+    default: ""
   skip_if_diff_unchanged:
     description: If true, skip the LLM review when the effective PR diff matches the last managed review comment fingerprint
     required: false
@@ -605,6 +620,8 @@ runs:
       env:
         GH_TOKEN: ${{ inputs.github_token }}
         PLATFORM: ${{ inputs.platform }}
+        FORGEJO_API_URL: ${{ inputs.forgejo_api_url || (github.server_url != 'https://github.com' && github.server_url) || '' }}
+        FORGEJO_TOKEN: ${{ inputs.forgejo_token || inputs.github_token }}
         REPO: ${{ inputs.repo || github.repository }}
         PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
         COMMENT_MARKER: ${{ inputs.comment_marker }}
@@ -676,6 +693,8 @@ runs:
       env:
         GH_TOKEN: ${{ inputs.github_token }}
         PLATFORM: ${{ inputs.platform }}
+        FORGEJO_API_URL: ${{ inputs.forgejo_api_url || (github.server_url != 'https://github.com' && github.server_url) || '' }}
+        FORGEJO_TOKEN: ${{ inputs.forgejo_token || inputs.github_token }}
         REPO: ${{ inputs.repo || github.repository }}
         PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
         PR_HEAD_SHA: ${{ github.event.pull_request.head.sha || steps.precheck.outputs.head_sha }}
@@ -693,6 +712,8 @@ runs:
       env:
         GH_TOKEN: ${{ inputs.github_token }}
         PLATFORM: ${{ inputs.platform }}
+        FORGEJO_API_URL: ${{ inputs.forgejo_api_url || (github.server_url != 'https://github.com' && github.server_url) || '' }}
+        FORGEJO_TOKEN: ${{ inputs.forgejo_token || inputs.github_token }}
         REPO: ${{ inputs.repo || github.repository }}
         PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
         AI_BASE_URL: ${{ inputs.ai_base_url }}
@@ -791,6 +812,8 @@ runs:
       env:
         GH_TOKEN: ${{ inputs.github_token }}
         PLATFORM: ${{ inputs.platform }}
+        FORGEJO_API_URL: ${{ inputs.forgejo_api_url || (github.server_url != 'https://github.com' && github.server_url) || '' }}
+        FORGEJO_TOKEN: ${{ inputs.forgejo_token || inputs.github_token }}
         REPO: ${{ inputs.repo || github.repository }}
         PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
         HEAD_SHA: ${{ github.event.pull_request.head.sha || steps.precheck.outputs.head_sha }}
@@ -859,6 +882,8 @@ runs:
       env:
         GH_TOKEN: ${{ inputs.github_token }}
         PLATFORM: ${{ inputs.platform }}
+        FORGEJO_API_URL: ${{ inputs.forgejo_api_url || (github.server_url != 'https://github.com' && github.server_url) || '' }}
+        FORGEJO_TOKEN: ${{ inputs.forgejo_token || inputs.github_token }}
         REPO: ${{ inputs.repo || github.repository }}
         PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
         HEAD_SHA: ${{ github.event.pull_request.head.sha || steps.precheck.outputs.head_sha }}
@@ -969,6 +994,8 @@ runs:
       env:
         GH_TOKEN: ${{ inputs.github_token }}
         PLATFORM: ${{ inputs.platform }}
+        FORGEJO_API_URL: ${{ inputs.forgejo_api_url || (github.server_url != 'https://github.com' && github.server_url) || '' }}
+        FORGEJO_TOKEN: ${{ inputs.forgejo_token || inputs.github_token }}
         REPO: ${{ inputs.repo || github.repository }}
         PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
         HEAD_SHA: ${{ github.event.pull_request.head.sha || steps.precheck.outputs.head_sha }}
@@ -1149,6 +1176,9 @@ runs:
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.github_token }}
+        PLATFORM: ${{ inputs.platform }}
+        FORGEJO_API_URL: ${{ inputs.forgejo_api_url || (github.server_url != 'https://github.com' && github.server_url) || '' }}
+        FORGEJO_TOKEN: ${{ inputs.forgejo_token || inputs.github_token }}
         REPO: ${{ inputs.repo || github.repository }}
         PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
         LABEL: ${{ inputs.rereview_label }}

--- a/pr_reviewer/forgejo_backend.py
+++ b/pr_reviewer/forgejo_backend.py
@@ -36,7 +36,12 @@ from urllib.parse import quote
 # ---------------------------------------------------------------------------
 
 FORGEJO_API_URL = os.environ.get("FORGEJO_API_URL", "").rstrip("/")
-FORGEJO_TOKEN = os.environ.get("FORGEJO_TOKEN", os.environ.get("GITHUB_TOKEN", ""))
+FORGEJO_TOKEN = (
+    os.environ.get("FORGEJO_TOKEN")
+    or os.environ.get("GITHUB_TOKEN")
+    or os.environ.get("GH_TOKEN")
+    or ""
+)
 COMMENT_MARKER = os.environ.get(
     "COMMENT_MARKER", "<!-- ai-pr-reviewer -->"
 )

--- a/tests/forgejo_e2e_smoke.sh
+++ b/tests/forgejo_e2e_smoke.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# End-to-end Forgejo smoke harness for the platform backend. It is opt-in
+# because it starts a disposable Forgejo container and needs Docker.
+# It exercises the real Forgejo REST seam that the composite action uses:
+# precheck PR metadata/diff, CI commit-status polling, and sticky comments.
+if [[ "${FORGEJO_E2E:-}" != "true" ]]; then
+  echo "SKIP: set FORGEJO_E2E=true to run the Docker-backed Forgejo smoke test"
+  exit 0
+fi
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+IMAGE="${FORGEJO_E2E_IMAGE:-codeberg.org/forgejo/forgejo:1.21}"
+NAME="pr-reviewer-forgejo-e2e-$$"
+HTTP_PORT="${FORGEJO_E2E_PORT:-31080}"
+PASSWORD="forgejo-e2e-pass"
+TOKEN_NAME="pr-reviewer-e2e"
+TMPDIR="$(mktemp -d)"
+
+cleanup() {
+  docker rm -f "$NAME" >/dev/null 2>&1 || true
+  rm -rf "$TMPDIR"
+}
+trap cleanup EXIT
+
+wait_http() {
+  local url="$1"
+  for _ in {1..90}; do
+    if curl -fsS "$url" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+  done
+  echo "Forgejo did not become ready at $url" >&2
+  return 1
+}
+
+api() {
+  curl -fsS -H "Authorization: token $FORGEJO_TOKEN" "$@"
+}
+
+api_json() {
+  local method="$1" url="$2" body="$3"
+  curl -fsS -X "$method" \
+    -H "Authorization: token $FORGEJO_TOKEN" \
+    -H "Content-Type: application/json" \
+    -d "$body" \
+    "$url"
+}
+
+container_forgejo() {
+  docker exec -u git "$NAME" forgejo \
+    --config /data/gitea/conf/app.ini \
+    --work-path /data/gitea "$@"
+}
+
+docker run -d --name "$NAME" \
+  -p "${HTTP_PORT}:3000" \
+  -e USER_UID=1000 \
+  -e USER_GID=1000 \
+  -e FORGEJO__security__INSTALL_LOCK=true \
+  -e FORGEJO__server__ROOT_URL="http://127.0.0.1:${HTTP_PORT}/" \
+  -e FORGEJO__service__DISABLE_REGISTRATION=true \
+  -e FORGEJO__repository__DEFAULT_BRANCH=main \
+  -e FORGEJO__actions__ENABLED=false \
+  "$IMAGE" >/dev/null
+
+wait_http "http://127.0.0.1:${HTTP_PORT}/api/healthz"
+
+container_forgejo admin user create \
+  --username reviewer \
+  --password "$PASSWORD" \
+  --email reviewer@example.test \
+  --admin \
+  --must-change-password=false >/dev/null
+
+TOKEN_JSON="$(curl -fsS \
+  -u "reviewer:${PASSWORD}" \
+  -H 'Content-Type: application/json' \
+  -d "{\"name\":\"${TOKEN_NAME}\",\"scopes\":[\"write:repository\",\"write:issue\",\"read:user\"]}" \
+  "http://127.0.0.1:${HTTP_PORT}/api/v1/users/reviewer/tokens")"
+FORGEJO_TOKEN="$(printf '%s' "$TOKEN_JSON" | jq -r '.sha1')"
+export PLATFORM=forgejo
+export FORGEJO_API_URL="http://127.0.0.1:${HTTP_PORT}"
+export FORGEJO_TOKEN
+export GH_TOKEN="$FORGEJO_TOKEN"
+export PYTHONPATH="$ROOT_DIR"
+
+api_json POST "$FORGEJO_API_URL/api/v1/user/repos" \
+  '{"name":"sample","auto_init":true,"default_branch":"main"}' >/dev/null
+
+cat > "$TMPDIR/commit.json" <<'JSON'
+{
+  "branch": "main",
+  "message": "add fixture",
+  "content": "b25lCg=="
+}
+JSON
+api_json POST "$FORGEJO_API_URL/api/v1/repos/reviewer/sample/contents/fixture.txt" \
+  "$(cat "$TMPDIR/commit.json")" >/dev/null
+
+api_json POST "$FORGEJO_API_URL/api/v1/repos/reviewer/sample/branches" \
+  '{"old_branch_name":"main","new_branch_name":"feature"}' >/dev/null
+
+SHA="$(api "$FORGEJO_API_URL/api/v1/repos/reviewer/sample/contents/fixture.txt?ref=feature" | jq -r '.sha')"
+cat > "$TMPDIR/update.json" <<JSON
+{
+  "branch": "feature",
+  "message": "update fixture",
+  "content": "dHdvCg==",
+  "sha": "$SHA"
+}
+JSON
+api_json PUT "$FORGEJO_API_URL/api/v1/repos/reviewer/sample/contents/fixture.txt" \
+  "$(cat "$TMPDIR/update.json")" >/dev/null
+
+PR_JSON="$(api_json POST "$FORGEJO_API_URL/api/v1/repos/reviewer/sample/pulls" \
+  '{"base":"main","head":"feature","title":"Update fixture","body":"E2E smoke PR"}')"
+PR_NUMBER="$(printf '%s' "$PR_JSON" | jq -r '.number')"
+HEAD_SHA="$(printf '%s' "$PR_JSON" | jq -r '.head.sha')"
+
+api_json POST "$FORGEJO_API_URL/api/v1/repos/reviewer/sample/statuses/${HEAD_SHA}" \
+  '{"state":"success","context":"build","description":"E2E build passed"}' >/dev/null
+
+WORK="$TMPDIR/work"
+git clone -q "$FORGEJO_API_URL/reviewer/sample.git" "$WORK"
+(
+  cd "$WORK"
+  git fetch -q origin pull/${PR_NUMBER}/head:pr-${PR_NUMBER}
+  git checkout -q "pr-${PR_NUMBER}"
+
+  export REPO=reviewer/sample
+  export PR_NUMBER
+  export COMMENT_MARKER='<!-- ai-pr-reviewer -->'
+  export GITHUB_OUTPUT="$TMPDIR/precheck.out"
+  export REVIEW_SCOPE=auto
+  export SKIP_IF_DIFF_UNCHANGED=true
+  export FORCE_REVIEW=false
+  export PUBLISH_MODE=comment
+  bash "$ROOT_DIR/scripts/check_review_needed.sh"
+
+  grep -q '^should_review=true$' "$TMPDIR/precheck.out"
+  jq -e '.head.sha == env.HEAD_SHA and .base.ref == "main"' pr-object.json >/dev/null
+
+  export PR_HEAD_SHA="$HEAD_SHA"
+  export GITHUB_OUTPUT="$TMPDIR/ci.out"
+  export CI_STATUS_CHECK=true
+  export CI_TIMEOUT_SEC=6
+  export CI_INTERVAL_SEC=1
+  export CI_CHECKS_FILE="$TMPDIR/ci-checks.md"
+  bash "$ROOT_DIR/scripts/wait_for_ci.sh"
+  grep -q '^ci_status_final=success$' "$TMPDIR/ci.out"
+
+  source "$ROOT_DIR/scripts/platform_api.sh"
+  printf '%s\n' "$COMMENT_MARKER" "Forgejo E2E sticky comment" > "$TMPDIR/comment.md"
+  platform_comment_sticky "$REPO" "$PR_NUMBER" "$TMPDIR/comment.md"
+  platform_issue_comments "$REPO" "$PR_NUMBER" | jq -e '.[] | select(.body | contains("Forgejo E2E sticky comment"))' >/dev/null
+)
+
+echo "PASS: Forgejo backend E2E smoke completed against $IMAGE"

--- a/tests/test_platform_api.sh
+++ b/tests/test_platform_api.sh
@@ -121,6 +121,13 @@ check "github_enrich_api passthrough" \
   "$(run_seam github "" 'github_enrich_api repos/up/stream/releases?per_page=8')" \
   "gh api repos/up/stream/releases?per_page=8"
 
+check "forgejo backend falls back from GITHUB_TOKEN to GH_TOKEN" \
+  "$(FORGEJO_API_URL= GITHUB_TOKEN= GH_TOKEN=from-gh python3 - <<'PYEOF'
+import pr_reviewer.forgejo_backend as fb
+print(fb.FORGEJO_TOKEN)
+PYEOF
+)" "from-gh"
+
 echo ""
 echo "=== forgejo mode: loud failures, no silent fallthrough ==="
 RESULT="$(run_seam forgejo "" 'platform_pr_get o/r 7')"


### PR DESCRIPTION
Fixes #228\n\n## Summary\n- Add an opt-in Docker-backed Forgejo smoke harness covering the real platform seam for precheck metadata/diff, CI commit-status polling, and sticky comments.\n- Wire CI to syntax-check the harness and py_compile the Forgejo backend.\n- Add explicit Forgejo API URL/token inputs and pass them through composite steps, with GH_TOKEN fallback in the backend for local/tool parity.\n- Update README Forgejo support notes for commit-status polling and the new inputs.\n\n## Tests\n- python3 - <<'PY' (yaml.safe_load action.yml and .github/workflows/ci.yaml)\n- bash -n tests/forgejo_e2e_smoke.sh\n- python3 -m py_compile pr_reviewer/forgejo_backend.py\n- bash tests/test_platform_api.sh\n- python3 -m pytest tests/test_forgejo_backend.py tests/test_platform.py -q\n\n## Not run\n- FORGEJO_E2E=true tests/forgejo_e2e_smoke.sh (blocked locally: Docker daemon unavailable at /var/run/docker.sock)