### PR TITLE
refactor(publish)!: collapse 3 publish steps into one dispatcher (#303)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ The action collects rich PR context (diff, files, linked issues, version hints, 
 
 ### Action definition and orchestration
 
-- **`action.yml`** — Action definition with all inputs/outputs and composite run steps (precheck → CI wait → review → publish). The publish steps live inline in this file using helpers from `scripts/publish_helpers.sh`.
+- **`action.yml`** — Action definition with all inputs/outputs and composite run steps (precheck → CI wait → review → publish). Publishing is a single `Publish review` step with one superset `env:` block that dispatches on `$PUBLISH_MODE` (comment / review_comment / review_verdict), using helpers from `scripts/publish_helpers.sh`.
 - **`scripts/platform_api.sh`** — Platform seam (#221): every host-forge API call goes through `platform_*` functions (github backend = the exact pre-seam `gh` invocations; forgejo backend = `pr_reviewer/forgejo_backend.py`, rolling out across 1.4.x). `github_enrich_*` functions are for linked-source enrichment and always target github.com. `pr_reviewer/platform.py` is the Python mirror for script consumers.
 - **`scripts/check_review_needed.sh`** — Precheck: computes `git patch-id --stable` fingerprint, decides full vs. incremental scope, and skips if unchanged since last managed comment (unless `force_review=true`)
 - **Re-review trigger** — adding the `rereview_label` (default `ai-review`) to a PR forces a fresh review (`check_review_needed.sh` reads the `labeled` event from `GITHUB_EVENT_PATH`, sets `force_review`, and skips unrelated labels; the label is removed post-publish in `action.yml`). Labels are maintainer-only, so no command-auth gate is needed.

--- a/action.yml
+++ b/action.yml
@@ -804,8 +804,14 @@ runs:
         TOOL_EVIDENCE_MEMORY: ${{ inputs.tool_evidence_memory }}
       run: bash "${{ github.action_path }}/scripts/run_review.sh"
 
-    - name: Publish review comment
-      if: inputs.publish_review_comment == 'true' && steps.precheck.outputs.should_review == 'true' && inputs.publish_mode == 'comment'
+    - name: Publish review
+      # Single dispatcher for all three publish modes. One superset env block
+      # (harmless unused keys per mode) replaces the three near-duplicate
+      # blocks that drifted apart and broke v1.2.10 (#255, #303): a single
+      # block makes a duplicate-key manifest error structurally impossible.
+      # All per-mode inline `${{ }}` expressions are hoisted into env so the
+      # run body is pure bash dispatching on $PUBLISH_MODE.
+      if: steps.precheck.outputs.should_review == 'true' && (inputs.publish_mode == 'review_comment' || inputs.publish_mode == 'review_verdict' || (inputs.publish_mode == 'comment' && inputs.publish_review_comment == 'true'))
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.github_token }}
@@ -826,325 +832,281 @@ runs:
         TOOL_EVIDENCE_MEMORY: ${{ inputs.tool_evidence_memory }}
         ANALYSIS_ENGINE: ${{ steps.review.outputs.analysis_engine }}
         COMMENT_MARKER: ${{ inputs.comment_marker }}
-        GITHUB_ACTION_PATH: ${{ github.action_path }}
-      run: |
-        set -euo pipefail
-        source "${GITHUB_ACTION_PATH}/scripts/publish_helpers.sh"
-
-        # Sanitize model output
-        sanitize_review_markdown "review-markdown.raw.md"
-
-        # Validate PR number
-        validate_pr_number "review_comment"
-
-        # Resolve effective scope and review result
-        EFFECTIVE_SCOPE="${{ steps.precheck.outputs.effective_review_scope || 'full' }}"
-        REVIEW_RESULT="clean"
-        if [ "$VERDICT" = "request_changes" ]; then
-          REVIEW_RESULT="issues"
-        fi
-
-        # Build metadata marker
-        METADATA_MARKER="$(build_metadata_marker "${{ github.event.pull_request.base.sha || steps.precheck.outputs.base_sha }}" "${{ steps.precheck.outputs.previous_head_sha || '' }}")"
-
-        if [ "$VERDICT" = "request_changes" ]; then
-          VERDICT_PREFIX="⚠️ **Automated recommendation: REQUEST CHANGES**"
-        else
-          VERDICT_PREFIX="✅ **Automated recommendation: APPROVE**"
-        fi
-        if [ "$EFFECTIVE_SCOPE" = "incremental" ]; then
-          VERDICT_PREFIX="$VERDICT_PREFIX (incremental)"
-        fi
-
-        {
-          emit_review_markers
-          echo "$VERDICT_PREFIX"
-          echo
-          printf '_Analysis engine: %s_\n' "$ANALYSIS_ENGINE"
-          echo
-          cat review-markdown.raw.md
-        } > review-comment.md
-
-        platform_comment_sticky "$REPO" "$PR_NUMBER" review-comment.md
-
-    - name: Publish review comment (non-blocking)
-      if: inputs.publish_mode == 'review_comment' && steps.precheck.outputs.should_review == 'true'
-      shell: bash
-      env:
-        GH_TOKEN: ${{ inputs.github_token }}
-        PLATFORM: ${{ inputs.platform }}
-        FORGEJO_API_URL: ${{ inputs.forgejo_api_url || (github.server_url != 'https://github.com' && github.server_url) || '' }}
-        FORGEJO_TOKEN: ${{ inputs.forgejo_token || inputs.github_token }}
-        REPO: ${{ inputs.repo || github.repository }}
-        PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
-        HEAD_SHA: ${{ github.event.pull_request.head.sha || steps.precheck.outputs.head_sha }}
-        VERDICT: ${{ steps.review.outputs.verdict }}
-        REQUIRED_CHECKS: ${{ steps.review.outputs.required_checks }}
-        REVIEW_ROUTE: ${{ steps.review.outputs.review_route }}
-        ESCALATION_REASON: ${{ steps.review.outputs.escalation_reason }}
-        REVIEW_MARKDOWN: ${{ steps.review.outputs.review_markdown }}
-        FINDINGS: ${{ steps.review.outputs.findings }}
-        EVIDENCE_DIGEST: ${{ steps.review.outputs.evidence_digest }}
-        TOOL_EVIDENCE_MEMORY: ${{ inputs.tool_evidence_memory }}
         INLINE_FINDINGS: ${{ inputs.inline_findings }}
         INLINE_FINDINGS_MAX: ${{ inputs.inline_findings_max }}
