### PR TITLE
refactor(inputs)!: drop the ai_fast_* deprecated aliases (#258)

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,10 +243,6 @@ Only three inputs are required: `github_token`, `ai_base_url`, and `ai_model`. E
 | `ai_primary_base_url` | Base URL for the primary route model; defaults to `ai_base_url` | No | `""` |
 | `ai_primary_api_format` | API format for the primary route model; defaults to `ai_api_format` | No | `""` |
 | `ai_primary_api_key` | API key for the primary route model; defaults to `ai_api_key` | No | `""` |
-| `ai_fast_model` | Deprecated alias for `ai_primary_model` (route renamed `fast` → `primary`) | No | `""` |
-| `ai_fast_base_url` | Deprecated alias for `ai_primary_base_url` | No | `""` |
-| `ai_fast_api_format` | Deprecated alias for `ai_primary_api_format` | No | `""` |
-| `ai_fast_api_key` | Deprecated alias for `ai_primary_api_key` | No | `""` |
 | `ai_smart_model` | Smart model for high-risk reviews in `auto` mode; defaults to `ai_fallback_model` | No | `""` |
 | `ai_smart_base_url` | Base URL for the smart model; defaults to `ai_fallback_base_url` | No | `""` |
 | `ai_smart_api_format` | API format for the smart model; defaults to `ai_fallback_api_format`, then `ai_api_format` | No | `""` |

--- a/action.yml
+++ b/action.yml
@@ -156,22 +156,6 @@ inputs:
     description: API key for the primary route model. Defaults to ai_api_key.
     required: false
     default: ""
-  ai_fast_model:
-    description: "Deprecated alias for ai_primary_model (the route was renamed fast -> primary)."
-    required: false
-    default: ""
-  ai_fast_base_url:
-    description: "Deprecated alias for ai_primary_base_url."
-    required: false
-    default: ""
-  ai_fast_api_format:
-    description: "Deprecated alias for ai_primary_api_format."
-    required: false
-    default: ""
-  ai_fast_api_key:
-    description: "Deprecated alias for ai_primary_api_key."
-    required: false
-    default: ""
   ai_smart_model:
     description: "Opt-in smarter model for high-risk reviews (review_routing_mode=auto). With no smart model set, auto-routing stays on the primary model and never escalates. The fallback model is NEVER an escalation target — it only catches a primary-availability failure."
     required: false
@@ -636,8 +620,7 @@ runs:
         AI_TOKENS_PARAM: ${{ inputs.ai_tokens_param }}
         AI_FALLBACK_MODEL: ${{ inputs.ai_fallback_model }}
         REVIEW_ROUTING_MODE: ${{ inputs.review_routing_mode }}
-        AI_PRIMARY_MODEL: ${{ inputs.ai_primary_model || inputs.ai_fast_model }}
-        AI_FAST_MODEL: ${{ inputs.ai_fast_model }}
+        AI_PRIMARY_MODEL: ${{ inputs.ai_primary_model }}
         AI_SMART_MODEL: ${{ inputs.ai_smart_model }}
         ESCALATE_ON_RISK_FLAGS: ${{ inputs.escalate_on_risk_flags }}
         ESCALATE_ON_INCOMPLETE_REQUIRED_CHECKS: ${{ inputs.escalate_on_incomplete_required_checks }}
@@ -734,14 +717,10 @@ runs:
         VALIDATE_REQUIRED_CHECKS: ${{ inputs.validate_required_checks }}
         REQUIRED_CHECK_VALIDATION_MODE: ${{ inputs.required_check_validation_mode }}
         REVIEW_ROUTING_MODE: ${{ inputs.review_routing_mode }}
-        AI_PRIMARY_BASE_URL: ${{ inputs.ai_primary_base_url || inputs.ai_fast_base_url }}
-        AI_PRIMARY_MODEL: ${{ inputs.ai_primary_model || inputs.ai_fast_model }}
-        AI_PRIMARY_API_FORMAT: ${{ inputs.ai_primary_api_format || inputs.ai_fast_api_format }}
-        AI_PRIMARY_API_KEY: ${{ inputs.ai_primary_api_key || inputs.ai_fast_api_key }}
-        AI_FAST_BASE_URL: ${{ inputs.ai_fast_base_url }}
-        AI_FAST_MODEL: ${{ inputs.ai_fast_model }}
-        AI_FAST_API_FORMAT: ${{ inputs.ai_fast_api_format }}
-        AI_FAST_API_KEY: ${{ inputs.ai_fast_api_key }}
+        AI_PRIMARY_BASE_URL: ${{ inputs.ai_primary_base_url }}
+        AI_PRIMARY_MODEL: ${{ inputs.ai_primary_model }}
+        AI_PRIMARY_API_FORMAT: ${{ inputs.ai_primary_api_format }}
+        AI_PRIMARY_API_KEY: ${{ inputs.ai_primary_api_key }}
         AI_SMART_BASE_URL: ${{ inputs.ai_smart_base_url }}
         AI_SMART_MODEL: ${{ inputs.ai_smart_model }}
         AI_SMART_API_FORMAT: ${{ inputs.ai_smart_api_format }}

--- a/scripts/check_review_needed.sh
+++ b/scripts/check_review_needed.sh
@@ -201,8 +201,8 @@ compute_config_hash() {
   if [[ -n "${REVIEW_ROUTING_MODE:-}" ]]; then
     parts+=("routing_mode:${REVIEW_ROUTING_MODE}")
   fi
-  if [[ -n "${AI_PRIMARY_MODEL:-${AI_FAST_MODEL:-}}" ]]; then
-    parts+=("primary_model:${AI_PRIMARY_MODEL:-${AI_FAST_MODEL}}")
+  if [[ -n "${AI_PRIMARY_MODEL:-}" ]]; then
+    parts+=("primary_model:${AI_PRIMARY_MODEL}")
   fi
   if [[ -n "${AI_SMART_MODEL:-}" ]]; then
     parts+=("smart_model:${AI_SMART_MODEL}")

--- a/scripts/sections/classification.sh
+++ b/scripts/sections/classification.sh
@@ -144,12 +144,11 @@ resolve_review_route() {
   fi
 }
 
-# The primary route is the default model (ai_model). ai_primary_* overrides it;
-# ai_fast_* is the deprecated alias for those overrides.
-PRIMARY_BASE_URL="${AI_PRIMARY_BASE_URL:-${AI_FAST_BASE_URL:-$AI_BASE_URL}}"
-PRIMARY_MODEL="${AI_PRIMARY_MODEL:-${AI_FAST_MODEL:-$AI_MODEL}}"
-PRIMARY_API_FORMAT="${AI_PRIMARY_API_FORMAT:-${AI_FAST_API_FORMAT:-$AI_API_FORMAT}}"
-PRIMARY_API_KEY="${AI_PRIMARY_API_KEY:-${AI_FAST_API_KEY:-$AI_API_KEY}}"
+# The primary route is the default model (ai_model). ai_primary_* overrides it.
+PRIMARY_BASE_URL="${AI_PRIMARY_BASE_URL:-$AI_BASE_URL}"
+PRIMARY_MODEL="${AI_PRIMARY_MODEL:-$AI_MODEL}"
+PRIMARY_API_FORMAT="${AI_PRIMARY_API_FORMAT:-$AI_API_FORMAT}"
+PRIMARY_API_KEY="${AI_PRIMARY_API_KEY:-$AI_API_KEY}"
 # Smart is an OPT-IN quality tier resolved ONLY from ai_smart_*. It deliberately
 # does NOT borrow the fallback model: the fallback exists solely to catch a
 # primary-availability failure, never as an escalation target. With no

--- a/scripts/sections/config.sh
+++ b/scripts/sections/config.sh
@@ -61,11 +61,6 @@ AI_PRIMARY_BASE_URL="${AI_PRIMARY_BASE_URL:-}"
 AI_PRIMARY_MODEL="${AI_PRIMARY_MODEL:-}"
 AI_PRIMARY_API_FORMAT="${AI_PRIMARY_API_FORMAT:-}"
 AI_PRIMARY_API_KEY="${AI_PRIMARY_API_KEY:-}"
-# ai_fast_* — deprecated aliases for ai_primary_* (route renamed fast -> primary)
-AI_FAST_BASE_URL="${AI_FAST_BASE_URL:-}"
-AI_FAST_MODEL="${AI_FAST_MODEL:-}"
-AI_FAST_API_FORMAT="${AI_FAST_API_FORMAT:-}"
-AI_FAST_API_KEY="${AI_FAST_API_KEY:-}"
 AI_SMART_BASE_URL="${AI_SMART_BASE_URL:-}"
 AI_SMART_MODEL="${AI_SMART_MODEL:-}"
 AI_SMART_API_FORMAT="${AI_SMART_API_FORMAT:-}"
@@ -268,10 +263,6 @@ esac
 
 if [[ -n "$AI_PRIMARY_API_FORMAT" ]] && ! AI_PRIMARY_API_FORMAT="$(normalize_api_format "$AI_PRIMARY_API_FORMAT")"; then
   error "Invalid AI_PRIMARY_API_FORMAT '$AI_PRIMARY_API_FORMAT'; expected openai or anthropic"
-  exit 1
-fi
-if [[ -n "$AI_FAST_API_FORMAT" ]] && ! AI_FAST_API_FORMAT="$(normalize_api_format "$AI_FAST_API_FORMAT")"; then
-  error "Invalid AI_FAST_API_FORMAT '$AI_FAST_API_FORMAT'; expected openai or anthropic"
   exit 1
 fi
 if [[ -n "$AI_SMART_API_FORMAT" ]] && ! AI_SMART_API_FORMAT="$(normalize_api_format "$AI_SMART_API_FORMAT")"; then

--- a/tests/test_review_routing.sh
+++ b/tests/test_review_routing.sh
@@ -89,7 +89,7 @@ check "custom list: matching kind routes smart" \
 echo ""
 echo "=== Test: wiring ==="
 RUN_REVIEW="$(cat "$ROOT_DIR/scripts/run_review.sh" "$ROOT_DIR"/scripts/sections/*.sh)"
-check_contains "primary route config defaults to ai_model (ai_fast_* alias)" "$RUN_REVIEW" 'PRIMARY_MODEL="${AI_PRIMARY_MODEL:-${AI_FAST_MODEL:-$AI_MODEL}}"'
+check_contains "primary route config defaults to ai_model" "$RUN_REVIEW" 'PRIMARY_MODEL="${AI_PRIMARY_MODEL:-$AI_MODEL}"'
 check_contains "smart resolves ONLY from ai_smart_model (not the fallback)" "$RUN_REVIEW" 'SMART_MODEL="${AI_SMART_MODEL}"'
 check "review_route output emitted" "$(grep -c '^echo "review_route=' "$ROOT_DIR/scripts/sections/review.sh")" "1"
 check "precheck fingerprints routing mode" "$(grep -c 'routing_mode:' "$ROOT_DIR/scripts/check_review_needed.sh")" "1"


### PR DESCRIPTION
Phase D of the 2.0 refactor (#258), input-surface prune.

## Summary
- Remove the 4 `ai_fast_*` inputs (`model`/`base_url`/`api_format`/`api_key`) — deprecated `fast`→`primary` aliases from #278, due to drop at a major version.
- Drop their `AI_FAST_*` env wiring in action.yml and the `:-${AI_FAST_*}` fallbacks in config.sh / classification.sh / check_review_needed.sh.

## Why it's safe (hard-break)
Audited all 7 fleet consumers + the dogfood workflow: **none set `ai_fast_*`** — they resolve the primary route from `ai_model`. The fallback chain becomes `ai_primary_* → ai_model`, unchanged for everyone.

## Audit note
The rest of the input surface is live, not dead: `tool_max_rounds`, the `tool_planning_*` trio, and `escalate_on_tool_planning_failure` all looked like plan_execute leftovers but are consumed by native_loop (and consumers set them) — kept. #326 already removed the planner-specific surface, so the aliases were the only verified-dead inputs.

## Verification
- full shell sweep — green
- `python3.14 -m pytest tests/ -q` — 945 passed
- `tests/smoke_test.sh` — 25 passed
- action.yml: 102 → 98 inputs; YAML parses; no `ai_fast_`/`AI_FAST_` refs remain