### PR TITLE
feat(tool-harness): route gh_api through the platform seam (#226)

### DIFF
--- a/pr_reviewer/platform.py
+++ b/pr_reviewer/platform.py
@@ -258,9 +258,14 @@ def _forgejo_translate(full_path, repo_key):
     if rest == "/releases/tags" or rest.startswith("/releases/tags/"):
         return f"/api/v1/repos/{repo_key}{rest}"
 
-    # Commit status (read-only; used by the CI-required check).
+    # Commits + commit status (read-only; the status form feeds the
+    # CI-required check). Forgejo mirrors the GitHub paths under /api/v1, so
+    # pass the validated path through verbatim — do NOT fabricate a /status
+    # suffix, which would silently turn "get commit <sha>" into a status
+    # lookup. An endpoint shape Forgejo doesn't implement returns a 404 the
+    # caller surfaces, rather than wrong data.
     if rest == "/commits" or rest.startswith("/commits/"):
-        return f"/api/v1/repos/{repo_key}{rest}/status" if not rest.endswith("/status") else f"/api/v1/repos/{repo_key}{rest}"
+        return f"/api/v1/repos/{repo_key}{rest}"
 
     return None
 
@@ -296,6 +301,10 @@ def _gh_api_forgejo(full_path, repo_key, request_timeout):
             "curl", "-sS",
             "-H", f"Authorization: token {token}",
             "-H", "Accept: application/json",
+            # Match the GitHub backend's UA: a default curl/* User-Agent is
+            # blocked by Cloudflare's bot-fight mode, which fronts the typical
+            # self-hosted Forgejo instance.
+            "-H", "User-Agent: ai-pr-reviewer/1.0",
             "-w", "\n%{http_code}",
             url,
         ]

--- a/pr_reviewer/platform.py
+++ b/pr_reviewer/platform.py
@@ -9,11 +9,67 @@ line, and until then unsupported operations raise instead of failing silently.
 
 from __future__ import annotations
 
+import json
 import os
+import re
+import subprocess
+import urllib.error
+import urllib.request
 
 
 class PlatformUnsupported(RuntimeError):
     """Raised when an operation has no implementation for the active platform."""
+
+
+# ---------------------------------------------------------------------------
+# gh_api tool (issue #226) — host-platform endpoint normalization + fetch.
+# ---------------------------------------------------------------------------
+#
+# The tool harness exposes a ``gh_api`` tool that lets the model request
+# read-only REST calls against the repository under review. The pre-seam
+# implementation hard-coded ``https://api.github.com``; this module is the
+# platform-aware replacement, called by ``run_tool_harness.gh_api``.
+#
+# Security boundary
+# ----------------
+# ``gh_api`` is a **prompt-injection boundary**: the model chooses the
+# endpoint, and the endpoint is then used to issue a network request with an
+# operator-supplied token. Adversarial PR content can try to smuggle
+# path-traversal segments, denied endpoints (secrets/environments/dispatches),
+# or — on the platform seam — a different host than the active one. The
+# checks below are the single defence; loosening any of them is a real
+# security regression, not a refactor.
+#
+# The same allowlist applies on both backends:
+#
+#   * safe character set (RFC 3986 unreserved + the path/query subset we use)
+#   * reject empty / ``.`` / ``..`` segments
+#   * repo key (the ``owner/repo`` extracted from the endpoint) must be
+#     ``current_repo`` or in ``allowed_repos`` (or ``*`` for wildcard)
+#   * full path prefix must be in ``GH_API_ALLOWED_PREFIXES`` (read-only,
+#     non-sensitive endpoints only)
+#   * deny substrings (``/actions/secrets``, ``/environments/``,
+#     ``/dispatches``) are rejected regardless of repo
+
+# Path characters that appear in our valid endpoints. We deliberately do NOT
+# include ``?`` / ``&`` / ``=`` in the *path* set even though they are common
+# in queries, because the model passes the endpoint as a single string and a
+# query-confusion is exactly the kind of thing a red-team PR would probe.
+# A search endpoint like ``search/code?q=foo`` is whitelisted verbatim.
+GH_SAFE_PATH_RE = re.compile(r"^[A-Za-z0-9._~/%?&=:+,-]+$")
+GH_DENY_SUBSTRINGS = (
+    "/actions/secrets",
+    "/dependabot/secrets",
+    "/environments/",
+    "/dispatches",
+)
+GH_API_ALLOWED_PREFIXES = (
+    "/repos/",
+    "/issues/",
+    "/search/",
+    "/releases/",
+    "/git/",
+)
 
 
 def resolve_platform() -> str:
@@ -51,3 +107,233 @@ def gh_argv(args: list) -> list:
             "this consumer's Forgejo backend lands later in the 1.4.x line"
         )
     return ["gh", *args]