-        ANALYSIS_ENGINE: ${{ steps.review.outputs.analysis_engine }}
-        COMMENT_MARKER: ${{ inputs.comment_marker }}
-        BROAD_FINGERPRINT: ${{ steps.precheck.outputs.diff_fingerprint }}
         CLEANUP_PREVIOUS_NATIVE_REVIEWS: ${{ inputs.cleanup_previous_native_reviews }}
-        GITHUB_ACTION_PATH: ${{ github.action_path }}
-      run: |
-        set -euo pipefail
-        source "${GITHUB_ACTION_PATH}/scripts/publish_helpers.sh"
-
-        # Sanitize model output
-        sanitize_review_markdown "review-comment-markdown.raw.md"
-
-        # Validate PR number
-        validate_pr_number "mode=review_comment"
-
-        # Resolve cleanup flag and execute cleanup
-        CLEANUP_NATIVE_REVIEWS="$(resolve_cleanup_flag "${CLEANUP_PREVIOUS_NATIVE_REVIEWS:-auto}" "review_comment")"
-        cleanup_native_reviews "$CLEANUP_NATIVE_REVIEWS"
-
-        # Resolve effective scope and review result
-        EFFECTIVE_SCOPE="${{ steps.precheck.outputs.effective_review_scope || 'full' }}"
-        REVIEW_RESULT="clean"
-        if [ "$VERDICT" = "request_changes" ]; then
-          REVIEW_RESULT="issues"
-        fi
-
-        # Build metadata marker
-        METADATA_MARKER="$(build_metadata_marker "${{ github.event.pull_request.base.sha || steps.precheck.outputs.base_sha }}" "")"
-        REVIEW_HEADER="# AI Automated Review"
-        if [ "$EFFECTIVE_SCOPE" = "incremental" ]; then
-          REVIEW_HEADER="# AI Automated Review (incremental)"
-        fi
-
-        # Build the review body with managed marker
-        BODY_FILE="review-comment-body.md"
-        {
-          emit_review_markers
-          echo "$REVIEW_HEADER"
-          echo
-          printf '_Analysis engine: %s_\n' "$ANALYSIS_ENGINE"
-          echo
-          cat review-comment-markdown.raw.md
-        } > "$BODY_FILE"
-
-        if [ "$VERDICT" = "request_changes" ]; then
-          echo "Submitting non-blocking review comment (request_changes) for #$PR_NUMBER"
-        else
-          echo "Submitting non-blocking review comment (approve) for #$PR_NUMBER"
-        fi
-
-        # NOTE: gh pr review --comment creates a COMMENTED review that is NOT visible in the PR UI timeline.
-        # Use gh pr comment instead for visibility, with --edit-last/--create-if-none for sticky behavior.
-        platform_comment_sticky "$REPO" "$PR_NUMBER" "$BODY_FILE"
-
-        # Resolve threads of carried findings this review verified as fixed,
-        # and reply on threads still open (#208, #209). Must precede the
-        # comment build so finding-threads.json suppresses duplicates.
-        resolve_finding_threads
-
-        # Optionally attach line-anchored inline comments from the structured
-        # findings as a separate native COMMENT review. It carries the managed
-        # marker so the next run's cleanup marks it superseded. Best-effort:
-        # the summary comment above is already published.
-        if [ "$(printf '%s' "${INLINE_FINDINGS:-false}" | tr '[:upper:]' '[:lower:]')" = "true" ] && [ -n "${FINDINGS:-}" ]; then
-          printf '%s' "$FINDINGS" > findings.json
-          COMMENTS_JSON="[]"
-          if SUPPRESS_FINDINGS_FILE=finding-threads.json INLINE_FINDINGS_MAX="${INLINE_FINDINGS_MAX:-20}" python3 "${GITHUB_ACTION_PATH}/scripts/build_review_comments.py" findings.json pr.diff review-comments.json; then
-            COMMENTS_JSON="$(cat review-comments.json)"
-          fi
-          if [ -n "$COMMENTS_JSON" ] && [ "$COMMENTS_JSON" != "[]" ]; then
-            {
-              echo "$COMMENT_MARKER"
-              echo "_Inline findings from the automated review (summary in the sticky comment)._"
-            } > inline-findings-body.md
-            jq -n --rawfile body inline-findings-body.md --argjson comments "$COMMENTS_JSON" \
-              '{body: $body, event: "COMMENT", comments: $comments}' > review-request.json
-            if platform_review_create_json "$REPO" "$PR_NUMBER" review-request.json >/dev/null 2>&1; then
-              echo "Attached $(printf '%s' "$COMMENTS_JSON" | jq 'length') inline finding comment(s)"
-            else
-              echo "WARN: inline findings review submission failed; summary comment was still published" >&2
-            fi
-          fi
-        fi
-
-    - name: Publish review verdict (native PR review)
-      if: inputs.publish_mode == 'review_verdict' && steps.precheck.outputs.should_review == 'true'
-      shell: bash
-      env:
-        GH_TOKEN: ${{ inputs.github_token }}
-        PLATFORM: ${{ inputs.platform }}
-        FORGEJO_API_URL: ${{ inputs.forgejo_api_url || (github.server_url != 'https://github.com' && github.server_url) || '' }}
-        FORGEJO_TOKEN: ${{ inputs.forgejo_token || inputs.github_token }}
-        REPO: ${{ inputs.repo || github.repository }}
-        PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
-        HEAD_SHA: ${{ github.event.pull_request.head.sha || steps.precheck.outputs.head_sha }}
-        VERDICT: ${{ steps.review.outputs.verdict }}
-        REQUIRED_CHECKS: ${{ steps.review.outputs.required_checks }}
-        REVIEW_ROUTE: ${{ steps.review.outputs.review_route }}
-        ESCALATION_REASON: ${{ steps.review.outputs.escalation_reason }}
-        REVIEW_MARKDOWN: ${{ steps.review.outputs.review_markdown }}
-        FINDINGS: ${{ steps.review.outputs.findings }}
-        EVIDENCE_DIGEST: ${{ steps.review.outputs.evidence_digest }}
-        TOOL_EVIDENCE_MEMORY: ${{ inputs.tool_evidence_memory }}
-        INLINE_FINDINGS: ${{ inputs.inline_findings }}
-        INLINE_FINDINGS_MAX: ${{ inputs.inline_findings_max }}
-        ANALYSIS_ENGINE: ${{ steps.review.outputs.analysis_engine }}
         ALLOW_APPROVE: ${{ inputs.allow_approve }}
         APPROVE_FORKS: ${{ inputs.approve_forks }}
