### PR TITLE
feat(classifier): per-file attribution for risk flags (#297)

### DIFF
--- a/pr_reviewer/classifier.py
+++ b/pr_reviewer/classifier.py
@@ -176,6 +176,7 @@ DB_MIGRATION_PATTERNS = [
 class PRClassification:
     pr_kind: str = "app_code"
     risk_flags: list[str] = field(default_factory=list)
+    risk_flags_with_files: dict[str, list[str]] = field(default_factory=dict)
     changed_files_summary: list[str] = field(default_factory=list)
     linked_issue_labels: list[str] = field(default_factory=list)
     must_check: list[str] = field(default_factory=list)
@@ -285,9 +286,22 @@ def _detect_risk_flags(
     files: list[dict],
     diff_text: str,
     linked_issues: list[dict],
-) -> list[str]:
-    """Detect risk flags based on file patterns and linked issue metadata."""
+) -> tuple[list[str], dict[str, list[str]]]:
+    """Detect risk flags based on file patterns and linked issue metadata.
+
+    Returns
+    -------
+    flags : list[str]
+        Ordered list of detected risk flag names (unchanged semantics).
+    flags_with_files : dict[str, list[str]]
+        Mapping from each file-based risk flag to the file paths that triggered
+        it.  Issue-linked flags (linked_security_issue, etc.) have no file
+        attribution and are omitted from this mapping.  When a flag fires only
+        from diff content (no filename match), the mapping contains an empty
+        list for that flag.
+    """
     flags: list[str] = []
+    flags_with_files: dict[str, list[str]] = {}
     filenames = [f.get("filename", "") for f in files]
 
     # Check for linked security/audit/priority issues
@@ -313,16 +327,19 @@ def _detect_risk_flags(
         (AUTH_PATTERNS, "auth_changes"),
         (SECRET_HANDLING_PATTERNS, "secret_handling_changes"),
     ]:
-        # Check both filenames and diff content for risk flags
-        matches_in_files = any(
-            any(pat.search(f) for pat in pat_set) for f in filenames
-        )
+        # Collect the specific files that triggered this flag
+        triggering_files = [
+            f for f in filenames
+            if any(pat.search(f) for pat in pat_set)
+        ]
         matches_in_diff = any(pat.search(diff_text) for pat in pat_set)
-        if matches_in_files or matches_in_diff:
+        if triggering_files or matches_in_diff:
             if flag not in flags:
                 flags.append(flag)
+            # Record file attribution (empty list when only diff content matched)
+            flags_with_files[flag] = triggering_files
 
-    return flags
+    return flags, flags_with_files
 
 
 # Checklist items per risk class. Keys are pr_kind values AND the file-based
@@ -424,7 +441,7 @@ def classify_pr(
         linked_issues = []
 
     pr_kind = _classify_pr_kind(pr_files, diff_text)
-    risk_flags = _detect_risk_flags(pr_files, diff_text, linked_issues)
+    risk_flags, risk_flags_with_files = _detect_risk_flags(pr_files, diff_text, linked_issues)
     must_check = _build_must_check(pr_kind, risk_flags)
 
     # Build changed files summary (just filenames, truncated)
@@ -442,6 +459,7 @@ def classify_pr(
     return PRClassification(
         pr_kind=pr_kind,
         risk_flags=risk_flags,
+        risk_flags_with_files=risk_flags_with_files,
         changed_files_summary=changed_files_summary,
         linked_issue_labels=linked_issue_labels,
         must_check=must_check,

--- a/scripts/run_review.sh
+++ b/scripts/run_review.sh
@@ -1098,7 +1098,7 @@ build_review_corpus() {
 
     echo "# PR Classification"
     if [ -f classification.json ]; then
-      jq '{pr_kind, risk_flags, changed_files_summary: (.changed_files_summary | .[0:20]), linked_issue_labels, must_check}' classification.json | head -c 8000
+      jq '{pr_kind, risk_flags, risk_flags_with_files, changed_files_summary: (.changed_files_summary | .[0:20]), linked_issue_labels, must_check}' classification.json | head -c 8000
     else
       echo "(Classification data unavailable for this review)"
     fi
@@ -1294,8 +1294,17 @@ parts = [base]
 pr_kind = str(data.get("pr_kind") or "unknown")
 parts.append(f"PR kind (deterministic classification): {pr_kind}.")
 flags = [str(flag) for flag in (data.get("risk_flags") or []) if flag]
+attribution = data.get("risk_flags_with_files") or {}
 if flags:
-    parts.append("Risk flags: " + ", ".join(flags[:12]) + ".")
+    flag_parts = []
+    for flag in flags[:12]:
+        files_for_flag = attribution.get(flag) or []
+        if files_for_flag:
+            file_list = ", ".join(files_for_flag[:5])
+            flag_parts.append(f"{flag} (triggered by: {file_list})")
+        else:
+            flag_parts.append(flag)
+    parts.append("Risk flags: " + ", ".join(flag_parts) + ".")
 checks = [str(check) for check in (data.get("must_check") or []) if check]
 if checks:
     parts.append(

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -94,7 +94,7 @@ class TestPRKindMultiLanguage:
         ) == "db_or_migration_changes"
 
     def test_auth_risk_flag_typescript(self):
-        flags = _detect_risk_flags([_make_file("src/auth.ts")], "", [])
+        flags, _ = _detect_risk_flags([_make_file("src/auth.ts")], "", [])
         assert "auth_changes" in flags
 
 
@@ -230,30 +230,111 @@ class TestPRKindDefault:
 class TestRiskFlags:
     def test_linked_security_issue(self):
         issues = [{"labels": [{"name": "security"}]}]
-        flags = _detect_risk_flags([], "", issues)
+        flags, _ = _detect_risk_flags([], "", issues)
         assert "linked_security_issue" in flags
 
     def test_linked_audit_issue(self):
         issues = [{"labels": [{"name": "audit"}]}]
-        flags = _detect_risk_flags([], "", issues)
+        flags, _ = _detect_risk_flags([], "", issues)
         assert "linked_audit_issue" in flags
 
     def test_linked_priority_p1(self):
         issues = [{"labels": [{"name": "priority/p1"}]}]
-        flags = _detect_risk_flags([], "", issues)
+        flags, _ = _detect_risk_flags([], "", issues)
         assert "linked_priority_p1" in flags
 
     def test_no_risk_flags(self):
         issues = [{"labels": [{"name": "bug"}]}]
-        flags = _detect_risk_flags([], "", issues)
+        flags, _ = _detect_risk_flags([], "", issues)
         assert not any(
             f.startswith("linked_") for f in flags
         ), f"Expected no linked risk flags, got {flags}"
 
     def test_file_serving_flag(self):
         files = [_make_file("static/handler.py")]
-        flags = _detect_risk_flags(files, "", [])
+        flags, _ = _detect_risk_flags(files, "", [])
         assert "file_serving_changes" in flags
+
+
+# ---------------------------------------------------------------------------
+# Risk flag file attribution tests
+# ---------------------------------------------------------------------------
+
+class TestRiskFlagsWithFiles:
+    """Tests for risk_flags_with_files — per-flag file attribution (issue #297)."""
+
+    def test_auth_flag_attributes_triggering_file(self):
+        # auth.py triggers auth_changes; the file should appear in attribution.
+        files = [_make_file("auth.py"), _make_file("utils.py")]
+        flags, attribution = _detect_risk_flags(files, "", [])
+        assert "auth_changes" in flags
+        assert "auth_changes" in attribution
+        assert "auth.py" in attribution["auth_changes"]
+        # utils.py did NOT trigger the flag
+        assert "utils.py" not in attribution["auth_changes"]
+
+    def test_secret_flag_attributes_multiple_files(self):
+        # Two secret-related files both appear in the attribution list.
+        files = [
+            _make_file("secrets.yaml"),
+            _make_file("vault_config.json"),
+            _make_file("main.py"),
+        ]
+        flags, attribution = _detect_risk_flags(files, "", [])
+        assert "secret_handling_changes" in flags
+        attributed = attribution.get("secret_handling_changes", [])
+        assert "secrets.yaml" in attributed
+        assert "vault_config.json" in attributed
+        assert "main.py" not in attributed
+
+    def test_path_handling_diff_only_has_empty_file_list(self):
+        # Flag fires only from diff content → attribution list is empty (no file names matched).
+        files = [_make_file("app.py")]
+        diff = "import pathlib\nresult = pathlib.Path(user_input)"
+        flags, attribution = _detect_risk_flags(files, diff, [])
+        assert "path_handling_changes" in flags
+        # app.py itself did not match any path-handling filename pattern
+        assert attribution.get("path_handling_changes", None) == []
+
+    def test_linked_flags_absent_from_attribution(self):
+        # Issue-linked flags have no file attribution and must not appear in mapping.
+        issues = [{"labels": [{"name": "security"}, {"name": "priority/p0"}]}]
+        flags, attribution = _detect_risk_flags([], "", issues)
+        assert "linked_security_issue" in flags
+        assert "linked_priority_p0" in flags
+        assert "linked_security_issue" not in attribution
+        assert "linked_priority_p0" not in attribution
+
+    def test_classify_pr_exposes_risk_flags_with_files(self):
+        # End-to-end: classify_pr should populate risk_flags_with_files on the result.
+        files = [_make_file("src/auth_service.py"), _make_file("app.py")]
+        result = classify_pr(files, diff_text="", linked_issues=[])
+        assert isinstance(result.risk_flags_with_files, dict)
+        assert "auth_changes" in result.risk_flags_with_files
+        assert "src/auth_service.py" in result.risk_flags_with_files["auth_changes"]
+        assert "app.py" not in result.risk_flags_with_files["auth_changes"]
+
+    def test_risk_flags_with_files_in_serialized_dict(self):
+        # risk_flags_with_files must survive to_dict() so run_review.sh can jq it.
+        files = [_make_file("static/serve.py")]
+        result = classify_pr(files)
+        d = result.to_dict()
+        assert "risk_flags_with_files" in d
+        assert isinstance(d["risk_flags_with_files"], dict)
+        assert "file_serving_changes" in d["risk_flags_with_files"]
+        assert "static/serve.py" in d["risk_flags_with_files"]["file_serving_changes"]
+
+    def test_no_file_based_flags_produces_empty_attribution(self):
+        # A PR with only linked-issue flags and no file-pattern hits has empty attribution.
+        files = [_make_file("README.md")]
+        issues = [{"labels": [{"name": "audit"}]}]
+        flags, attribution = _detect_risk_flags(files, "", issues)
+        assert "linked_audit_issue" in flags
+        # No file-based flags fired, so attribution only contains file-based entries
+        file_based_flags = {"file_serving_changes", "path_handling_changes",
+                            "auth_changes", "secret_handling_changes"}
+        for flag in attribution:
+            assert flag in file_based_flags
 
 
 # ---------------------------------------------------------------------------
@@ -352,6 +433,7 @@ class TestClassifyPR:
         d = result.to_dict()
         assert "pr_kind" in d
         assert "risk_flags" in d
+        assert "risk_flags_with_files" in d
         assert "changed_files_summary" in d
         assert "linked_issue_labels" in d
         assert "must_check" in d


### PR DESCRIPTION
Audit P2-1 (#297). `_detect_risk_flags` now also returns a `{flag: [file_paths]}` map of which files triggered each file-based flag. It's stored on `PRClassification` (`risk_flags_with_files`), serialized to classification.json, and rendered inline in the corpus 'Why this PR is being reviewed' section so a reviewer sees *which* file triggered each flag — e.g. `auth_changes (triggered by: src/auth.py)`. Backward-compatible (plain flag name when the key is absent); **no flag semantics changed**. Full sweep green (incl. updated callers + new TestRiskFlagsWithFiles). Fixes #297.