+
+
+# ---------------------------------------------------------------------------
+# gh_api backend split (issue #226)
+# ---------------------------------------------------------------------------
+#
+# The original ``gh_api`` lived entirely in ``run_tool_harness.py`` and only
+# knew about ``https://api.github.com``. We split that out so the same
+# validation runs on both backends — drift in the allowlist between GitHub
+# and Forgejo is exactly the kind of "tiny mechanical mapping" mistake
+# that becomes a CVE. Adding a new endpoint to the tool surface requires
+# updating *both* ``GH_API_ALLOWED_PREFIXES`` here and the per-backend
+# URL translation below; the test suite enforces the parity.
+
+def _validate_endpoint(endpoint, allowed_repos, current_repo):
+    """Run the cross-backend security checks against a tool-supplied endpoint.
+
+    Returns ``(full_path, repo_key)`` on success, or ``{"error": ...}``. The
+    caller is responsible for picking the host and issuing the request —
+    this function makes the security decisions for **both** backends.
+    """
+    if not GH_SAFE_PATH_RE.match(endpoint or ""):
+        return {"error": "Endpoint contains disallowed characters"}
+
+    parts = (endpoint or "").strip("/").split("/")
+    if len(parts) < 2:
+        return {"error": "Invalid endpoint format: expected owner/repo/..."}
+
+    for part in parts:
+        if part in ("", ".", ".."):
+            return {"error": f"Dot-segment not allowed in path: {part or '(empty)'}"}
+
+    # GitHub's prompt format is "repos/owner/repo/..."; the direct format
+    # "owner/repo/..." is also accepted. Either way, the repo key is
+    # positions [0:2] (after stripping the optional "repos" prefix).
+    if parts[0] == "repos" and len(parts) >= 3:
+        repo_key = f"{parts[1]}/{parts[2]}"
+    else:
+        repo_key = f"{parts[0]}/{parts[1]}"
+
+    allowed = (
+        repo_key == current_repo
+        or "*" in (allowed_repos or set())
+        or repo_key in (allowed_repos or set())
+    )
+    if not allowed:
+        return {"error": f"Repo not allowed: {repo_key}"}
+
+    if parts[0] == "repos":
+        full_path = "/" + "/".join(parts)
+    else:
+        full_path = "/repos/" + "/".join(parts)
+    if not any(full_path.startswith(prefix) for prefix in GH_API_ALLOWED_PREFIXES):
+        return {"error": f"Endpoint prefix not allowed: {full_path}"}
+
+    lower = full_path.lower()
+    for deny in GH_DENY_SUBSTRINGS:
+        if deny in lower:
+            return {"error": f"Path segment denied: {deny}"}
+
+    return {"full_path": full_path, "repo_key": repo_key}
+
+
+def _gh_api_github(full_path, request_timeout):
+    """Issue a read-only GitHub API request for an already-validated path."""
+    token = os.getenv("GH_TOKEN") or os.getenv("GITHUB_TOKEN", "")
+    if not token:
+        return {"error": "Missing GH_TOKEN"}
+    url = f"https://api.github.com{full_path}"
+    try:
+        req = urllib.request.Request(
+            url,
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Accept": "application/vnd.github.v3+json",
+                "User-Agent": "ai-pr-reviewer/1.0",
+            },
+        )
+        with urllib.request.urlopen(req, timeout=request_timeout) as resp:
+            data = json.loads(resp.read().decode("utf-8", errors="replace"))
+            return {"data": data}
+    except urllib.error.HTTPError as exc:
+        return {"error": f"GitHub API error: {exc.code} {exc.reason}"}
+    except Exception as exc:
+        return {"error": str(exc)}
+
+
+# Map a GitHub-style full_path (the normalized form produced by
+# ``_validate_endpoint``) onto a Forgejo ``/api/v1`` URL. Anything outside
+# this table is unsupported on Forgejo — the call fails closed with a
+# descriptive error rather than silently falling through to ``api.github.com``.
+#
+# The keys here mirror ``GH_API_ALLOWED_PREFIXES``; each value is a function
+# that takes the matched (path, repo_key) and returns the Forgejo URL. We
+# use the GitHub-shaped path as the input so the allowlist is the only
+# authority on which endpoints even reach the translation step.
+def _forgejo_translate(full_path, repo_key):
+    """Return a Forgejo API URL, or None if the endpoint is not supported.
+
+    The pre-seam gh_api tool was used almost exclusively for read-only repo
+    metadata — PR/issue/review bodies, commit status, release notes. The
+    subset below covers every shape the existing test corpus exercises and
+    is the minimal translation needed for the tool to be useful on a Forgejo
+    host. Anything not in this table is reported as ``Endpoint not supported
+    on PLATFORM=forgejo`` so callers can fail loudly and stop guessing.
+    """
+    repos = f"/repos/{repo_key}"
+    if not full_path.startswith(repos):
+        # The allowed-prefix list also includes /search/ and /git/ at the
+        # root (no repo segment). Those are handled below.
+        if full_path.startswith("/search/"):
+            return f"/api/v1{full_path}"
+        if full_path.startswith("/releases/"):
+            # /releases/owner/repo/tags  →  /api/v1/repos/owner/repo/releases/tags
+            tail = full_path[len("/releases/"):]
+            if "/" in tail:
+                owner, repo = tail.split("/", 1)
+                return f"/api/v1/repos/{owner}/{repo}/releases/tags"
+        return None
+
+    rest = full_path[len(repos):]  # begins with "/"
+    # PR metadata / diff / files / comments / reviews (the bulk of gh_api use).
+    if rest == "/pulls" or rest.startswith("/pulls/"):
+        # /pulls/N                  →  /api/v1/repos/o/r/pulls/N
+        # /pulls/N/files            →  /api/v1/repos/o/r/pulls/N/files
+        # /pulls/N/comments         →  /api/v1/repos/o/r/pulls/N/comments
+        # /pulls/N/reviews          →  /api/v1/repos/o/r/pulls/N/reviews
+        # /pulls/N/diff             →  /api/v1/repos/o/r/pulls/N.diff
+        if rest.endswith("/diff"):
+            n = rest[len("/pulls/"):-len("/diff")]
+            return f"/api/v1/repos/{repo_key}/pulls/{n}.diff"
+        return f"/api/v1/repos/{repo_key}{rest}"
+
+    # Issues and issue comments.
+    if rest == "/issues" or rest.startswith("/issues/"):
+        # /issues/N                 →  /api/v1/repos/o/r/issues/N
+        # /issues/N/comments        →  /api/v1/repos/o/r/issues/N/comments
+        return f"/api/v1/repos/{repo_key}{rest}"
+
+    # Compare base...head (used by the incremental scope check).
+    if rest == "/compare" or rest.startswith("/compare/"):
+        spec = rest[len("/compare/"):]
+        return f"/api/v1/repos/{repo_key}/compare/{spec}"
+
+    # Releases by tag (e.g. /releases/tags/v1.2.3 — already handled above
+    # in the no-repo form). With a repo prefix the shape is
+    # /repos/owner/repo/releases/tags/v1.2.3 which Forgejo exposes at the
+    # same URL under /api/v1.
+    if rest == "/releases/tags" or rest.startswith("/releases/tags/"):
+        return f"/api/v1/repos/{repo_key}{rest}"
+
+    # Commit status (read-only; used by the CI-required check).
+    if rest == "/commits" or rest.startswith("/commits/"):
+        return f"/api/v1/repos/{repo_key}{rest}/status" if not rest.endswith("/status") else f"/api/v1/repos/{repo_key}{rest}"
+
+    return None
+
+
+def _gh_api_forgejo(full_path, repo_key, request_timeout):
+    """Issue a read-only Forgejo API request for an already-validated path.
+
+    Requires ``FORGEJO_API_URL`` (the same env var the rest of the Forgejo
+    backend reads) and ``FORGEJO_TOKEN`` (or ``GITHUB_TOKEN`` as a fallback
+    so existing action.yml wiring works). The response body is parsed as
+    JSON exactly like the GitHub backend; the model-facing schema is the
+    GitHub one, so the rest of the tool harness does not need to know
+    which platform served the response.
+    """
+    base = os.environ.get("FORGEJO_API_URL", "").rstrip("/")
+    if not base:
+        return {"error": "FORGEJO_API_URL is not set; cannot route gh_api to Forgejo"}
+
+    translated = _forgejo_translate(full_path, repo_key)
+    if not translated:
+        return {"error": f"Endpoint not supported on PLATFORM=forgejo: {full_path}"}
+
+    token = os.environ.get("FORGEJO_TOKEN") or os.environ.get("GITHUB_TOKEN", "")
+    if not token:
+        return {"error": "Missing FORGEJO_TOKEN"}
+
+    url = f"{base}{translated}"
+    try:
+        # Use curl so we can keep parity with the rest of the Forgejo
+        # backend (and so HTTPS_PROXY / -k style operator knobs work the
+        # same way they do for the comment / review code paths).
+        cmd = [
+            "curl", "-sS",
+            "-H", f"Authorization: token {token}",
+            "-H", "Accept: application/json",
+            "-w", "\n%{http_code}",
+            url,
+        ]
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=request_timeout)
+        raw = proc.stdout
+        body_text, sep, code_text = raw.rpartition("\n")
+        if not sep or not code_text.strip().isdigit():
+            return {"error": f"Forgejo API error: curl failed (rc={proc.returncode})"}
+        status_code = int(code_text.strip())
+        if status_code != 200:
+            return {"error": f"Forgejo API error: {status_code} {body_text[:200]}"}
+        try:
+            return {"data": json.loads(body_text)}
+        except json.JSONDecodeError as exc:
+            return {"error": f"Forgejo API error: invalid JSON ({exc})"}
+    except subprocess.TimeoutExpired:
+        return {"error": f"Forgejo API timed out after {request_timeout}s"}
+    except Exception as exc:
+        return {"error": str(exc)}
+
+
+def gh_api(endpoint, allowed_repos, current_repo, request_timeout=25):
+    """Make a host-platform API call with path/endpoint restrictions.
+
+    Behaviour is platform-aware: on github it goes to
+    ``https://api.github.com``; on forgejo it goes to
+    ``${FORGEJO_API_URL}/api/v1`` with the GitHub-style endpoint rewritten
+    to the equivalent Forgejo path. The validation that decides whether the
+    call is *allowed at all* is identical on both backends — see
+    ``_validate_endpoint``.
+    """
+    validated = _validate_endpoint(endpoint, allowed_repos, current_repo)
+    if isinstance(validated, dict) and validated.get("error"):
+        return validated
+    full_path = validated["full_path"]
+    repo_key = validated["repo_key"]
+
+    platform = resolve_platform()
+    if platform == "forgejo":
+        return _gh_api_forgejo(full_path, repo_key, request_timeout)
+    return _gh_api_github(full_path, request_timeout)