-        COMMENT_MARKER: ${{ inputs.comment_marker }}
-        BROAD_FINGERPRINT: ${{ steps.precheck.outputs.diff_fingerprint }}
-        CLEANUP_PREVIOUS_NATIVE_REVIEWS: ${{ inputs.cleanup_previous_native_reviews }}
+        PUBLISH_MODE: ${{ inputs.publish_mode }}
+        EFFECTIVE_SCOPE: ${{ steps.precheck.outputs.effective_review_scope || 'full' }}
+        BASE_SHA: ${{ github.event.pull_request.base.sha || steps.precheck.outputs.base_sha }}
+        PREVIOUS_HEAD_SHA: ${{ steps.precheck.outputs.previous_head_sha || '' }}
+        IS_FORK_PR: ${{ steps.precheck.outputs.is_fork_pr }}
+        BASELINE_CLEAN: ${{ steps.precheck.outputs.baseline_clean || 'false' }}
         GITHUB_ACTION_PATH: ${{ github.action_path }}
       run: |
         set -euo pipefail
         source "${GITHUB_ACTION_PATH}/scripts/publish_helpers.sh"
 
-        # Sanitize model output
-        sanitize_review_markdown "review-verdict-markdown.raw.md"
+        case "$PUBLISH_MODE" in
+          comment)
+            # Sanitize model output
+            sanitize_review_markdown "review-markdown.raw.md"
 
-        # Validate PR number
-        validate_pr_number "mode=review_verdict"
+            # Validate PR number
+            validate_pr_number "review_comment"
 
-        # Resolve cleanup flag and execute cleanup
-        CLEANUP_NATIVE_REVIEWS="$(resolve_cleanup_flag "${CLEANUP_PREVIOUS_NATIVE_REVIEWS:-auto}" "review_verdict")"
-        cleanup_native_reviews "$CLEANUP_NATIVE_REVIEWS"
-
-        # Determine if the PR is from a fork. The precheck step already fetched
-        # the PR object; only fall back to the API when its output is missing.
-        IS_FORK_PR="${{ steps.precheck.outputs.is_fork_pr }}"
-        if [ -z "$IS_FORK_PR" ]; then
-          IS_FORK_PR="$(platform_pr_get "$REPO" "$PR_NUMBER" --jq '((.head.repo.full_name // "") != (.base.repo.full_name // ""))' 2>/dev/null || echo false)"
-        fi
-
-        # Resolve effective scope and review result
-        EFFECTIVE_SCOPE="${{ steps.precheck.outputs.effective_review_scope || 'full' }}"
-        PREVIOUS_HEAD_SHA="${{ steps.precheck.outputs.previous_head_sha || '' }}"
-        BASELINE_CLEAN="${{ steps.precheck.outputs.baseline_clean || 'false' }}"
-        REVIEW_RESULT="clean"
-        if [ "$VERDICT" = "request_changes" ]; then
-          REVIEW_RESULT="issues"
-        fi
-
-        # Build metadata marker with verdict safety for incremental
-        METADATA_MARKER="$(build_metadata_marker "${{ github.event.pull_request.base.sha || steps.precheck.outputs.base_sha }}" "$PREVIOUS_HEAD_SHA")"
-        REVIEW_HEADER="# AI Automated Review"
-        if [ "$EFFECTIVE_SCOPE" = "incremental" ]; then
-          REVIEW_HEADER="# AI Automated Review (incremental)"
-        fi
-
-        # Evaluate approval guardrails with baseline check for incremental
-        ALLOW_APPROVE_BOOL="$(printf '%s' "$ALLOW_APPROVE" | tr '[:upper:]' '[:lower:]')"
-        APPROVE_FORKS_BOOL="$(printf '%s' "$APPROVE_FORKS" | tr '[:upper:]' '[:lower:]')"
-
-        CAN_APPROVE=false
-
-        if [ "$VERDICT" = "approve" ] && [ "$ALLOW_APPROVE_BOOL" = "true" ]; then
-          # For incremental reviews, require a trusted clean full baseline
-          if [ "$EFFECTIVE_SCOPE" = "incremental" ] && [ "$BASELINE_CLEAN" != "true" ]; then
-            echo "Blocking approval: incremental review without trusted clean full baseline" >&2
-            CAN_APPROVE=false
-          else
-            # Check fork gate
-            if [ "$IS_FORK_PR" != "true" ]; then
-              CAN_APPROVE=true
-            elif [ "$APPROVE_FORKS_BOOL" = "true" ]; then
-              CAN_APPROVE=true
+            # Resolve review result
+            REVIEW_RESULT="clean"
+            if [ "$VERDICT" = "request_changes" ]; then
+              REVIEW_RESULT="issues"
             fi
-          fi
-        fi
 
-        # Build the review body with managed marker
-        BODY_FILE="review-verdict-body.md"
-        {
-          emit_review_markers
-          echo "$REVIEW_HEADER"
-          echo
-          if [ "$EFFECTIVE_SCOPE" = "incremental" ]; then
-            echo "_Incremental review: reviewed the changes since the last managed review; unresolved findings from that review are carried forward._"
-          else
-            echo "_Full PR review._"
-          fi
-          echo
-          printf '_Analysis engine: %s_\n' "$ANALYSIS_ENGINE"
-          echo
-          cat review-verdict-markdown.raw.md
-        } > "$BODY_FILE"
+            # Build metadata marker
+            METADATA_MARKER="$(build_metadata_marker "$BASE_SHA" "$PREVIOUS_HEAD_SHA")"
 
