### PR TITLE
feat(evidence): warn on shell-string provider commands (#300)

### DIFF
--- a/scripts/run_evidence_providers.py
+++ b/scripts/run_evidence_providers.py
@@ -2,6 +2,7 @@
 """Execute evidence-provider commands and write structured results."""
 
 import json
+import logging
 import os
 import shlex
 import subprocess
@@ -16,6 +17,8 @@ if str(_SCRIPTS_DIR) not in sys.path:
     sys.path.insert(0, str(_SCRIPTS_DIR))
 
 from redact import mask_and_truncate, mask_secrets  # noqa: E402
+
+logger = logging.getLogger(__name__)
 
 
 def env_int(name: str, default: int) -> int:
@@ -169,6 +172,19 @@ def run_provider(
         else:
             command_text = str(command)
             entry["command"] = command_text
+            # SECURITY: shell-string commands are executed via `bash -lc`, which
+            # interprets the string in a login shell — the full bash injection
+            # surface is available.  Prefer argv arrays (see SECURITY.md:
+            # "Prefer argv arrays … over shell strings … to avoid shell injection
+            # risks from `bash -lc` execution").  This branch is a trust
+            # boundary: the string is treated as trusted operator-supplied input,
+            # not as sanitised user content.
+            logger.warning(
+                "evidence provider %r: command is a shell string and will be "
+                "executed via `bash -lc`.  Prefer an argv list to avoid the "
+                "bash trust boundary (see SECURITY.md).",
+                entry["id"],
+            )
             completed = subprocess.run(
                 ["bash", "-lc", command_text],
                 stdout=subprocess.PIPE,

--- a/tests/test_evidence_providers.py
+++ b/tests/test_evidence_providers.py
@@ -19,6 +19,7 @@ from run_evidence_providers import (  # noqa: E402
     parse_findings,
     severity_rank,
     env_int,
+    run_provider,
 )
 
 EVIDENCE_SCRIPT = _SCRIPTS_DIR / "run_evidence_providers.py"
@@ -522,6 +523,35 @@ class TestCommandFormat:
         data = _load_json_output(tmp_path)
         p = data["providers"][0]
         assert p["command"] == 'echo "verbatim"'
+
+
+# ── Unit tests: shell-string trust-boundary WARN log ───────────────
+
+class TestShellStringWarnLog:
+    """Verify that run_provider emits a WARNING for shell-string commands.
+
+    The warning is the sole observability hook for the string→bash trust
+    boundary documented in SECURITY.md ("Prefer argv arrays … over shell
+    strings … to avoid shell injection risks from `bash -lc` execution").
+    Execution behaviour is unchanged by this test.
+    """
+
+    def test_warn_fires_for_shell_string_command(self):
+        """A string command triggers a WARNING containing 'bash -lc'."""
+        provider = {"id": "shell-warn-probe", "command": "true"}
+        with mock.patch("run_evidence_providers.logger") as mock_logger:
+            run_provider(1, provider, default_timeout=5, default_max_output=4096)
+        # Exactly one warning call, mentioning the bash trust boundary.
+        assert mock_logger.warning.call_count == 1
+        warn_msg = mock_logger.warning.call_args[0][0]
+        assert "bash -lc" in warn_msg
+
+    def test_no_warn_for_argv_list_command(self):
+        """An argv-list command must NOT trigger the shell-string WARNING."""
+        provider = {"id": "argv-no-warn-probe", "command": ["true"]}
+        with mock.patch("run_evidence_providers.logger") as mock_logger:
+            run_provider(1, provider, default_timeout=5, default_max_output=4096)
+        assert mock_logger.warning.call_count == 0
 
 
 # ── Integration tests: fork enablement skip behavior ────────────────


### PR DESCRIPTION
Audit P2-4 (#300). When an evidence provider command is a shell **string** (→ `bash -lc`) rather than an argv list, emit a WARNING naming the provider and citing SECURITY.md's trust-model guidance. Surfaces the string-vs-list trust boundary for same-repo PRs. **Additive only** — no change to execution or the fork gate. Two unit tests assert the warning fires once for a string command and not for an argv list. Full sweep green. Fixes #300.