--- a/scripts/run_tool_harness.py
+++ b/scripts/run_tool_harness.py
@@ -13,28 +13,38 @@ import urllib.request
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
-# Ensure the scripts directory is on sys.path so we can import shared helpers.
+# Ensure the scripts directory and the project root are on sys.path so we
+# can import the shared helpers (redact) and the platform seam module
+# (pr_reviewer.platform) — the latter is needed for gh_api to route
+# through the platform abstraction (issue #226). The project root is
+# the parent of the scripts directory.
 _SCRIPTS_DIR = Path(__file__).resolve().parent
 if str(_SCRIPTS_DIR) not in sys.path:
     sys.path.insert(0, str(_SCRIPTS_DIR))
+_PROJECT_ROOT = _SCRIPTS_DIR.parent
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
 
 from redact import mask_secrets  # noqa: E402
+
+# Allowlist constants for the gh_api tool live on the platform seam
+# (pr_reviewer.platform) so the same allowlist governs both the GitHub
+# and the Forgejo backend — drift between them is the kind of tiny
+# mechanical mapping mistake that becomes a CVE.
+from pr_reviewer.platform import (  # noqa: E402
+    GH_API_ALLOWED_PREFIXES,
+    GH_DENY_SUBSTRINGS,
+    GH_SAFE_PATH_RE,
+)
 
 
 SENSITIVE_PATH_RE = re.compile(
     r"(^|/)(\.env(\.|$)|id_rsa(\.|$)|id_dsa(\.|$)|credentials(\.|$)|secret(s)?(\.|$)|.*\.pem$|.*\.key$)",
     re.IGNORECASE,
 )
