### PR TITLE
refactor(publish): centralize the review-comment marker preamble (#296)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -859,14 +859,7 @@ runs:
         fi
 
         {
-          echo "$COMMENT_MARKER"
-          echo "$METADATA_MARKER"
-          if [ -n "${HEAD_SHA:-}" ]; then
-            echo "<!-- ai-pr-review-sha:${HEAD_SHA} -->"
-          fi
-          if [ -n "${BROAD_FINGERPRINT:-}" ]; then
-            echo "<!-- ai-pr-review-fingerprint:${BROAD_FINGERPRINT} -->"
-          fi
+          emit_review_markers
           echo "$VERDICT_PREFIX"
           echo
           printf '_Analysis engine: %s_\n' "$ANALYSIS_ENGINE"
@@ -933,14 +926,7 @@ runs:
         # Build the review body with managed marker
         BODY_FILE="review-comment-body.md"
         {
-          echo "$COMMENT_MARKER"
-          echo "$METADATA_MARKER"
-          if [ -n "${HEAD_SHA:-}" ]; then
-            echo "<!-- ai-pr-review-sha:${HEAD_SHA} -->"
-          fi
-          if [ -n "${BROAD_FINGERPRINT:-}" ]; then
-            echo "<!-- ai-pr-review-fingerprint:${BROAD_FINGERPRINT} -->"
-          fi
+          emit_review_markers
           echo "$REVIEW_HEADER"
           echo
           printf '_Analysis engine: %s_\n' "$ANALYSIS_ENGINE"
@@ -1077,14 +1063,7 @@ runs:
         # Build the review body with managed marker
         BODY_FILE="review-verdict-body.md"
         {
-          echo "$COMMENT_MARKER"
-          echo "$METADATA_MARKER"
-          if [ -n "${HEAD_SHA:-}" ]; then
-            echo "<!-- ai-pr-review-sha:${HEAD_SHA} -->"
-          fi
-          if [ -n "${BROAD_FINGERPRINT:-}" ]; then
-            echo "<!-- ai-pr-review-fingerprint:${BROAD_FINGERPRINT} -->"
-          fi
+          emit_review_markers
           echo "$REVIEW_HEADER"
           echo
           if [ "$EFFECTIVE_SCOPE" = "incremental" ]; then

--- a/scripts/publish_helpers.sh
+++ b/scripts/publish_helpers.sh
@@ -214,6 +214,28 @@ build_metadata_marker() {
   printf '<!-- ai-pr-reviewer:%s -->' "$marker_json"
 }
 
+# Emit the managed review-comment marker preamble to stdout: the sticky
+# comment marker, the metadata marker, and (when set) the head-sha and
+# fingerprint markers. Centralizes the strip-then-append discipline so a
+# publish step cannot silently drop the markers that skip-on-unchanged
+# (check_review_needed.sh) and managed-comment cleanup depend on. The two
+# required markers are guarded so a future refactor that forgets to set them
+# fails loudly under `set -e` rather than publishing an unmatchable comment.
+# Reads env/globals: COMMENT_MARKER, METADATA_MARKER, HEAD_SHA (optional),
+# BROAD_FINGERPRINT (optional).
+emit_review_markers() {
+  : "${COMMENT_MARKER:?emit_review_markers: COMMENT_MARKER must be set}"
+  : "${METADATA_MARKER:?emit_review_markers: METADATA_MARKER must be set}"
+  echo "$COMMENT_MARKER"
+  echo "$METADATA_MARKER"
+  if [ -n "${HEAD_SHA:-}" ]; then
+    echo "<!-- ai-pr-review-sha:${HEAD_SHA} -->"
+  fi
+  if [ -n "${BROAD_FINGERPRINT:-}" ]; then
+    echo "<!-- ai-pr-review-fingerprint:${BROAD_FINGERPRINT} -->"
+  fi
+}
+
 # Validate that PR_NUMBER is set.
 # Requires env: PR_NUMBER
 # Args: $1 = mode description for error message

--- a/tests/test_cleanup_previous_native_reviews.sh
+++ b/tests/test_cleanup_previous_native_reviews.sh
@@ -139,21 +139,18 @@ STICKY_COMMENT_BODY=$(awk '/Publish review comment$/,/^    - name: Publish revie
 check_contains "sticky comment mode uses COMMENT_MARKER variable" \
   "$STICKY_COMMENT_BODY" "COMMENT_MARKER"
 
-# Every published body must carry the bare COMMENT_MARKER and the fingerprint
-# marker, otherwise the precheck cannot find prior state and skip-if-unchanged /
-# incremental scope silently never trigger (regression guard).
-check_contains "sticky comment body emits the bare COMMENT_MARKER" \
-  "$STICKY_COMMENT_BODY" 'echo "$COMMENT_MARKER"'
-check_contains "sticky comment body emits the fingerprint marker" \
-  "$STICKY_COMMENT_BODY" "ai-pr-review-fingerprint"
-check_contains "review_comment body emits the bare COMMENT_MARKER" \
-  "$BODY_CONTENT_REVIEW_COMMENT" 'echo "$COMMENT_MARKER"'
-check_contains "review_comment body emits the fingerprint marker" \
-  "$BODY_CONTENT_REVIEW_COMMENT" "ai-pr-review-fingerprint"
-check_contains "review_verdict body emits the bare COMMENT_MARKER" \
-  "$BODY_CONTENT_REVIEW_VERDICT" 'echo "$COMMENT_MARKER"'
-check_contains "review_verdict body emits the fingerprint marker" \
-  "$BODY_CONTENT_REVIEW_VERDICT" "ai-pr-review-fingerprint"
+# Every published body must emit the marker preamble (sticky COMMENT_MARKER +
+# METADATA_MARKER + head-sha + fingerprint) so the precheck can find prior
+# state; otherwise skip-if-unchanged / incremental scope silently never trigger
+# (regression guard). The preamble is emitted via emit_review_markers
+# (publish_helpers.sh); its exact content and ordering are asserted in
+# tests/test_emit_review_markers.sh.
+check_contains "sticky comment body emits markers via emit_review_markers" \
+  "$STICKY_COMMENT_BODY" "emit_review_markers"
+check_contains "review_comment body emits markers via emit_review_markers" \
+  "$BODY_CONTENT_REVIEW_COMMENT" "emit_review_markers"
+check_contains "review_verdict body emits markers via emit_review_markers" \
+  "$BODY_CONTENT_REVIEW_VERDICT" "emit_review_markers"
 
 echo ""
 echo "=== Helper script validation ==="

--- a/tests/test_emit_review_markers.sh
+++ b/tests/test_emit_review_markers.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# Tests for emit_review_markers (#296): the publish steps' marker preamble is
+# now a single sourced helper instead of inline heredoc text in three places.
+# This pins the emitted order/content AND the fail-loud guard, so a future
+# refactor can't silently drop the markers that skip-on-unchanged
+# (check_review_needed.sh) and managed-comment cleanup rely on.
+
+if [ -z "${BASH_VERSINFO:-}" ] || [ "${BASH_VERSINFO[0]}" -lt 4 ]; then
+  echo "SKIP: bash >= 4 required (found ${BASH_VERSION:-unknown}); on macOS run with PATH=\"/opt/homebrew/bin:\$PATH\"" >&2
+  exit 0
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+PASS=0
+FAIL=0
+check() {
+  local desc="$1" result="$2" expected="$3"
+  if [[ "$result" == "$expected" ]]; then
+    echo "  PASS: $desc"; PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc"; echo "    expected: [$expected]"; echo "    got:      [$result]"; FAIL=$((FAIL + 1))
+  fi
+}
+
+# shellcheck disable=SC1090
+source "$ROOT_DIR/scripts/publish_helpers.sh"
+set +e  # we deliberately exercise the fail-loud path below
+
+# Full preamble: sticky marker, metadata marker, head-sha, fingerprint — in order.
+out="$(COMMENT_MARKER='<!-- ai-pr-reviewer -->' METADATA_MARKER='<!-- ai-pr-reviewer:{} -->' HEAD_SHA='abc123' BROAD_FINGERPRINT='fp1|cfg:xyz' emit_review_markers)"
+check "sticky marker first"       "$(printf '%s\n' "$out" | sed -n '1p')" '<!-- ai-pr-reviewer -->'
+check "metadata marker second"    "$(printf '%s\n' "$out" | sed -n '2p')" '<!-- ai-pr-reviewer:{} -->'
+check "head-sha marker third"     "$(printf '%s\n' "$out" | sed -n '3p')" '<!-- ai-pr-review-sha:abc123 -->'
+check "fingerprint marker fourth" "$(printf '%s\n' "$out" | sed -n '4p')" '<!-- ai-pr-review-fingerprint:fp1|cfg:xyz -->'
+check "exactly four lines"        "$(printf '%s\n' "$out" | grep -c .)" "4"
+
+# Optional markers omitted when unset → only the two required lines.
+out2="$(COMMENT_MARKER='<!-- ai-pr-reviewer -->' METADATA_MARKER='<!-- ai-pr-reviewer:{} -->' HEAD_SHA='' BROAD_FINGERPRINT='' emit_review_markers)"
+check "omits optional markers when unset" "$(printf '%s\n' "$out2" | grep -c .)" "2"
+
+# Fail-loud: a missing required marker must abort (non-zero), never emit a
+# marker-less comment that breaks skip-on-unchanged.
+if ( unset COMMENT_MARKER; METADATA_MARKER='x' emit_review_markers >/dev/null 2>&1 ); then
+  check "missing COMMENT_MARKER fails loudly" "did-not-fail" "should-fail"
+else
+  check "missing COMMENT_MARKER fails loudly" "should-fail" "should-fail"
+fi
+
+echo ""
+echo "emit_review_markers: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Audit P1-3 (#296).

The three publish steps each inlined an identical marker preamble. If a future refactor moved or dropped that heredoc, the comment would publish **without** its markers — silently breaking skip-on-unchanged (`check_review_needed.sh`) and managed-comment cleanup, with no test catching it.

**Change:** extract `emit_review_markers()` into `publish_helpers.sh`, called by all three steps. The two required markers (`COMMENT_MARKER`, `METADATA_MARKER`) are guarded with `${VAR:?}`, so a missing one **fails loudly** under `set -e` rather than shipping an unmatchable comment. The strip-then-append discipline is now code-enforced. The line 978 inline-findings marker is intentionally left as-is (distinct, sticky-marker-only).

New `tests/test_emit_review_markers.sh` pins emitted order/content, optional-marker omission, and the fail-loud guard. Full sweep green (22 shell + pytest + smoke).

Fixes #296