-        # Resolve threads of carried findings this review verified as fixed,
-        # and reply on threads still open (#208, #209). Must precede the
-        # comment build so finding-threads.json suppresses duplicates.
-        resolve_finding_threads
-
-        # Build line-anchored inline comments from the structured findings
-        # when enabled. Anchors are validated against pr.diff (written by the
-        # review step); non-anchorable findings stay in the body only.
-        COMMENTS_JSON="[]"
-        if [ "$(printf '%s' "${INLINE_FINDINGS:-false}" | tr '[:upper:]' '[:lower:]')" = "true" ] && [ -n "${FINDINGS:-}" ]; then
-          printf '%s' "$FINDINGS" > findings.json
-          if SUPPRESS_FINDINGS_FILE=finding-threads.json INLINE_FINDINGS_MAX="${INLINE_FINDINGS_MAX:-20}" python3 "${GITHUB_ACTION_PATH}/scripts/build_review_comments.py" findings.json pr.diff review-comments.json; then
-            COMMENTS_JSON="$(cat review-comments.json)"
-          fi
-        fi
-
-        # Submit the native review, attaching inline comments when present.
-        # If GitHub rejects the comments payload (e.g. an anchor raced a new
-        # push), fall back to the plain review so publishing never breaks
-        # because of inline findings.
-        submit_native_review() {
-          local event="$1" body_file="$2"
-          if [ -n "$COMMENTS_JSON" ] && [ "$COMMENTS_JSON" != "[]" ]; then
-            jq -n --rawfile body "$body_file" --arg event "$event" --argjson comments "$COMMENTS_JSON" \
-              '{body: $body, event: $event, comments: $comments}' > review-request.json
-            if platform_review_create_json "$REPO" "$PR_NUMBER" review-request.json >/dev/null 2>&1; then
-              echo "Submitted native review ($event) with $(printf '%s' "$COMMENTS_JSON" | jq 'length') inline comment(s)"
-              return 0
-            fi
-            echo "WARN: inline-comment review submission failed; falling back to plain review" >&2
-          fi
-          case "$event" in
-            APPROVE) platform_review_native "$REPO" "$PR_NUMBER" APPROVE "$body_file" ;;
-            *) platform_review_native "$REPO" "$PR_NUMBER" REQUEST_CHANGES "$body_file" ;;
-          esac
-        }
-
-        if [ "$CAN_APPROVE" = true ]; then
-          echo "Submitting native approval for #$PR_NUMBER"
-          if ! submit_native_review APPROVE "$BODY_FILE" 2>&1; then
-            echo "ERROR: Native approval failed for #$PR_NUMBER." >&2
-            echo "This may be caused by the 'Allow GitHub Actions to create and approve pull requests' setting being disabled." >&2
-            echo "Enable this setting at: Repository Settings → Actions → General → Allow GitHub Actions to create and approve pull requests" >&2
-            echo "Or at the organization level: Organization Settings → Actions → Organization permissions → Allow GitHub Actions to create and approve pull requests" >&2
-            exit 1
-          fi
-        else
-          # Block approval: submit request_changes with explanation
-          echo "Blocking native approval for #$PR_NUMBER (allow_approve=${ALLOW_APPROVE_BOOL}, approve_forks=${APPROVE_FORKS_BOOL}, is_fork=${IS_FORK_PR})"
-
-          if [ "$VERDICT" = "request_changes" ]; then
-            submit_native_review REQUEST_CHANGES "$BODY_FILE"
-          else
-            # The review approved but a guardrail blocked native approval —
-            # explain the actual reason.
-            if [ "$EFFECTIVE_SCOPE" = "incremental" ] && [ "$BASELINE_CLEAN" != "true" ]; then
-              {
-                echo ""
-                echo "> **Approval withheld**: the previous review of this PR found blocking issues. This review's verdict is approve, but native approval is withheld until a review against a clean baseline confirms the PR as a whole."
-              } >> "$BODY_FILE"
+            if [ "$VERDICT" = "request_changes" ]; then
+              VERDICT_PREFIX="⚠️ **Automated recommendation: REQUEST CHANGES**"
             else
-              {
-                echo ""
-                echo "> **Approval blocked by policy**: native approvals require \`allow_approve: true\` (and \`approve_forks: true\` for cross-repository PRs)."
-              } >> "$BODY_FILE"
+              VERDICT_PREFIX="✅ **Automated recommendation: APPROVE**"
+            fi
+            if [ "$EFFECTIVE_SCOPE" = "incremental" ]; then
+              VERDICT_PREFIX="$VERDICT_PREFIX (incremental)"
             fi
 
