### PR TITLE
perf(corpus): compact corpus-bound JSON to cut prefill tokens

### DIFF
--- a/scripts/sections/context.sh
+++ b/scripts/sections/context.sh
@@ -38,7 +38,7 @@ platform_pr_files "$REPO" "$PR_NUMBER" > pr-files.raw.json
 # raw diff that is already embedded in the corpus, and the classifier does not
 # read them. Keeping them here doubled the diff bytes sent to the model.
 TOTAL_CHANGED_FILES="$(jq -r '.changedFiles // 0' pr.json 2>/dev/null || echo 0)"
-jq --argjson total "${TOTAL_CHANGED_FILES:-0}" \
+jq -c --argjson total "${TOTAL_CHANGED_FILES:-0}" \
   '[.[] | {filename,status,additions,deletions,changes,previous_filename}]
    + (if $total > 100 then [{note: "file list truncated to first 100 of \($total) changed files"}] else [] end)' \
   pr-files.raw.json > pr-files.json

--- a/scripts/sections/corpus.sh
+++ b/scripts/sections/corpus.sh
@@ -52,14 +52,14 @@ build_review_corpus() {
     # Project to review-relevant fields and cap the body: the full object also
     # carries the entire .files array (duplicating the PR Files section and the
     # classification summary) and an unbounded body.
-    jq '{number, title, author: (.author.login // .author), baseRefName, headRefName, headRefOid, changedFiles, additions, deletions, url, body: ((.body // "")[0:4000])}' pr.json
+    jq -c '{number, title, author: (.author.login // .author), baseRefName, headRefName, headRefOid, changedFiles, additions, deletions, url, body: ((.body // "")[0:4000])}' pr.json
     echo '```'
     echo
 
 
     echo "# PR Classification"
     if [ -f classification.json ]; then
-      jq '{pr_kind, risk_flags, risk_flags_with_files, changed_files_summary: (.changed_files_summary | .[0:20]), linked_issue_labels, must_check}' classification.json | head -c 8000
+      jq -c '{pr_kind, risk_flags, risk_flags_with_files, changed_files_summary: (.changed_files_summary | .[0:20]), linked_issue_labels, must_check}' classification.json | head -c 8000
     else
       echo "(Classification data unavailable for this review)"
     fi

--- a/scripts/sections/enrichment.sh
+++ b/scripts/sections/enrichment.sh
@@ -96,7 +96,7 @@ if [ -s urls.txt ]; then
       echo "### GitHub Release Metadata: $owner/$repo@$tag" >> linked-sources.md
 
       if enrichment_budget_ok && github_enrich_api "repos/$owner/$repo/releases/tags/$tag" > gh-release.json 2>/dev/null; then
-        jq '{tag_name,name,published_at,html_url,body}' gh-release.json > gh-release.filtered.json
+        jq -c '{tag_name,name,published_at,html_url,body}' gh-release.json > gh-release.filtered.json
         echo '```json' >> linked-sources.md
         head -c 5000 gh-release.filtered.json >> linked-sources.md
         echo >> linked-sources.md
@@ -106,7 +106,7 @@ if [ -s urls.txt ]; then
       fi
 
       if enrichment_budget_ok && github_enrich_api "repos/$owner/$repo/releases?per_page=8" > gh-releases.json 2>/dev/null; then
-        jq '[.[] | {tag_name,name,published_at,html_url}]' gh-releases.json > gh-releases.filtered.json
+        jq -c '[.[] | {tag_name,name,published_at,html_url}]' gh-releases.json > gh-releases.filtered.json
         echo "### Recent Releases" >> linked-sources.md
         echo '```json' >> linked-sources.md
         head -c 3000 gh-releases.filtered.json >> linked-sources.md
@@ -124,13 +124,13 @@ if [ -s urls.txt ]; then
       echo "### GitHub Compare Metadata: $owner/$repo@$compare_spec" >> linked-sources.md
 
       if enrichment_budget_ok && github_enrich_api "repos/$owner/$repo/compare/$compare_spec" > gh-compare.json 2>/dev/null; then
-        jq '{html_url,status,ahead_by,behind_by,total_commits,commits:[.commits[]? | {sha,commit:{message,author,date}}]}' gh-compare.json > gh-compare.filtered.json
+        jq -c '{html_url,status,ahead_by,behind_by,total_commits,commits:[.commits[]? | {sha,commit:{message,author,date}}]}' gh-compare.json > gh-compare.filtered.json
         echo '```json' >> linked-sources.md
         head -c 7000 gh-compare.filtered.json >> linked-sources.md
         echo >> linked-sources.md
         echo '```' >> linked-sources.md
 
-        jq '[.files[]? | {filename,status,additions,deletions,changes,patch}]' gh-compare.json > gh-compare.files.json
+        jq -c '[.files[]? | {filename,status,additions,deletions,changes,patch}]' gh-compare.json > gh-compare.files.json
         echo "### GitHub Compare Files" >> linked-sources.md
         echo '```json' >> linked-sources.md
         head -c 7000 gh-compare.files.json >> linked-sources.md
@@ -163,7 +163,7 @@ if [ -s urls.txt ]; then
       echo "### GitHub Releases Enrichment: $repo_key" >> linked-sources.md
 
       if enrichment_budget_ok && github_enrich_api "repos/$owner/$repo/releases?per_page=30" > gh-releases.repo.json 2>/dev/null; then
-        jq '[.[] | {tag_name,name,published_at,html_url}]' gh-releases.repo.json > gh-releases.repo.filtered.json
+        jq -c '[.[] | {tag_name,name,published_at,html_url}]' gh-releases.repo.json > gh-releases.repo.filtered.json
         echo "#### Recent Releases (tags)" >> linked-sources.md
         echo '```json' >> linked-sources.md
         head -c 5000 gh-releases.repo.filtered.json >> linked-sources.md
@@ -191,7 +191,7 @@ if [ -s urls.txt ]; then
           else
             echo "(No release tags matched target version $TARGET_VERSION in $repo_key)" >> linked-sources.md
             if enrichment_budget_ok && github_enrich_api "repos/$owner/$repo/tags?per_page=50" > gh-tags.repo.json 2>/dev/null; then
-              jq '[.[] | {name,commit:.commit.sha}]' gh-tags.repo.json > gh-tags.repo.filtered.json
+              jq -c '[.[] | {name,commit:.commit.sha}]' gh-tags.repo.json > gh-tags.repo.filtered.json
               echo "#### Recent Tags" >> linked-sources.md
               echo '```json' >> linked-sources.md
               head -c 4000 gh-tags.repo.filtered.json >> linked-sources.md


### PR DESCRIPTION
First of the backend-agnostic prefill optimizations (quality-neutral — same data, fewer tokens).

## Summary
- The corpus embedded JSON **pretty-printed** for: PR Metadata, PR Classification, PR Files, and every enrichment blob (releases / compare / tags) folded into `linked-sources.md`.
- Switched the 8 corpus-bound `jq` calls to `jq -c`. Measured **~25% byte savings** on a representative file-list sample — pure whitespace, no signal change.
- Bonus: the `head -c` caps on those sections now hold ~25% more *real* content.
- Did **not** touch `jq -r` (raw extraction) or intermediate JSON consumed only by other shell logic where format is irrelevant.

## Why it's quality-neutral
Compact and pretty JSON carry identical data; the model parses both. The diff (the large section) is raw text and unchanged.

## Verification
- 945 pytest + full shell sweep + smoke (25) green
- `bash -n` clean on all three edited sections

## Note
This is prompt-affecting (corpus format), so per the project's eval discipline it's worth a confirming N≥3 eval against `corpus-agentic` before relying on it — though the change is semantically identical JSON. The dogfood review on this PR is the first signal.