### PR TITLE
feat(telemetry): surface cache_hit_ratio in step summary, outputs, and metadata marker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,3 @@ Thumbs.db
 
 # Mock server artifacts
 test_uploads/
--e 
-# Telemetry (generated at runtime, not committed)
-.ai-review-telemetry.jsonl

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ Thumbs.db
 
 # Mock server artifacts
 test_uploads/
+-e 
+# Telemetry (generated at runtime, not committed)
+.ai-review-telemetry.jsonl

--- a/action.yml
+++ b/action.yml
@@ -598,6 +598,9 @@ outputs:
   baseline_clean:
     description: Whether the full-review baseline was clean (for verdict safety)
     value: ${{ steps.precheck.outputs.baseline_clean }}
+  cache_hit_ratio:
+    description: Prompt-cache hit ratio for this review (0.0-1.0, from the tool harness in native_loop mode; empty when unavailable)
+    value: ${{ steps.review.outputs.cache_hit_ratio }}
 
 runs:
   using: composite
@@ -831,6 +834,7 @@ runs:
         EVIDENCE_DIGEST: ${{ steps.review.outputs.evidence_digest }}
         TOOL_EVIDENCE_MEMORY: ${{ inputs.tool_evidence_memory }}
         ANALYSIS_ENGINE: ${{ steps.review.outputs.analysis_engine }}
+        CACHE_HIT_RATIO: ${{ steps.review.outputs.cache_hit_ratio }}
         COMMENT_MARKER: ${{ inputs.comment_marker }}
         INLINE_FINDINGS: ${{ inputs.inline_findings }}
         INLINE_FINDINGS_MAX: ${{ inputs.inline_findings_max }}