-            submit_native_review REQUEST_CHANGES "$BODY_FILE"
-          fi
-        fi
+            {
+              emit_review_markers
+              echo "$VERDICT_PREFIX"
+              echo
+              printf '_Analysis engine: %s_\n' "$ANALYSIS_ENGINE"
+              echo
+              cat review-markdown.raw.md
+            } > review-comment.md
+
+            platform_comment_sticky "$REPO" "$PR_NUMBER" review-comment.md
+            ;;
+
+          review_comment)
+            # Sanitize model output
+            sanitize_review_markdown "review-comment-markdown.raw.md"
+
+            # Validate PR number
+            validate_pr_number "mode=review_comment"
+
+            # Resolve cleanup flag and execute cleanup
+            CLEANUP_NATIVE_REVIEWS="$(resolve_cleanup_flag "${CLEANUP_PREVIOUS_NATIVE_REVIEWS:-auto}" "review_comment")"
+            cleanup_native_reviews "$CLEANUP_NATIVE_REVIEWS"
+
+            # Resolve review result
+            REVIEW_RESULT="clean"
+            if [ "$VERDICT" = "request_changes" ]; then
+              REVIEW_RESULT="issues"
+            fi
+
+            # Build metadata marker
+            METADATA_MARKER="$(build_metadata_marker "$BASE_SHA" "")"
+            REVIEW_HEADER="# AI Automated Review"
+            if [ "$EFFECTIVE_SCOPE" = "incremental" ]; then
+              REVIEW_HEADER="# AI Automated Review (incremental)"
+            fi
+
+            # Build the review body with managed marker
+            BODY_FILE="review-comment-body.md"
+            {
+              emit_review_markers
+              echo "$REVIEW_HEADER"
+              echo
+              printf '_Analysis engine: %s_\n' "$ANALYSIS_ENGINE"
+              echo
+              cat review-comment-markdown.raw.md
+            } > "$BODY_FILE"
+
+            if [ "$VERDICT" = "request_changes" ]; then
+              echo "Submitting non-blocking review comment (request_changes) for #$PR_NUMBER"
+            else
+              echo "Submitting non-blocking review comment (approve) for #$PR_NUMBER"
+            fi
+
+            # NOTE: gh pr review --comment creates a COMMENTED review that is NOT visible in the PR UI timeline.
+            # Use gh pr comment instead for visibility, with --edit-last/--create-if-none for sticky behavior.
+            platform_comment_sticky "$REPO" "$PR_NUMBER" "$BODY_FILE"
+
+            # Resolve threads of carried findings this review verified as fixed,
+            # and reply on threads still open (#208, #209). Must precede the
+            # comment build so finding-threads.json suppresses duplicates.
+            resolve_finding_threads
+
+            # Optionally attach line-anchored inline comments from the structured
+            # findings as a separate native COMMENT review. It carries the managed
+            # marker so the next run's cleanup marks it superseded. Best-effort:
+            # the summary comment above is already published.
+            if [ "$(printf '%s' "${INLINE_FINDINGS:-false}" | tr '[:upper:]' '[:lower:]')" = "true" ] && [ -n "${FINDINGS:-}" ]; then
+              printf '%s' "$FINDINGS" > findings.json
+              COMMENTS_JSON="[]"
+              if SUPPRESS_FINDINGS_FILE=finding-threads.json INLINE_FINDINGS_MAX="${INLINE_FINDINGS_MAX:-20}" python3 "${GITHUB_ACTION_PATH}/scripts/build_review_comments.py" findings.json pr.diff review-comments.json; then
+                COMMENTS_JSON="$(cat review-comments.json)"
+              fi
+              if [ -n "$COMMENTS_JSON" ] && [ "$COMMENTS_JSON" != "[]" ]; then
+                {
+                  echo "$COMMENT_MARKER"
+                  echo "_Inline findings from the automated review (summary in the sticky comment)._"
+                } > inline-findings-body.md
+                jq -n --rawfile body inline-findings-body.md --argjson comments "$COMMENTS_JSON" \
+                  '{body: $body, event: "COMMENT", comments: $comments}' > review-request.json
+                if platform_review_create_json "$REPO" "$PR_NUMBER" review-request.json >/dev/null 2>&1; then
+                  echo "Attached $(printf '%s' "$COMMENTS_JSON" | jq 'length') inline finding comment(s)"
+                else
+                  echo "WARN: inline findings review submission failed; summary comment was still published" >&2
+                fi
+              fi
+            fi
+            ;;
+
+          review_verdict)
+            # Sanitize model output
+            sanitize_review_markdown "review-verdict-markdown.raw.md"
+
+            # Validate PR number
+            validate_pr_number "mode=review_verdict"
+
+            # Resolve cleanup flag and execute cleanup
+            CLEANUP_NATIVE_REVIEWS="$(resolve_cleanup_flag "${CLEANUP_PREVIOUS_NATIVE_REVIEWS:-auto}" "review_verdict")"
+            cleanup_native_reviews "$CLEANUP_NATIVE_REVIEWS"
+
+            # Determine if the PR is from a fork. The precheck step already fetched
+            # the PR object; only fall back to the API when its output is missing.
+            if [ -z "$IS_FORK_PR" ]; then
+              IS_FORK_PR="$(platform_pr_get "$REPO" "$PR_NUMBER" --jq '((.head.repo.full_name // "") != (.base.repo.full_name // ""))' 2>/dev/null || echo false)"
+            fi
+
+            # Resolve review result
+            REVIEW_RESULT="clean"
+            if [ "$VERDICT" = "request_changes" ]; then
+              REVIEW_RESULT="issues"
+            fi
+
+            # Build metadata marker with verdict safety for incremental
+            METADATA_MARKER="$(build_metadata_marker "$BASE_SHA" "$PREVIOUS_HEAD_SHA")"
+            REVIEW_HEADER="# AI Automated Review"
+            if [ "$EFFECTIVE_SCOPE" = "incremental" ]; then
+              REVIEW_HEADER="# AI Automated Review (incremental)"
+            fi
+
+            # Evaluate approval guardrails with baseline check for incremental
+            ALLOW_APPROVE_BOOL="$(printf '%s' "$ALLOW_APPROVE" | tr '[:upper:]' '[:lower:]')"
+            APPROVE_FORKS_BOOL="$(printf '%s' "$APPROVE_FORKS" | tr '[:upper:]' '[:lower:]')"
+
+            CAN_APPROVE=false
+
+            if [ "$VERDICT" = "approve" ] && [ "$ALLOW_APPROVE_BOOL" = "true" ]; then
+              # For incremental reviews, require a trusted clean full baseline
+              if [ "$EFFECTIVE_SCOPE" = "incremental" ] && [ "$BASELINE_CLEAN" != "true" ]; then
+                echo "Blocking approval: incremental review without trusted clean full baseline" >&2
+                CAN_APPROVE=false
+              else
+                # Check fork gate
+                if [ "$IS_FORK_PR" != "true" ]; then
+                  CAN_APPROVE=true
+                elif [ "$APPROVE_FORKS_BOOL" = "true" ]; then
+                  CAN_APPROVE=true
+                fi
+              fi
+            fi
+
+            # Build the review body with managed marker
+            BODY_FILE="review-verdict-body.md"
+            {
+              emit_review_markers
+              echo "$REVIEW_HEADER"
+              echo
+              if [ "$EFFECTIVE_SCOPE" = "incremental" ]; then
+                echo "_Incremental review: reviewed the changes since the last managed review; unresolved findings from that review are carried forward._"
+              else
+                echo "_Full PR review._"
+              fi
+              echo
+              printf '_Analysis engine: %s_\n' "$ANALYSIS_ENGINE"
+              echo
+              cat review-verdict-markdown.raw.md
+            } > "$BODY_FILE"
+
+            # Resolve threads of carried findings this review verified as fixed,
+            # and reply on threads still open (#208, #209). Must precede the
+            # comment build so finding-threads.json suppresses duplicates.
+            resolve_finding_threads
+
+            # Build line-anchored inline comments from the structured findings
+            # when enabled. Anchors are validated against pr.diff (written by the
+            # review step); non-anchorable findings stay in the body only.
+            COMMENTS_JSON="[]"
+            if [ "$(printf '%s' "${INLINE_FINDINGS:-false}" | tr '[:upper:]' '[:lower:]')" = "true" ] && [ -n "${FINDINGS:-}" ]; then
+              printf '%s' "$FINDINGS" > findings.json
+              if SUPPRESS_FINDINGS_FILE=finding-threads.json INLINE_FINDINGS_MAX="${INLINE_FINDINGS_MAX:-20}" python3 "${GITHUB_ACTION_PATH}/scripts/build_review_comments.py" findings.json pr.diff review-comments.json; then
+                COMMENTS_JSON="$(cat review-comments.json)"
+              fi
+            fi
+
+            # Submit the native review, attaching inline comments when present.
+            # If GitHub rejects the comments payload (e.g. an anchor raced a new
+            # push), fall back to the plain review so publishing never breaks
+            # because of inline findings.
+            submit_native_review() {
+              local event="$1" body_file="$2"
+              if [ -n "$COMMENTS_JSON" ] && [ "$COMMENTS_JSON" != "[]" ]; then
+                jq -n --rawfile body "$body_file" --arg event "$event" --argjson comments "$COMMENTS_JSON" \
+                  '{body: $body, event: $event, comments: $comments}' > review-request.json
+                if platform_review_create_json "$REPO" "$PR_NUMBER" review-request.json >/dev/null 2>&1; then
+                  echo "Submitted native review ($event) with $(printf '%s' "$COMMENTS_JSON" | jq 'length') inline comment(s)"
+                  return 0
+                fi
+                echo "WARN: inline-comment review submission failed; falling back to plain review" >&2
+              fi
+              case "$event" in
+                APPROVE) platform_review_native "$REPO" "$PR_NUMBER" APPROVE "$body_file" ;;
+                *) platform_review_native "$REPO" "$PR_NUMBER" REQUEST_CHANGES "$body_file" ;;
+              esac
+            }
+
+            if [ "$CAN_APPROVE" = true ]; then
+              echo "Submitting native approval for #$PR_NUMBER"
+              if ! submit_native_review APPROVE "$BODY_FILE" 2>&1; then
+                echo "ERROR: Native approval failed for #$PR_NUMBER." >&2
+                echo "This may be caused by the 'Allow GitHub Actions to create and approve pull requests' setting being disabled." >&2
+                echo "Enable this setting at: Repository Settings → Actions → General → Allow GitHub Actions to create and approve pull requests" >&2
+                echo "Or at the organization level: Organization Settings → Actions → Organization permissions → Allow GitHub Actions to create and approve pull requests" >&2
+                exit 1
+              fi
+            else
+              # Block approval: submit request_changes with explanation
+              echo "Blocking native approval for #$PR_NUMBER (allow_approve=${ALLOW_APPROVE_BOOL}, approve_forks=${APPROVE_FORKS_BOOL}, is_fork=${IS_FORK_PR})"
+
+              if [ "$VERDICT" = "request_changes" ]; then
+                submit_native_review REQUEST_CHANGES "$BODY_FILE"
+              else
+                # The review approved but a guardrail blocked native approval —
+                # explain the actual reason.
+                if [ "$EFFECTIVE_SCOPE" = "incremental" ] && [ "$BASELINE_CLEAN" != "true" ]; then
+                  {
+                    echo ""
+                    echo "> **Approval withheld**: the previous review of this PR found blocking issues. This review's verdict is approve, but native approval is withheld until a review against a clean baseline confirms the PR as a whole."
+                  } >> "$BODY_FILE"
+                else
+                  {
+                    echo ""
+                    echo "> **Approval blocked by policy**: native approvals require \`allow_approve: true\` (and \`approve_forks: true\` for cross-repository PRs)."
+                  } >> "$BODY_FILE"
+                fi
+
+                submit_native_review REQUEST_CHANGES "$BODY_FILE"
+              fi
+            fi
+            ;;
+
+          *)
+            echo "Unknown publish_mode: $PUBLISH_MODE" >&2
+            exit 1
+            ;;
+        esac
 
     - name: Clear re-review label
       # When a label add triggered this review, remove it so re-adding the