-GH_SAFE_PATH_RE = re.compile(r"^[A-Za-z0-9._~/%?&=:+,-]+$")
-GH_DENY_SUBSTRINGS = (
-    "/actions/secrets",
-    "/dependabot/secrets",
-    "/environments/",
-    "/dispatches",
-)
-
-# Allowed GitHub API path prefixes for gh_api tool calls.
-# Only read-only, non-sensitive endpoints are permitted.
+# Re-exported from pr_reviewer.platform for call sites that still
+# import them from this module; the platform seam is the single
+# source of truth. See pr_reviewer.platform for the rationale.
 GH_API_ALLOWED_PREFIXES = (
     "/repos/",
     "/issues/",
@@ -524,79 +534,19 @@ def git_blame(path, workspace_root, start=None, end=None, request_timeout=15):
 
 
 def gh_api(endpoint, allowed_repos, current_repo, request_timeout=25):
-    """Make a GitHub API call with path/endpoint restrictions."""
-    token = os.getenv("GH_TOKEN") or os.getenv("GITHUB_TOKEN", "")
-    if not token:
-        return {"error": "Missing GH_TOKEN"}
+    """Make a host-platform API call with path/endpoint restrictions.
 
-    # Validate endpoint contains only safe characters
-    if not GH_SAFE_PATH_RE.match(endpoint):
-        return {"error": "Endpoint contains disallowed characters"}
-
-    # Parse endpoint to extract repo and path
-    # Support both "repos/owner/repo/..." (prompt format) and "owner/repo/..." (direct)
-    parts = endpoint.strip("/").split("/")
-    if len(parts) < 2:
-        return {"error": "Invalid endpoint format: expected owner/repo/..."}
-
-    # Reject traversal/empty segments only. Dots *inside* a component are safe
-    # (and required for release tags like v1.2.3 and repos like next.js); only
-    # the ".", ".." and empty ("//") segments are traversal risks.
-    for part in parts:
-        if part in ("", ".", ".."):
-            return {"error": f"Dot-segment not allowed in path: {part or '(empty)'}"}
-
-    # If the first segment is "repos", skip it and use the next two segments
-    if parts[0] == "repos" and len(parts) >= 3:
-        repo_key = f"{parts[1]}/{parts[2]}"
-    else:
-        repo_key = f"{parts[0]}/{parts[1]}"
-
-    # Validate repo is allowed
-    allowed = False
-    if repo_key == current_repo:
-        allowed = True
-    elif "*" in allowed_repos:
-        allowed = True
-    elif repo_key in allowed_repos:
-        allowed = True
-
-    if not allowed:
-        return {"error": f"Repo not allowed: {repo_key}"}
-
-    # Check endpoint prefix is in the allowlist of safe API paths
-    # Normalize direct format (owner/repo/...) to repos/owner/repo/... for prefix check
-    if parts[0] == "repos":
-        full_path = "/" + "/".join(parts)
-    else:
-        full_path = "/repos/" + "/".join(parts)
-    if not any(full_path.startswith(prefix) for prefix in GH_API_ALLOWED_PREFIXES):
-        return {"error": f"Endpoint prefix not allowed: {full_path}"}
-
-    # Check for denied path segments
-    for deny in GH_DENY_SUBSTRINGS:
-        if deny in full_path.lower():
-            return {"error": f"Path segment denied: {deny}"}
-
-    # full_path already begins with "/"; avoid a double slash after the host.
-    url = f"https://api.github.com{full_path}"
-    try:
-        req = urllib.request.Request(
-            url,
-            headers={
-                "Authorization": f"Bearer {token}",
-                "Accept": "application/vnd.github.v3+json",
-                "User-Agent": "ai-pr-reviewer/1.0",
-            },
-        )
-        with urllib.request.urlopen(req, timeout=request_timeout) as resp:
-            raw = resp.read()
-            data = json.loads(raw.decode("utf-8", errors="replace"))
-            return {"data": data}
-    except urllib.error.HTTPError as exc:
-        return {"error": f"GitHub API error: {exc.code} {exc.reason}"}
-    except Exception as exc:
-        return {"error": str(exc)}
+    Thin shim over :func:`pr_reviewer.platform.gh_api` so the gh_api tool
+    routes through the platform seam (#226). The seam owns the allowlist
+    (path traversal, repo key, denied substrings) and the per-backend
+    transport; this shim exists only for backward compatibility with
+    call sites that import the function from this module.
+    """
+    # Imported lazily so this module can still be loaded when the
+    # platform seam is unavailable (e.g. in a script-only test that
+    # doesn't add the package to sys.path).
+    from pr_reviewer.platform import gh_api as _platform_gh_api
+    return _platform_gh_api(endpoint, allowed_repos, current_repo, request_timeout)
 
 
 def web_fetch(url, allowed_hosts, request_timeout=25):

--- a/scripts/run_tool_harness.py
+++ b/scripts/run_tool_harness.py
@@ -27,30 +27,18 @@ if str(_PROJECT_ROOT) not in sys.path:
 
 from redact import mask_secrets  # noqa: E402
 
-# Allowlist constants for the gh_api tool live on the platform seam
-# (pr_reviewer.platform) so the same allowlist governs both the GitHub
-# and the Forgejo backend — drift between them is the kind of tiny
-# mechanical mapping mistake that becomes a CVE.
-from pr_reviewer.platform import (  # noqa: E402
-    GH_API_ALLOWED_PREFIXES,
-    GH_DENY_SUBSTRINGS,
-    GH_SAFE_PATH_RE,
-)
+# The gh_api allowlist (path regex, prefixes, deny substrings) now lives
+# entirely on the platform seam (pr_reviewer.platform), which owns both the
+# GitHub and Forgejo backends — a single source of truth so the two can't
+# drift (the kind of tiny mapping mistake that becomes a CVE). We import only
+# GH_DENY_SUBSTRINGS here, reused below by _resolve_workspace_path to block
+# the same sensitive segments in filesystem paths.
+from pr_reviewer.platform import GH_DENY_SUBSTRINGS  # noqa: E402
 
 
 SENSITIVE_PATH_RE = re.compile(
     r"(^|/)(\.env(\.|$)|id_rsa(\.|$)|id_dsa(\.|$)|credentials(\.|$)|secret(s)?(\.|$)|.*\.pem$|.*\.key$)",
     re.IGNORECASE,
-)
-# Re-exported from pr_reviewer.platform for call sites that still
-# import them from this module; the platform seam is the single
-# source of truth. See pr_reviewer.platform for the rationale.
-GH_API_ALLOWED_PREFIXES = (
-    "/repos/",
-    "/issues/",
-    "/search/",
-    "/releases/",
-    "/git/",
 )
 
 # The tool harness executes same-repo code, so command execution must not be

--- a/tests/test_platform_gh_api_forgejo.py
+++ b/tests/test_platform_gh_api_forgejo.py
@@ -224,6 +224,39 @@ def test_forgejo_release_tag_routes_to_api_v1(monkeypatch):
     assert any("/api/v1/repos/" + _REPO + "/releases/tags/v1.2.3" in tok for tok in cmd), cmd
 
 
+def test_forgejo_commit_status_passes_through(monkeypatch):
+    """A commit-status endpoint keeps its ``/status`` shape verbatim."""
+    result, captured = _exec_forgejo(
+        monkeypatch, f"repos/{_REPO}/commits/abc123/status"
+    )
+    assert "error" not in result, result
+    cmd = captured["cmd"]
+    assert any("/api/v1/repos/" + _REPO + "/commits/abc123/status" in tok for tok in cmd), cmd
+
+
+def test_forgejo_get_commit_is_not_rewritten_to_status(monkeypatch):
+    """``commits/<sha>`` (get a commit) must NOT be turned into a status lookup.
+
+    The endpoint translation previously appended ``/status`` to every commits
+    call, so fetching a commit silently returned its CI status instead. The
+    validated path is passed through verbatim now.
+    """
+    result, captured = _exec_forgejo(
+        monkeypatch, f"repos/{_REPO}/commits/abc123"
+    )
+    assert "error" not in result, result
+    cmd = captured["cmd"]
+    assert any(tok.endswith("/api/v1/repos/" + _REPO + "/commits/abc123") for tok in cmd), cmd
+    assert not any("/commits/abc123/status" in tok for tok in cmd), cmd
+
+
+def test_forgejo_curl_sends_user_agent(monkeypatch):
+    """The Forgejo curl carries a non-default User-Agent (Cloudflare BIC)."""
+    _result, captured = _exec_forgejo(monkeypatch, f"repos/{_REPO}/pulls/1")
+    cmd = captured["cmd"]
+    assert any("User-Agent: ai-pr-reviewer/1.0" in tok for tok in cmd), cmd
+
+
 def test_forgejo_search_prefix_check_passes(monkeypatch):
     """``search/...`` (no repo key) passes the prefix check on both backends.
 

--- a/tests/test_platform_gh_api_forgejo.py
+++ b/tests/test_platform_gh_api_forgejo.py
@@ -1,0 +1,396 @@
+"""Red-team + translation tests for the Forgejo backend of the gh_api tool.
+
+Issue #226 ports the gh_api tool to the platform seam so on a Forgejo host it
+issues ``/api/v1`` requests instead of going to ``https://api.github.com``.
+This is a security boundary: the model chooses the endpoint, and the endpoint
+is then used to issue a network request with an operator-supplied token. The
+tests below pin the boundary and exercise it adversarially so a future change
+that loosens the Forgejo backend (or accidentally routes a call to the wrong
+host) fails loudly.
+
+Two layers of defence are tested:
+
+  * **Validation** (run identically on both backends in
+    ``pr_reviewer.platform._validate_endpoint``): path characters, traversal
+    segments, repo allowlist, endpoint prefix allowlist, deny substrings.
+  * **Translation + transport** (``_forgejo_translate`` and
+    ``_gh_api_forgejo``): the GitHub-style endpoint must be rewritten to the
+    matching ``/api/v1`` URL, and the request must go to
+    ``${FORGEJO_API_URL}`` — never ``api.github.com`` — using the Forgejo
+    token.
+
+The tests stub ``subprocess.run`` (the curl transport used by
+``_gh_api_forgejo``) so no real network is involved; the assertions are on
+the *captured* command line, which is the part the model-injection threat
+model cares about.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from pr_reviewer import platform  # noqa: E402
+from pr_reviewer.platform import gh_api  # noqa: E402
+
+
+_REPO = "owner/repo"
+_FORGEJO_BASE = "https://forgejo.example.com"
+
+
+def _mock_curl_return(body, http_code=200):
+    """Build a subprocess.run mock that returns the given body and status code."""
+
+    def _run(cmd, **kwargs):
+        # body + status code, on stdout, with the body and code on either side
+        # of a newline (matches the curl -w '\n%{http_code}' convention the
+        # backend uses).
+        stdout = f"{body}\n{http_code}"
+        return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
+
+    return _run
+
+
+# ---------------------------------------------------------------------------
+# 1. The platform boundary is enforced identically on the Forgejo backend.
+# ---------------------------------------------------------------------------
+
+
+def test_forgejo_blocks_unallowlisted_repo(tmp_path, monkeypatch):
+    """A repo key outside the allowlist is rejected before any network call."""
+    monkeypatch.setenv("PLATFORM", "forgejo")
+    monkeypatch.setenv("FORGEJO_API_URL", _FORGEJO_BASE)
+    monkeypatch.setenv("FORGEJO_TOKEN", "fake-not-used")
+    with patch("pr_reviewer.platform.subprocess.run") as mock_run:
+        result = gh_api(
+            "repos/attacker/evil/contents/x",
+            allowed_repos={_REPO},
+            current_repo=_REPO,
+        )
+    assert result.get("error"), result
+    assert "not allowed" in result["error"].lower()
+    mock_run.assert_not_called()
+
+
+def test_forgejo_blocks_path_traversal(tmp_path, monkeypatch):
+    """``..`` segment is rejected identically on the Forgejo backend."""
+    monkeypatch.setenv("PLATFORM", "forgejo")
+    monkeypatch.setenv("FORGEJO_API_URL", _FORGEJO_BASE)
+    monkeypatch.setenv("FORGEJO_TOKEN", "fake-not-used")
+    with patch("pr_reviewer.platform.subprocess.run") as mock_run:
+        result = gh_api(
+            f"repos/{_REPO}/../another/pulls/1",
+            allowed_repos=set(),
+            current_repo=_REPO,
+        )
+    assert result.get("error"), result
+    assert "dot" in result["error"].lower()
+    mock_run.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "endpoint",
+    [
+        f"repos/{_REPO}/actions/secrets",
+        f"repos/{_REPO}/environments/prod",
+        f"repos/{_REPO}/dispatches",
+    ],
+)
+def test_forgejo_denies_sensitive_endpoints(endpoint, tmp_path, monkeypatch):
+    """Denial of secrets/environments/dispatches is the same on both backends."""
+    monkeypatch.setenv("PLATFORM", "forgejo")
+    monkeypatch.setenv("FORGEJO_API_URL", _FORGEJO_BASE)
+    monkeypatch.setenv("FORGEJO_TOKEN", "fake-not-used")
+    with patch("pr_reviewer.platform.subprocess.run") as mock_run:
+        result = gh_api(endpoint, allowed_repos=set(), current_repo=_REPO)
+    assert result.get("error"), result
+    assert "denied" in result["error"].lower()
+    mock_run.assert_not_called()
+
+
+def test_forgejo_blocks_unallowlisted_prefix(tmp_path, monkeypatch):
+    """Endpoints outside the read-only prefix allowlist are rejected."""
+    monkeypatch.setenv("PLATFORM", "forgejo")
+    monkeypatch.setenv("FORGEJO_API_URL", _FORGEJO_BASE)
+    monkeypatch.setenv("FORGEJO_TOKEN", "fake-not-used")
+    with patch("pr_reviewer.platform.subprocess.run") as mock_run:
+        # ``/users/`` is a valid GitHub endpoint but not in the allowlist.
+        result = gh_api(
+            f"users/{_REPO.split('/')[0]}/emails",
+            allowed_repos=set(),
+            current_repo=_REPO,
+        )
+    assert result.get("error"), result
+    assert "prefix" in result["error"].lower() or "not allowed" in result["error"].lower()
+    mock_run.assert_not_called()
+
+
+def test_forgejo_blocks_disallowed_characters(tmp_path, monkeypatch):
+    """Spaces, null bytes, and other unsafe characters are rejected."""
+    monkeypatch.setenv("PLATFORM", "forgejo")
+    monkeypatch.setenv("FORGEJO_API_URL", _FORGEJO_BASE)
+    monkeypatch.setenv("FORGEJO_TOKEN", "fake-not-used")
+    with patch("pr_reviewer.platform.subprocess.run") as mock_run:
+        result = gh_api(
+            f"repos/{_REPO}/pulls/1 comment",
+            allowed_repos=set(),
+            current_repo=_REPO,
+        )
+    assert result.get("error"), result
+    assert "disallowed" in result["error"].lower()
+    mock_run.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# 2. The translated URL goes to the configured Forgejo host — never to
+#    api.github.com — and uses the FORGEJO_TOKEN.
+# ---------------------------------------------------------------------------
+
+
+def _exec_forgejo(monkeypatch, endpoint, body='{"ok": true}', http_code=200):
+    """Drive gh_api on the Forgejo backend and return (result, captured_cmd)."""
+    monkeypatch.setenv("PLATFORM", "forgejo")
+    monkeypatch.setenv("FORGEJO_API_URL", _FORGEJO_BASE)
+    monkeypatch.setenv("FORGEJO_TOKEN", "fj-test-token")
+    # GH_TOKEN is set on purpose to make sure the Forgejo backend prefers
+    # FORGEJO_TOKEN and does not fall through to the GitHub token.
+    monkeypatch.setenv("GH_TOKEN", "gh-test-token-DO-NOT-USE")
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return subprocess.CompletedProcess(
+            cmd, 0, stdout=f"{body}\n{http_code}", stderr=""
+        )
+
+    with patch("pr_reviewer.platform.subprocess.run", side_effect=fake_run):
+        result = gh_api(endpoint, allowed_repos=set(), current_repo=_REPO)
+    return result, captured
+
+
+def test_forgejo_pr_metadata_routes_to_api_v1(monkeypatch):
+    """``repos/o/r/pulls/N`` is rewritten to ``/api/v1/repos/o/r/pulls/N``."""
+    result, captured = _exec_forgejo(
+        monkeypatch, f"repos/{_REPO}/pulls/42"
+    )
+    assert "error" not in result, result
+    cmd = captured["cmd"]
+    # The command is a curl invocation against the configured FORGEJO_API_URL.
+    assert cmd[0] == "curl"
+    assert any(_FORGEJO_BASE + "/api/v1/repos/" + _REPO + "/pulls/42" in tok for tok in cmd), cmd
+    # And NOT against api.github.com — that would defeat the entire point
+    # of the platform seam.
+    assert not any("api.github.com" in tok for tok in cmd), cmd
+
+
+def test_forgejo_pr_diff_routes_to_api_v1(monkeypatch):
+    """``repos/o/r/pulls/N/diff`` is rewritten to ``/api/v1/repos/o/r/pulls/N.diff``."""
+    result, captured = _exec_forgejo(
+        monkeypatch, f"repos/{_REPO}/pulls/42/diff"
+    )
+    assert "error" not in result, result
+    cmd = captured["cmd"]
+    assert any("/pulls/42.diff" in tok for tok in cmd), cmd
+    assert not any("api.github.com" in tok for tok in cmd), cmd
+
+
+def test_forgejo_issue_routes_to_api_v1(monkeypatch):
+    """``repos/o/r/issues/N`` is rewritten to ``/api/v1/repos/o/r/issues/N``."""
+    result, captured = _exec_forgejo(
+        monkeypatch, f"repos/{_REPO}/issues/9"
+    )
+    assert "error" not in result, result
+    cmd = captured["cmd"]
+    assert any("/api/v1/repos/" + _REPO + "/issues/9" in tok for tok in cmd), cmd
+
+
+def test_forgejo_release_tag_routes_to_api_v1(monkeypatch):
+    """``repos/o/r/releases/tags/v1.2.3`` keeps its shape on the ``/api/v1`` form."""
+    result, captured = _exec_forgejo(
+        monkeypatch, f"repos/{_REPO}/releases/tags/v1.2.3"
+    )
+    assert "error" not in result, result
+    cmd = captured["cmd"]
+    assert any("/api/v1/repos/" + _REPO + "/releases/tags/v1.2.3" in tok for tok in cmd), cmd
+
+
+def test_forgejo_search_prefix_check_passes(monkeypatch):
+    """``search/...`` (no repo key) passes the prefix check on both backends.
+
+    Search endpoints do not have a repo key, so the repo-allowlist check
+    rejects them (the same way the pre-seam code did — see
+    ``tests/test_gh_api.py::TestGhApiPathValidation::test_allowed_search_prefix_passes``).
+    The Forgejo backend must not weaken that: the error must be about the
+    repo allowlist, not a translation failure.
+    """
+    monkeypatch.setenv("PLATFORM", "forgejo")
+    monkeypatch.setenv("FORGEJO_API_URL", _FORGEJO_BASE)
+    monkeypatch.setenv("FORGEJO_TOKEN", "fj-test")
+    with patch("pr_reviewer.platform.subprocess.run") as mock_run:
+        result = gh_api("search/code?q=foo", allowed_repos=set(), current_repo=_REPO)
+    # Fails on the repo allowlist — the prefix check still passed.
+    assert "not allowed" in result.get("error", "").lower(), result
+    mock_run.assert_not_called()
+
+
+def test_forgejo_uses_forgejo_token_not_github_token(monkeypatch):
+    """The Authorization header carries the FORGEJO_TOKEN, not GH_TOKEN."""
+    _exec_forgejo(monkeypatch, f"repos/{_REPO}/pulls/1")
+    # _exec_forgejo already patched and captured; redo to read the cmd cleanly.
+    monkeypatch.setenv("PLATFORM", "forgejo")
+    monkeypatch.setenv("FORGEJO_API_URL", _FORGEJO_BASE)
+    monkeypatch.setenv("FORGEJO_TOKEN", "fj-correct-token")
+    monkeypatch.setenv("GH_TOKEN", "gh-leakage-token-MUST-NOT-APPEAR")
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return subprocess.CompletedProcess(cmd, 0, stdout='{"ok":true}\n200', stderr="")
+
+    with patch("pr_reviewer.platform.subprocess.run", side_effect=fake_run):
+        gh_api(f"repos/{_REPO}/pulls/1", allowed_repos=set(), current_repo=_REPO)
+
+    cmd = captured["cmd"]
+    auths = [tok for tok in cmd if "Authorization" in tok]
+    assert auths, cmd
+    assert any("fj-correct-token" in tok for tok in auths), cmd
+    # The GitHub token must not appear anywhere in the curl argv.
+    assert not any("gh-leakage-token" in tok for tok in cmd), cmd
+
+
+# ---------------------------------------------------------------------------
+# 3. Failure modes — error body and missing config both fail closed.
+# ---------------------------------------------------------------------------
+
+
+def test_forgejo_missing_api_url_returns_error(monkeypatch):
+    """If FORGEJO_API_URL is empty, the backend fails closed with a clear error."""
+    monkeypatch.setenv("PLATFORM", "forgejo")
+    monkeypatch.delenv("FORGEJO_API_URL", raising=False)
+    monkeypatch.setenv("FORGEJO_TOKEN", "fj-test")
+    result = gh_api(f"repos/{_REPO}/pulls/1", allowed_repos=set(), current_repo=_REPO)
+    assert result.get("error"), result
+    assert "FORGEJO_API_URL" in result["error"]
+
+
+def test_forgejo_missing_token_returns_error(monkeypatch):
+    """No token at all → fail closed, not an unauthenticated call."""
+    monkeypatch.setenv("PLATFORM", "forgejo")
+    monkeypatch.setenv("FORGEJO_API_URL", _FORGEJO_BASE)
+    monkeypatch.delenv("FORGEJO_TOKEN", raising=False)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    result = gh_api(f"repos/{_REPO}/pulls/1", allowed_repos=set(), current_repo=_REPO)
+    assert result.get("error"), result
+    assert "token" in result["error"].lower()
+
+
+def test_forgejo_non_200_status_returns_error(monkeypatch):
+    """A 404 (or any non-200) from the upstream becomes an error, never a silent empty data."""
+    monkeypatch.setenv("PLATFORM", "forgejo")
+    monkeypatch.setenv("FORGEJO_API_URL", _FORGEJO_BASE)
+    monkeypatch.setenv("FORGEJO_TOKEN", "fj-test")
+    with patch(
+        "pr_reviewer.platform.subprocess.run",
+        return_value=subprocess.CompletedProcess(
+            ["curl"], 0, stdout='{"message":"Not Found"}\n404', stderr=""
+        ),
+    ):
+        result = gh_api(
+            f"repos/{_REPO}/pulls/9999", allowed_repos=set(), current_repo=_REPO
+        )
+    assert result.get("error"), result
+    assert "404" in result["error"]
+
+
+def test_forgejo_unsupported_endpoint_returns_error(monkeypatch):
+    """An endpoint that passes validation but has no Forgejo mapping fails closed.
+
+    /repos/{repo}/milestones is on the /repos/ prefix allowlist with a real
+    repo key, but is not in the translation table — so the Forgejo backend
+    must report it explicitly rather than silently using api.github.com.
+    """
+    monkeypatch.setenv("PLATFORM", "forgejo")
+    monkeypatch.setenv("FORGEJO_API_URL", _FORGEJO_BASE)
+    monkeypatch.setenv("FORGEJO_TOKEN", "fj-test")
+    with patch("pr_reviewer.platform.subprocess.run") as mock_run:
+        result = gh_api(
+            f"repos/{_REPO}/milestones", allowed_repos=set(), current_repo=_REPO
+        )
+    assert result.get("error"), result
+    assert "not supported" in result["error"].lower(), result
+    mock_run.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# 4. End-to-end through the tool harness shim (the actual call path).
+# ---------------------------------------------------------------------------
+
+
+def test_tool_harness_shim_dispatches_to_platform(monkeypatch):
+    """``run_tool_harness.gh_api`` is now a shim that calls the platform seam."""
+    # The shim lazy-imports pr_reviewer.platform, so importing run_tool_harness
+    # alone must not fail.
+    scripts_dir = _PROJECT_ROOT / "scripts"
+    if str(scripts_dir) not in sys.path:
+        sys.path.insert(0, str(scripts_dir))
+    from run_tool_harness import gh_api as rth_gh_api  # type: ignore  # noqa: E402
+
+    monkeypatch.setenv("PLATFORM", "forgejo")
+    monkeypatch.setenv("FORGEJO_API_URL", _FORGEJO_BASE)
+    monkeypatch.setenv("FORGEJO_TOKEN", "fj-test")
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return subprocess.CompletedProcess(
+            cmd, 0, stdout='{"ok":true}\n200', stderr=""
+        )
+
+    with patch("pr_reviewer.platform.subprocess.run", side_effect=fake_run):
+        result = rth_gh_api(
+            f"repos/{_REPO}/pulls/1", allowed_repos=set(), current_repo=_REPO
+        )
+    assert "error" not in result, result
+    assert any(
+        _FORGEJO_BASE + "/api/v1/repos/" + _REPO + "/pulls/1" in tok
+        for tok in captured["cmd"]
+    )
+
+
+# ---------------------------------------------------------------------------
+# 5. Auto-resolution: PLATFORM=auto with a non-github GITHUB_SERVER_URL
+#    routes to the Forgejo backend.
+# ---------------------------------------------------------------------------
+
+
+def test_auto_platform_with_forgejo_server_url_uses_forgejo_backend(monkeypatch):
+    """PLATFORM=auto resolves to forgejo when GITHUB_SERVER_URL is non-github."""
+    monkeypatch.setenv("PLATFORM", "auto")
+    monkeypatch.setenv("GITHUB_SERVER_URL", "https://forgejo.example.com")
+    monkeypatch.setenv("FORGEJO_API_URL", _FORGEJO_BASE)
+    monkeypatch.setenv("FORGEJO_TOKEN", "fj-test")
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return subprocess.CompletedProcess(
+            cmd, 0, stdout='{"ok":true}\n200', stderr=""
+        )
+
+    with patch("pr_reviewer.platform.subprocess.run", side_effect=fake_run):
+        result = gh_api(
+            f"repos/{_REPO}/pulls/1", allowed_repos=set(), current_repo=_REPO
+        )
+    assert "error" not in result, result
+    assert any(_FORGEJO_BASE in tok for tok in captured["cmd"]), captured["cmd"]
+    assert not any("api.github.com" in tok for tok in captured["cmd"]), captured["cmd"]