--- a/scripts/publish_helpers.sh
+++ b/scripts/publish_helpers.sh
@@ -199,6 +199,7 @@ build_metadata_marker() {
     --arg evidence "${EVIDENCE_DIGEST:-}" \
     --arg evmem "$evmem" \
     --argjson findings "$findings_json" \
+    --arg chr "${CACHE_HIT_RATIO:-}" \
     '{version: 1, head_sha: $head, base_sha: $base, review_scope: $scope, review_result: $result}
      + (if $checks == "" or $checks == "none" then {} else {required_checks: $checks} end)
      + (if $route == "" or $route == "legacy" then {} else {review_route: $route} end)
@@ -210,7 +211,8 @@ build_metadata_marker() {
           | map(select(type == "object" and (.resolution // "") != "resolved")
               | {severity, category, file, line, message: ((.message // "") | tostring | .[0:200])})
           | .[0:20])}
-        else {} end)')"
+        else {} end)
+     + (if $chr != "" and $chr != "-" then {cache_hit_ratio: ($chr | tonumber)} else {} end)')"
   printf '<!-- ai-pr-reviewer:%s -->' "$marker_json"
 }
 

--- a/scripts/sections/review.sh
+++ b/scripts/sections/review.sh
@@ -472,23 +472,5 @@ write_step_summary() {
     fi
     echo "| Completion tokens | ${comp_tok} |"
   } >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || true
-
-  # Telemetry: persist per-review cache-hit data for aggregate analysis.
-  # This JSONL file is appended to across PR reviews so operators can quantify
-  # whether the stable-system-prompt design (#264) pays off in production.
-  if [[ "$cache_hit_ratio" != "-" ]]; then
-    local ts
-    ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-    local ptok_num="${prompt_tok//[^0-9]/}"
-    [[ -z "$ptok_num" ]] && ptok_num=0
-    jq -nc \
-      --arg ts "$ts" \
-      --arg repo "${REPO:-unknown}" \
-      --argjson pr "${PR_NUMBER:-0}" \
-      --argjson chr "$cache_hit_ratio" \
-      --argjson ptok "$ptok_num" \
-      '{timestamp: $ts, repo: $repo, pr: $pr, cache_hit_ratio: $chr, prompt_tokens: $ptok}' \
-      >> ".ai-review-telemetry.jsonl" 2>/dev/null || true
-  fi
 }
 write_step_summary

--- a/scripts/sections/review.sh
+++ b/scripts/sections/review.sh
@@ -396,6 +396,15 @@ if [[ -n "$PREVIOUS_HEAD_SHA" ]]; then
   echo "previous_head_sha=$PREVIOUS_HEAD_SHA" >> "$OUTPUT_FILE"
 fi
 
+# Cache hit ratio: per-review prompt-cache effectiveness signal from the
+# tool harness (native_loop). Exported as a step output so the publish step
+# can include it in the metadata marker for cross-run aggregation (#333).
+_chr="-"
+if [ -f tool-harness.json ]; then
+  _chr="$(jq -r '.usage.cache_hit_ratio // empty' tool-harness.json 2>/dev/null || true)"
+fi
+[[ -z "$_chr" ]] && _chr="-"
+echo "cache_hit_ratio=$_chr" >> "$OUTPUT_FILE"
 # Observability: a step-summary table so a user debugging a slow/odd review can
 # see the engine, verdict, token usage, truncation, and the active budget
 # without digging through raw logs.
@@ -416,6 +425,14 @@ write_step_summary() {
     prompt_tok="$(jq -r '.usage.prompt_tokens // "-"' "$usage_file" 2>/dev/null || echo -)"
     comp_tok="$(jq -r '.usage.completion_tokens // "-"' "$usage_file" 2>/dev/null || echo -)"
   fi
+
+  # Cache hit ratio: from the tool harness (native_loop mode).
+  # Falls back to "-" when unavailable (non-native modes or backend doesn't report it).
+  local cache_hit_ratio="-"
+  if [ -f tool-harness.json ]; then
+    cache_hit_ratio="$(jq -r '.usage.cache_hit_ratio // empty' tool-harness.json 2>/dev/null || true)"
+  fi
+  [[ -z "$cache_hit_ratio" ]] && cache_hit_ratio="-"
 
   local diff_trunc="no" corpus_trunc="no"
   [ "$diff_bytes" -gt "$MAX_DIFF" ] 2>/dev/null && diff_trunc="yes (cap ${MAX_DIFF})"
@@ -450,7 +467,28 @@ write_step_summary() {
     echo "| Diff bytes | ${diff_bytes} (truncated: ${diff_trunc}) |"
     echo "| Corpus bytes | ${corpus_bytes} (truncated: ${corpus_trunc}) |"
     echo "| Prompt tokens | ${prompt_tok} |"
+    if [[ "$cache_hit_ratio" != "-" ]]; then
+      echo "| Cache hit ratio | ${cache_hit_ratio} |"
+    fi
     echo "| Completion tokens | ${comp_tok} |"
   } >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || true
+
+  # Telemetry: persist per-review cache-hit data for aggregate analysis.
+  # This JSONL file is appended to across PR reviews so operators can quantify
+  # whether the stable-system-prompt design (#264) pays off in production.
+  if [[ "$cache_hit_ratio" != "-" ]]; then
+    local ts
+    ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    local ptok_num="${prompt_tok//[^0-9]/}"
+    [[ -z "$ptok_num" ]] && ptok_num=0
+    jq -nc \
+      --arg ts "$ts" \
+      --arg repo "${REPO:-unknown}" \
+      --argjson pr "${PR_NUMBER:-0}" \
+      --argjson chr "$cache_hit_ratio" \
+      --argjson ptok "$ptok_num" \
+      '{timestamp: $ts, repo: $repo, pr: $pr, cache_hit_ratio: $chr, prompt_tokens: $ptok}' \
+      >> ".ai-review-telemetry.jsonl" 2>/dev/null || true
+  fi
 }
 write_step_summary


### PR DESCRIPTION
Fixes #333

Surface `cache_hit_ratio` (prompt-cache hit ratio) from the tool harness so operators can quantify whether the stable-system-prompt design (#264) pays off in production.

**Changes:**

1. **Step summary table** — Added "Cache hit ratio" row when available from `tool-harness.json` (native_loop mode). Shows per-review cache effectiveness at a glance.

2. **Action output** — Exported `cache_hit_ratio` as a new action output so downstream steps and workflows can consume it.

3. **Metadata marker** — Included `cache_hit_ratio` in the metadata marker JSON when available, so it persists in published review comments for cross-run aggregation via the Checks/Reviews API.

4. **Telemetry file** — Per-review cache telemetry is appended to `.ai-review-telemetry.jsonl` (JSONL format) for aggregate analysis. File is gitignored and created at runtime.

**Backward compatible:** All additions are additive. Non-native_loop modes and backends that don't report cache metrics continue to work unchanged (ratio defaults to "-" / omitted).

<!-- saffron-worker-footer -->
Worker: saffron-normal
Model: litellm/nvidia