--- a/tests/test_approval_guardrails.sh
+++ b/tests/test_approval_guardrails.sh
@@ -93,8 +93,10 @@ check_contains "publish_mode default is comment" \
 check_contains "allow_approve default is false" \
   "$(cat "$ACTION_YML")" "default: \"false\""
 
-check_exists "action.yml has native review step" \
-  "$(grep -c 'Publish review verdict' "$ACTION_YML" || echo 0)"
+check_exists "action.yml has the publish dispatcher step" \
+  "$(grep -c '^    - name: Publish review$' "$ACTION_YML" || echo 0)"
+check_exists "action.yml dispatches the review_verdict publish mode" \
+  "$(grep -c '^          review_verdict)' "$ACTION_YML" || echo 0)"
 
 # The native-review invocations route through the platform seam (#221):
 # action.yml calls platform_review_native, whose github backend holds the

--- a/tests/test_build_review_comments.py
+++ b/tests/test_build_review_comments.py
@@ -299,11 +299,13 @@ class TestActionWiring:
         assert "inline_findings_max:" in self.ACTION
 
     def test_all_publish_steps_receive_findings(self):
-        # All three publish steps (comment, review_comment, review_verdict)
-        # must receive FINDINGS so build_metadata_marker persists
-        # open_findings — without it, carry-forward never engages.
-        assert self.ACTION.count("FINDINGS: ${{ steps.review.outputs.findings }}") == 3
-        assert self.ACTION.count("INLINE_FINDINGS: ${{ inputs.inline_findings }}") == 2
+        # The single publish dispatcher (#303) carries one superset env block
+        # serving all three modes (comment, review_comment, review_verdict), so
+        # FINDINGS/INLINE_FINDINGS each appear once. FINDINGS lets
+        # build_metadata_marker persist open_findings — without it,
+        # carry-forward never engages.
+        assert self.ACTION.count("FINDINGS: ${{ steps.review.outputs.findings }}") == 1
+        assert self.ACTION.count("INLINE_FINDINGS: ${{ inputs.inline_findings }}") == 1
 
     def test_review_verdict_falls_back_on_failure(self):
         assert "falling back to plain review" in self.ACTION