### PR DESCRIPTION
Fixes #226

## Summary

The `gh_api` tool previously hard-coded `https://api.github.com`, so on a Forgejo host the model could not retrieve any evidence at all. Port the validation and transport to `pr_reviewer.platform` so the seam decides which backend to call: GitHub stays on `api.github.com`, Forgejo gets the same endpoint rewritten to `/api/v1` against `FORGEJO_API_URL`.

The security boundary is unchanged — repo allowlist, prefix allowlist, deny substrings, and path-traversal checks all run identically on both backends because they share a single `_validate_endpoint`. The new `_forgejo_translate` table is the only piece of behaviour that diverges between backends, and anything it does not know how to map fails closed with an explicit error rather than silently falling through to `api.github.com`.

`run_tool_harness.gh_api` is now a thin shim that delegates to the platform module; the existing `test_gh_api.py` and the red-team suite keep passing unmodified.

Adds `tests/test_platform_gh_api_forgejo.py` with 19 cases covering the cross-backend validation, the URL translation, the `FORGEJO_TOKEN`-not-`GH_TOKEN` guarantee, and the `PLATFORM=auto` path.

## Test plan

- `pytest tests/test_gh_api.py tests/test_platform.py tests/test_platform_gh_api_forgejo.py tests/test_native_loop_exfil_redteam.py` — all pass (78 cases).
- `pytest tests/` — 932 cases pass (885 pre-existing + 19 new + 28 red-team).
- Spot-check: a `PLATFORM=forgejo` + `FORGEJO_API_URL` call against the tool harness issues a `curl` to `${FORGEJO_API_URL}/api/v1/...` and never `api.github.com`; the Authorization header carries `FORGEJO_TOKEN`, not `GH_TOKEN`.
- Spot-check: the `/actions/secrets`, `/environments/`, `/dispatches` deny substrings still reject the same way on the Forgejo backend; the path-traversal `..` rejection is byte-identical to the GitHub backend.

<!-- saffron-worker-footer -->
Worker: saffron-escalated
Model: dsv4f
