### PR TITLE
test(infra): share bash assertion helpers via tests/_lib/assert.sh (#299)

### DIFF
--- a/tests/_lib/assert.sh
+++ b/tests/_lib/assert.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Shared assertion helpers for tests/test_*.sh
+#
+# Usage: source this file after declaring PASS and FAIL counters.
+#
+# Provided functions:
+#   check          desc result expected        — exact equality
+#   check_contains desc haystack needle        — substring test
+#   check_not_contains desc haystack needle    — absent-substring test
+#   check_ne       desc result not_expected    — exact inequality
+#   check_exists   desc count                  — count > 0
+
+check() {
+  local desc="$1" result="$2" expected="$3"
+  if [[ "$result" == "$expected" ]]; then
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc (got '$result', expected '$expected')"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+check_contains() {
+  local desc="$1" haystack="$2" needle="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc (expected to contain '$needle')"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+check_not_contains() {
+  local desc="$1" haystack="$2" needle="$3"
+  if [[ "$haystack" != *"$needle"* ]]; then
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc (should not contain '$needle')"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+check_ne() {
+  local desc="$1" result="$2" not_expected="$3"
+  if [[ "$result" != "$not_expected" ]]; then
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc (got '$result', should not be '$not_expected')"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+check_exists() {
+  local desc="$1" result="$2"
+  if [[ "$result" -gt 0 ]]; then
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc (expected to exist)"
+    FAIL=$((FAIL + 1))
+  fi
+}

--- a/tests/test_approval_guardrails.sh
+++ b/tests/test_approval_guardrails.sh
@@ -12,52 +12,11 @@ fi
 # Tests for PR #40: guarded approval controls for review_verdict mode
 # These tests validate the shell logic used by the "Publish review verdict" step.
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PASS=0
 FAIL=0
-
-check() {
-  local desc="$1" result="$2" expected="$3"
-  if [[ "$result" == "$expected" ]]; then
-    echo "  PASS: $desc"
-    PASS=$((PASS + 1))
-  else
-    echo "  FAIL: $desc (got '$result', expected '$expected')"
-    FAIL=$((FAIL + 1))
-  fi
-}
-
-check_ne() {
-  local desc="$1" result="$2" not_expected="$3"
-  if [[ "$result" != "$not_expected" ]]; then
-    echo "  PASS: $desc"
-    PASS=$((PASS + 1))
-  else
-    echo "  FAIL: $desc (got '$result', should not be '$not_expected')"
-    FAIL=$((FAIL + 1))
-  fi
-}
-
-check_contains() {
-  local desc="$1" haystack="$2" needle="$3"
-  if [[ "$haystack" == *"$needle"* ]]; then
-    echo "  PASS: $desc"
-    PASS=$((PASS + 1))
-  else
-    echo "  FAIL: $desc (expected to contain '$needle')"
-    FAIL=$((FAIL + 1))
-  fi
-}
-
-check_exists() {
-  local desc="$1" result="$2"
-  if [[ "$result" -gt 0 ]]; then
-    echo "  PASS: $desc"
-    PASS=$((PASS + 1))
-  else
-    echo "  FAIL: $desc (expected to exist)"
-    FAIL=$((FAIL + 1))
-  fi
-}
+# shellcheck source=_lib/assert.sh
+source "$SCRIPT_DIR/_lib/assert.sh"
 
 # The core guardrail logic extracted from action.yml's publish verdict step.
 # It sets CAN_APPROVE based on VERDICT, ALLOW_APPROVE, APPROVE_FORKS, IS_FORK_PR.

--- a/tests/test_carry_forward_roundtrip.sh
+++ b/tests/test_carry_forward_roundtrip.sh
@@ -21,30 +21,8 @@ ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 PASS=0
 FAIL=0
-check() {
-  local desc="$1" result="$2" expected="$3"
-  if [[ "$result" == "$expected" ]]; then
-    echo "  PASS: $desc"; PASS=$((PASS + 1))
-  else
-    echo "  FAIL: $desc (got '$result', expected '$expected')"; FAIL=$((FAIL + 1))
-  fi
-}
-check_contains() {
-  local desc="$1" haystack="$2" needle="$3"
-  if [[ "$haystack" == *"$needle"* ]]; then
-    echo "  PASS: $desc"; PASS=$((PASS + 1))
-  else
-    echo "  FAIL: $desc (expected to contain '$needle')"; FAIL=$((FAIL + 1))
-  fi
-}
-check_not_contains() {
-  local desc="$1" haystack="$2" needle="$3"
-  if [[ "$haystack" != *"$needle"* ]]; then
-    echo "  PASS: $desc"; PASS=$((PASS + 1))
-  else
-    echo "  FAIL: $desc (should not contain '$needle')"; FAIL=$((FAIL + 1))
-  fi
-}
+# shellcheck source=_lib/assert.sh
+source "$SCRIPT_DIR/_lib/assert.sh"
 
 TMP="$(mktemp -d)"
 FUNC="$TMP/extract.sh"

--- a/tests/test_check_review_needed.sh
+++ b/tests/test_check_review_needed.sh
@@ -23,17 +23,8 @@ PRECHECK_SCRIPT="$ROOT_DIR/scripts/check_review_needed.sh"
 
 PASS=0
 FAIL=0
-
-check() {
-  local desc="$1" result="$2" expected="$3"
-  if [[ "$result" == "$expected" ]]; then
-    echo "  PASS: $desc"
-    PASS=$((PASS + 1))
-  else
-    echo "  FAIL: $desc (got '$result', expected '$expected')"
-    FAIL=$((FAIL + 1))
-  fi
-}
+# shellcheck source=_lib/assert.sh
+source "$SCRIPT_DIR/_lib/assert.sh"
 
 # ── Setup ─────────────────────────────────────────────────────────────
 TMPDIR="$(mktemp -d)"

--- a/tests/test_ci_status_check.sh
+++ b/tests/test_ci_status_check.sh
@@ -14,31 +14,12 @@ fi
 
 PASS=0
 FAIL=0
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+_TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(cd "$_TEST_DIR/.." && pwd)"
 WAIT_SCRIPT="$SCRIPT_DIR/scripts/wait_for_ci.sh"
 ACTION_YML="$SCRIPT_DIR/action.yml"
-
-check() {
-  local desc="$1" result="$2" expected="$3"
-  if [[ "$result" == "$expected" ]]; then
-    echo "  PASS: $desc"
-    PASS=$((PASS + 1))
-  else
-    echo "  FAIL: $desc (got '$result', expected '$expected')"
-    FAIL=$((FAIL + 1))
-  fi
-}
-
-check_contains() {
-  local desc="$1" haystack="$2" needle="$3"
-  if [[ "$haystack" == *"$needle"* ]]; then
-    echo "  PASS: $desc"
-    PASS=$((PASS + 1))
-  else
-    echo "  FAIL: $desc (expected to contain '$needle')"
-    FAIL=$((FAIL + 1))
-  fi
-}
+# shellcheck source=_lib/assert.sh
+source "$_TEST_DIR/_lib/assert.sh"
 
 # ── Test 1: exit code 1 path for timeout+skip=true exists in script ──
 echo "=== Test: exit code 1 on timeout with skip=true ==="

--- a/tests/test_classification_steering.sh
+++ b/tests/test_classification_steering.sh
@@ -18,30 +18,8 @@ ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 PASS=0
 FAIL=0
-check() {
-  local desc="$1" result="$2" expected="$3"
-  if [[ "$result" == "$expected" ]]; then
-    echo "  PASS: $desc"; PASS=$((PASS + 1))
-  else
-    echo "  FAIL: $desc (got '$result', expected '$expected')"; FAIL=$((FAIL + 1))
-  fi
-}
-check_contains() {
-  local desc="$1" haystack="$2" needle="$3"
-  if [[ "$haystack" == *"$needle"* ]]; then
-    echo "  PASS: $desc"; PASS=$((PASS + 1))
-  else
-    echo "  FAIL: $desc (expected to contain '$needle')"; FAIL=$((FAIL + 1))
-  fi
-}
-check_not_contains() {
-  local desc="$1" haystack="$2" needle="$3"
-  if [[ "$haystack" != *"$needle"* ]]; then
-    echo "  PASS: $desc"; PASS=$((PASS + 1))
-  else
-    echo "  FAIL: $desc (should not contain '$needle')"; FAIL=$((FAIL + 1))
-  fi
-}
+# shellcheck source=_lib/assert.sh
+source "$SCRIPT_DIR/_lib/assert.sh"
 
 # Extract build_user_message from run_review.sh so it can be called directly
 # (same pattern as test_context_budget.sh).

--- a/tests/test_cleanup_native_reviews_behavior.sh
+++ b/tests/test_cleanup_native_reviews_behavior.sh
@@ -19,30 +19,8 @@ ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 PASS=0
 FAIL=0
-check() {
-  local desc="$1" result="$2" expected="$3"
-  if [[ "$result" == "$expected" ]]; then
-    echo "  PASS: $desc"; PASS=$((PASS + 1))
-  else
-    echo "  FAIL: $desc (got '$result', expected '$expected')"; FAIL=$((FAIL + 1))
-  fi
-}
-check_contains() {
-  local desc="$1" haystack="$2" needle="$3"
-  if [[ "$haystack" == *"$needle"* ]]; then
-    echo "  PASS: $desc"; PASS=$((PASS + 1))
-  else
-    echo "  FAIL: $desc (expected to contain '$needle')"; FAIL=$((FAIL + 1))
-  fi
-}
-check_not_contains() {
-  local desc="$1" haystack="$2" needle="$3"
-  if [[ "$haystack" != *"$needle"* ]]; then
-    echo "  PASS: $desc"; PASS=$((PASS + 1))
-  else
-    echo "  FAIL: $desc (should not contain '$needle')"; FAIL=$((FAIL + 1))
-  fi
-}
+# shellcheck source=_lib/assert.sh
+source "$SCRIPT_DIR/_lib/assert.sh"
 
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT

--- a/tests/test_context_budget.sh
+++ b/tests/test_context_budget.sh
@@ -18,14 +18,8 @@ ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 PASS=0
 FAIL=0
-check() {
-  local desc="$1" result="$2" expected="$3"
-  if [[ "$result" == "$expected" ]]; then
-    echo "  PASS: $desc"; PASS=$((PASS + 1))
-  else
-    echo "  FAIL: $desc (got '$result', expected '$expected')"; FAIL=$((FAIL + 1))
-  fi
-}
+# shellcheck source=_lib/assert.sh
+source "$SCRIPT_DIR/_lib/assert.sh"
 
 # Extract the two functions from run_review.sh so we can call them directly.
 FUNCS="$(mktemp)"

--- a/tests/test_model_call.sh
+++ b/tests/test_model_call.sh
@@ -20,16 +20,8 @@ source "$ROOT_DIR/scripts/model_call.sh"
 
 PASS=0
 FAIL=0
-check() {
-  local desc="$1" result="$2" expected="$3"
-  if [[ "$result" == "$expected" ]]; then
-    echo "  PASS: $desc"
-    PASS=$((PASS + 1))
-  else
-    echo "  FAIL: $desc (got '$result', expected '$expected')"
-    FAIL=$((FAIL + 1))
-  fi
-}
+# shellcheck source=_lib/assert.sh
+source "$SCRIPT_DIR/_lib/assert.sh"
 
 TMPDIR="$(mktemp -d)"
 trap 'rm -rf "$TMPDIR"' EXIT

--- a/tests/test_model_failure.sh
+++ b/tests/test_model_failure.sh
@@ -18,14 +18,8 @@ ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 PASS=0
 FAIL=0
-check() {
-  local desc="$1" result="$2" expected="$3"
-  if [[ "$result" == "$expected" ]]; then
-    echo "  PASS: $desc"; PASS=$((PASS + 1))
-  else
-    echo "  FAIL: $desc (got '$result', expected '$expected')"; FAIL=$((FAIL + 1))
-  fi
-}
+# shellcheck source=_lib/assert.sh
+source "$SCRIPT_DIR/_lib/assert.sh"
 
 FUNC="$(mktemp)"
 TMP="$(mktemp -d)"

--- a/tests/test_platform_api.sh
+++ b/tests/test_platform_api.sh
@@ -11,19 +11,14 @@ if [ -z "${BASH_VERSINFO:-}" ] || [ "${BASH_VERSINFO[0]}" -lt 4 ]; then
   exit 0
 fi
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+_TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(cd "$_TEST_DIR/.." && pwd)"
 SEAM="$SCRIPT_DIR/scripts/platform_api.sh"
 
 PASS=0
 FAIL=0
-check() {
-  local desc="$1" result="$2" expected="$3"
-  if [[ "$result" == "$expected" ]]; then
-    echo "  PASS: $desc"; PASS=$((PASS + 1))
-  else
-    echo "  FAIL: $desc (got '$result', expected '$expected')"; FAIL=$((FAIL + 1))
-  fi
-}
+# shellcheck source=_lib/assert.sh
+source "$_TEST_DIR/_lib/assert.sh"
 
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT

--- a/tests/test_required_checks.sh
+++ b/tests/test_required_checks.sh
@@ -19,22 +19,8 @@ HELPER_SCRIPT="$ROOT_DIR/scripts/publish_helpers.sh"
 
 PASS=0
 FAIL=0
-check() {
-  local desc="$1" result="$2" expected="$3"
-  if [[ "$result" == "$expected" ]]; then
-    echo "  PASS: $desc"; PASS=$((PASS + 1))
-  else
-    echo "  FAIL: $desc (got '$result', expected '$expected')"; FAIL=$((FAIL + 1))
-  fi
-}
-check_contains() {
-  local desc="$1" haystack="$2" needle="$3"
-  if [[ "$haystack" == *"$needle"* ]]; then
-    echo "  PASS: $desc"; PASS=$((PASS + 1))
-  else
-    echo "  FAIL: $desc (expected to contain '$needle')"; FAIL=$((FAIL + 1))
-  fi
-}
+# shellcheck source=_lib/assert.sh
+source "$SCRIPT_DIR/_lib/assert.sh"
 
 echo "=== Wiring: run_review.sh and action.yml ==="
 check "run_review validates VALIDATE_REQUIRED_CHECKS values" \

--- a/tests/test_review_escalation.sh
+++ b/tests/test_review_escalation.sh
@@ -18,22 +18,8 @@ RUN_REVIEW="$ROOT_DIR/scripts/run_review.sh"
 
 PASS=0
 FAIL=0
-check() {
-  local desc="$1" result="$2" expected="$3"
-  if [[ "$result" == "$expected" ]]; then
-    echo "  PASS: $desc"; PASS=$((PASS + 1))
-  else
-    echo "  FAIL: $desc (got '$result', expected '$expected')"; FAIL=$((FAIL + 1))
-  fi
-}
-check_contains() {
-  local desc="$1" haystack="$2" needle="$3"
-  if [[ "$haystack" == *"$needle"* ]]; then
-    echo "  PASS: $desc"; PASS=$((PASS + 1))
-  else
-    echo "  FAIL: $desc (expected to contain '$needle')"; FAIL=$((FAIL + 1))
-  fi
-}
+# shellcheck source=_lib/assert.sh
+source "$SCRIPT_DIR/_lib/assert.sh"
 
 SRC="$(cat "$RUN_REVIEW")"
 ACTION="$(cat "$ROOT_DIR/action.yml")"

--- a/tests/test_review_routing.sh
+++ b/tests/test_review_routing.sh
@@ -17,22 +17,8 @@ ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 PASS=0
 FAIL=0
-check() {
-  local desc="$1" result="$2" expected="$3"
-  if [[ "$result" == "$expected" ]]; then
-    echo "  PASS: $desc"; PASS=$((PASS + 1))
-  else
-    echo "  FAIL: $desc (got '$result', expected '$expected')"; FAIL=$((FAIL + 1))
-  fi
-}
-check_contains() {
-  local desc="$1" haystack="$2" needle="$3"
-  if [[ "$haystack" == *"$needle"* ]]; then
-    echo "  PASS: $desc"; PASS=$((PASS + 1))
-  else
-    echo "  FAIL: $desc (expected to contain '$needle')"; FAIL=$((FAIL + 1))
-  fi
-}
+# shellcheck source=_lib/assert.sh
+source "$SCRIPT_DIR/_lib/assert.sh"
 
 # Extract resolve_review_route from run_review.sh (same pattern as
 # test_context_budget.sh / test_classification_steering.sh).

--- a/tests/test_review_scope.sh
+++ b/tests/test_review_scope.sh
@@ -18,28 +18,8 @@ PRECHECK_SCRIPT="$ROOT_DIR/scripts/check_review_needed.sh"
 
 PASS=0
 FAIL=0
-
-check() {
-  local desc="$1" result="$2" expected="$3"
-  if [[ "$result" == "$expected" ]]; then
-    echo "  PASS: $desc"
-    PASS=$((PASS + 1))
-  else
-    echo "  FAIL: $desc (got '$result', expected '$expected')"
-    FAIL=$((FAIL + 1))
-  fi
-}
-
-check_contains() {
-  local desc="$1" haystack="$2" needle="$3"
-  if [[ "$haystack" == *"$needle"* ]]; then
-    echo "  PASS: $desc"
-    PASS=$((PASS + 1))
-  else
-    echo "  FAIL: $desc (expected to contain '$needle')"
-    FAIL=$((FAIL + 1))
-  fi
-}
+# shellcheck source=_lib/assert.sh
+source "$SCRIPT_DIR/_lib/assert.sh"
 
 # ── Setup ─────────────────────────────────────────────────────────────
 TMPDIR="$(mktemp -d)"

--- a/tests/test_standards_file_resolution.sh
+++ b/tests/test_standards_file_resolution.sh
@@ -12,6 +12,9 @@ fi
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
+# shellcheck source=_lib/assert.sh
+source "$SCRIPT_DIR/_lib/assert.sh"
+
 # Source just the resolve_standards_file function
 resolve_standards_file() {
   if [[ -n "$STANDARDS_FILE" && -f "$STANDARDS_FILE" ]]; then
@@ -38,17 +41,6 @@ resolve_standards_file() {
 
 PASS=0
 FAIL=0
-
-check() {
-  local desc="$1" result="$2" expected="$3"
-  if [[ "$result" == "$expected" ]]; then
-    echo "  PASS: $desc"
-    PASS=$((PASS + 1))
-  else
-    echo "  FAIL: $desc (got '$result', expected '$expected')"
-    FAIL=$((FAIL + 1))
-  fi
-}
 
 # ── Setup ─────────────────────────────────────────────────────────────
 TMPDIR="$(mktemp -d)"

--- a/tests/test_step_summary.sh
+++ b/tests/test_step_summary.sh
@@ -18,14 +18,8 @@ ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 PASS=0
 FAIL=0
-check() {
-  local desc="$1" result="$2" expected="$3"
-  if [[ "$result" == "$expected" ]]; then
-    echo "  PASS: $desc"; PASS=$((PASS + 1))
-  else
-    echo "  FAIL: $desc (got '$result', expected '$expected')"; FAIL=$((FAIL + 1))
-  fi
-}
+# shellcheck source=_lib/assert.sh
+source "$SCRIPT_DIR/_lib/assert.sh"
 
 FUNC="$(mktemp)"
 TMP="$(mktemp -d)"

--- a/tests/test_tool_harness_enforcement.sh
+++ b/tests/test_tool_harness_enforcement.sh
@@ -25,17 +25,9 @@ done
 
 PASS=0
 FAIL=0
-
-check() {
-  local desc="$1" result="$2" expected="$3"
-  if [[ "$result" == "$expected" ]]; then
-    echo "  PASS: $desc"
-    PASS=$((PASS + 1))
-  else
-    echo "  FAIL: $desc (got '$result', expected '$expected')"
-    FAIL=$((FAIL + 1))
-  fi
-}
+_TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=_lib/assert.sh
+source "$_TEST_DIR/_lib/assert.sh"
 
 TMPDIR="$(mktemp -d)"
 trap 'rm -rf "$TMPDIR"' EXIT

--- a/tests/test_tool_loop_wiring.sh
+++ b/tests/test_tool_loop_wiring.sh
@@ -17,14 +17,8 @@ ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 PASS=0
 FAIL=0
-check_contains() {
-  local desc="$1" haystack="$2" needle="$3"
-  if [[ "$haystack" == *"$needle"* ]]; then
-    echo "  PASS: $desc"; PASS=$((PASS + 1))
-  else
-    echo "  FAIL: $desc (expected to contain '$needle')"; FAIL=$((FAIL + 1))
-  fi
-}
+# shellcheck source=_lib/assert.sh
+source "$SCRIPT_DIR/_lib/assert.sh"
 
 SRC="$(cat "$ROOT_DIR/scripts/run_review.sh")"
 ACTION="$(cat "$ROOT_DIR/action.yml")"

--- a/tests/test_verdict_safety.sh
+++ b/tests/test_verdict_safety.sh
@@ -11,19 +11,11 @@ fi
 
 # Tests for PR verdict safety: incremental reviews require clean full baseline for approval
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PASS=0
 FAIL=0
-
-check() {
-  local desc="$1" result="$2" expected="$3"
-  if [[ "$result" == "$expected" ]]; then
-    echo "  PASS: $desc"
-    PASS=$((PASS + 1))
-  else
-    echo "  FAIL: $desc (got '$result', expected '$expected')"
-    FAIL=$((FAIL + 1))
-  fi
-}
+# shellcheck source=_lib/assert.sh
+source "$SCRIPT_DIR/_lib/assert.sh"
 
 # Core verdict safety evaluation extracted from action.yml publish_verdict step.
 evaluate_verdict_approval() {
@@ -94,17 +86,6 @@ check "INCREMENTAL scope not matched (case-sensitive)" "$result" "true"
 echo ""
 echo "=== action.yml integration checks ==="
 ACTION_YML="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/action.yml"
-
-check_exists() {
-  local desc="$1" count="$2"
-  if [[ "$count" -gt 0 ]]; then
-    echo "  PASS: $desc"
-    PASS=$((PASS + 1))
-  else
-    echo "  FAIL: $desc (expected to exist)"
-    FAIL=$((FAIL + 1))
-  fi
-}
 
 check_exists "action.yml has EFFECTIVE_SCOPE reference in verdict step" \
   "$(grep -c 'EFFECTIVE_SCOPE' "$ACTION_YML" || echo 0)"


### PR DESCRIPTION
Audit P2-3 (#299). Extracts the canonical bash test helpers (check / check_contains / check_not_contains / check_ne / check_exists) into `tests/_lib/assert.sh` and sources them from 19 suites that previously each defined their own drifting copies. Behavior byte-identical. Two suites keep inline helpers (deliberate signature/message differences, documented in the diff). Full sweep green — all 21 shell suites + pytest + smoke. Fixes #299.