--- a/tests/test_cleanup_previous_native_reviews.sh
+++ b/tests/test_cleanup_previous_native_reviews.sh
@@ -124,20 +124,25 @@ echo "=== Review body marker validation ==="
 
 ACTION_YML="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/action.yml"
 
-# Check that native review bodies include the ai-pr-reviewer marker
-BODY_CONTENT_REVIEW_COMMENT=$(awk '/Publish review comment \(non-blocking\)/,/^    - name: Publish review verdict/' "$ACTION_YML")
-BODY_CONTENT_REVIEW_VERDICT=$(awk '/Publish review verdict/,0' "$ACTION_YML")
+# The three publish modes are now case arms inside a single "Publish review"
+# dispatcher step (#303): one superset env block, dispatching on $PUBLISH_MODE.
+# Extract each arm by its case label so the per-mode assertions still target
+# the right body.
+PUBLISH_STEP_BODY=$(awk '/^    - name: Publish review$/,/^    - name: Clear re-review label/' "$ACTION_YML")
+STICKY_COMMENT_BODY=$(awk '/^          comment\)/,/^          review_comment\)/' "$ACTION_YML")
+BODY_CONTENT_REVIEW_COMMENT=$(awk '/^          review_comment\)/,/^          review_verdict\)/' "$ACTION_YML")
+BODY_CONTENT_REVIEW_VERDICT=$(awk '/^          review_verdict\)/,/^          \*\)/' "$ACTION_YML")
 
-check_contains "review_comment step uses METADATA_MARKER in body" \
+check_contains "review_comment arm uses METADATA_MARKER in body" \
   "$BODY_CONTENT_REVIEW_COMMENT" "METADATA_MARKER"
 
-check_contains "review_verdict step uses METADATA_MARKER in body" \
+check_contains "review_verdict arm uses METADATA_MARKER in body" \
   "$BODY_CONTENT_REVIEW_VERDICT" "METADATA_MARKER"
 
-# Check that review_comment body does NOT have the marker in the sticky comment mode (comment mode)
-STICKY_COMMENT_BODY=$(awk '/Publish review comment$/,/^    - name: Publish review comment \(non-blocking\)/' "$ACTION_YML")
-check_contains "sticky comment mode uses COMMENT_MARKER variable" \
-  "$STICKY_COMMENT_BODY" "COMMENT_MARKER"
+# The dispatcher wires COMMENT_MARKER into its (shared) env block; every arm
+# emits it through emit_review_markers (asserted below).
+check_contains "publish step wires COMMENT_MARKER in env" \
+  "$PUBLISH_STEP_BODY" "COMMENT_MARKER:"
 
 # Every published body must emit the marker preamble (sticky COMMENT_MARKER +
 # METADATA_MARKER + head-sha + fingerprint) so the precheck can find prior
@@ -145,11 +150,11 @@ check_contains "sticky comment mode uses COMMENT_MARKER variable" \
 # (regression guard). The preamble is emitted via emit_review_markers
 # (publish_helpers.sh); its exact content and ordering are asserted in
 # tests/test_emit_review_markers.sh.
-check_contains "sticky comment body emits markers via emit_review_markers" \
+check_contains "sticky comment arm emits markers via emit_review_markers" \
   "$STICKY_COMMENT_BODY" "emit_review_markers"
-check_contains "review_comment body emits markers via emit_review_markers" \
+check_contains "review_comment arm emits markers via emit_review_markers" \
   "$BODY_CONTENT_REVIEW_COMMENT" "emit_review_markers"
-check_contains "review_verdict body emits markers via emit_review_markers" \
+check_contains "review_verdict arm emits markers via emit_review_markers" \
   "$BODY_CONTENT_REVIEW_VERDICT" "emit_review_markers"
 
 echo ""
@@ -178,26 +183,21 @@ check_contains "helper contains build_metadata_marker function" \
 echo ""
 echo "=== Cleanup logic presence validation ==="
 
-# Verify native review steps source the helper script and call functions
-BODY_CONTENT_REVIEW_COMMENT=$(awk '/Publish review comment \(non-blocking\)/,/^    - name: Publish review verdict/' "$ACTION_YML")
-BODY_CONTENT_REVIEW_VERDICT=$(awk '/Publish review verdict/,0' "$ACTION_YML")
+# The dispatcher sources the helper script once (before the case); the
+# review_comment / review_verdict arms each run the cleanup.
+check_contains "publish step sources publish_helpers.sh" \
+  "$PUBLISH_STEP_BODY" "publish_helpers.sh"
 
-check_contains "review_comment step sources publish_helpers.sh" \
-  "$BODY_CONTENT_REVIEW_COMMENT" "publish_helpers.sh"
-
-check_contains "review_verdict step sources publish_helpers.sh" \
-  "$BODY_CONTENT_REVIEW_VERDICT" "publish_helpers.sh"
-
-check_contains "review_comment step calls cleanup_native_reviews" \
+check_contains "review_comment arm calls cleanup_native_reviews" \
   "$BODY_CONTENT_REVIEW_COMMENT" "cleanup_native_reviews"
 
-check_contains "review_verdict step calls cleanup_native_reviews" \
+check_contains "review_verdict arm calls cleanup_native_reviews" \
   "$BODY_CONTENT_REVIEW_VERDICT" "cleanup_native_reviews"
 
-check_contains "review_comment step calls resolve_cleanup_flag" \
+check_contains "review_comment arm calls resolve_cleanup_flag" \
   "$BODY_CONTENT_REVIEW_COMMENT" "resolve_cleanup_flag"
 
-check_contains "review_verdict step calls resolve_cleanup_flag" \
+check_contains "review_verdict arm calls resolve_cleanup_flag" \
   "$BODY_CONTENT_REVIEW_VERDICT" "resolve_cleanup_flag"
 
 echo ""
@@ -209,10 +209,10 @@ check_exists "action.yml has cleanup_previous_native_reviews input" \
 check_contains "cleanup_previous_native_reviews default is auto" \
   "$(cat "$ACTION_YML")" 'default: "auto"'
 
-check_exists "action.yml has CLEANUP_PREVIOUS_NATIVE_REVIEWS env in review_comment step" \
+check_exists "review_comment arm reads CLEANUP_PREVIOUS_NATIVE_REVIEWS" \
   "$(grep -c 'CLEANUP_PREVIOUS_NATIVE_REVIEWS' <<< "$BODY_CONTENT_REVIEW_COMMENT" || echo 0)"
 
-check_exists "action.yml has CLEANUP_PREVIOUS_NATIVE_REVIEWS env in review_verdict step" \
+check_exists "review_verdict arm reads CLEANUP_PREVIOUS_NATIVE_REVIEWS" \
   "$(grep -c 'CLEANUP_PREVIOUS_NATIVE_REVIEWS' <<< "$BODY_CONTENT_REVIEW_VERDICT" || echo 0)"
 
 echo ""

--- a/tests/test_required_checks.sh
+++ b/tests/test_required_checks.sh
@@ -35,8 +35,8 @@ ACTION="$(cat "$ROOT_DIR/action.yml")"
 check_contains "action.yml declares validate_required_checks input" "$ACTION" "validate_required_checks:"
 check_contains "action.yml declares required_check_validation_mode input" "$ACTION" "required_check_validation_mode:"
 check_contains "action.yml declares required_checks output" "$ACTION" "required_checks:"
-check "publish steps receive REQUIRED_CHECKS" \
-  "$(grep -c 'REQUIRED_CHECKS: \${{ steps.review.outputs.required_checks }}' "$ROOT_DIR/action.yml")" "3"
+check "publish step receives REQUIRED_CHECKS" \
+  "$(grep -c 'REQUIRED_CHECKS: \${{ steps.review.outputs.required_checks }}' "$ROOT_DIR/action.yml")" "1"
 
 echo ""
 echo "=== Functional: build_metadata_marker carries required_checks ==="

--- a/tests/test_review_escalation.sh
+++ b/tests/test_review_escalation.sh
@@ -67,8 +67,8 @@ check_contains "input escalate_on_dirty_baseline" "$ACTION" "escalate_on_dirty_b
 check_contains "review step receives BASELINE_CLEAN" "$ACTION" 'BASELINE_CLEAN: ${{ steps.precheck.outputs.baseline_clean }}'
 check_contains "run_review wires dirty_baseline into should_escalate" "$SRC" "dirty_baseline=('\$DIRTY_BASELINE' == 'true')"
 check_contains "escalation_reason output declared" "$ACTION" "escalation_reason:"
-check "publish steps receive ESCALATION_REASON" \
-  "$(grep -c 'ESCALATION_REASON: \${{ steps.review.outputs.escalation_reason }}' "$ROOT_DIR/action.yml")" "3"
+check "publish step receives ESCALATION_REASON" \
+  "$(grep -c 'ESCALATION_REASON: \${{ steps.review.outputs.escalation_reason }}' "$ROOT_DIR/action.yml")" "1"
 
 echo ""
 echo "=== Marker carries escalation metadata ==="

--- a/tests/test_review_routing.sh
+++ b/tests/test_review_routing.sh
@@ -98,8 +98,8 @@ ACTION="$(cat "$ROOT_DIR/action.yml")"
 check_contains "action.yml declares review_routing_mode" "$ACTION" "review_routing_mode:"
 check_contains "action.yml declares ai_smart_model" "$ACTION" "ai_smart_model:"
 check_contains "action.yml declares review_route output" "$ACTION" "review_route:"
-check "publish steps receive REVIEW_ROUTE" \
-  "$(grep -c 'REVIEW_ROUTE: \${{ steps.review.outputs.review_route }}' "$ROOT_DIR/action.yml")" "3"
+check "publish step receives REVIEW_ROUTE" \
+  "$(grep -c 'REVIEW_ROUTE: \${{ steps.review.outputs.review_route }}' "$ROOT_DIR/action.yml")" "1"
 check_contains "marker carries review_route" "$(cat "$ROOT_DIR/scripts/publish_helpers.sh")" "review_route"
 
 echo ""


### PR DESCRIPTION
Closes #303. Phase C of the 2.0 refactor (#258).

## Summary
- Collapse the three publish steps (`comment` / `review_comment` / `review_verdict`) into one `Publish review` step with a single superset `env:` block, dispatching on `$PUBLISH_MODE` in a pure-bash `case`.
- Hoist per-mode inline `${{ }}` exprs (`EFFECTIVE_SCOPE`, `BASE_SHA`, `PREVIOUS_HEAD_SHA`, `IS_FORK_PR`, `BASELINE_CLEAN`) into env so each arm is pure bash.
- Per-mode bodies are otherwise preserved verbatim; net −38 lines in action.yml.

## Why it matters
One env block makes the duplicate-key drift that broke v1.2.10 (#255, the `PLATFORM`-defined-twice manifest error) structurally impossible — there's now nowhere for the three blocks to drift apart.

## Verification
- `for t in tests/test_*.sh; do bash "$t"; done` — green
- `python3.14 -m pytest tests/ -q` — 945 passed (incl. the duplicate-env-key guard)
- `tests/smoke_test.sh` — 25 passed
- Confirmed the merged `env:` block has zero duplicate keys; YAML parses via `yaml.safe_load`.

## Notes
- Breaking-marked per the 2.0 hard-break convention, but consumer-facing behavior is unchanged — same inputs, same published output per mode.
- Tests repointed from per-step body extraction to the single step / case arms; env-key occurrence counts adjusted 3→1 (and 2→1 for `INLINE_FINDINGS`).