### PR TITLE
perf(tool-loop): compact gh_api + web_search result JSON

### DIFF
--- a/pr_reviewer/tool_executors.py
+++ b/pr_reviewer/tool_executors.py
@@ -420,7 +420,10 @@ def execute_tool_request(
             data = res.get("data")
             text = ""
             if isinstance(data, (dict, list)):
-                text = json.dumps(data, indent=2)[:max_response_bytes]
+                # Compact JSON: the model re-prefills tool results on every loop
+                # round, so indent whitespace is pure repeated prefill cost — and
+                # compacting fits ~25% more real data under max_response_bytes.
+                text = json.dumps(data, separators=(",", ":"))[:max_response_bytes]
             tool_result["result"] = {"response": text}
 
         elif tool_name == "web_fetch":
@@ -441,7 +444,7 @@ def execute_tool_request(
             res = web_search(query, search_url, request_timeout, max_search_results)
             if res.get("error"):
                 raise ValueError(res["error"])
-            text = json.dumps(res.get("results", []), indent=2)
+            text = json.dumps(res.get("results", []), separators=(",", ":"))
             text, _ = mask_and_truncate(text, max_response_bytes)
             tool_result["result"] = {"results": text}
 


### PR DESCRIPTION
Follow-on to #337 — the same quality-neutral prefill cut, on the path that compounds hardest.

## Why this compounds
Native_loop tool results persist in the conversation and are **re-prefilled on every subsequent round** (cache reuse on the review endpoint is ~12%, so the prefix isn't reused turn-to-turn). `gh_api` and `web_search` emitted their result JSON with `indent=2`; that whitespace is repeated prefill cost ×rounds. `gh_api` also truncated *after* pretty-printing, so ~25% of `max_response_bytes` was whitespace rather than data.

## Change
- `gh_api`, `web_search`: `json.dumps(..., separators=(",", ":"))` instead of `indent=2`.
- Same evidence to the model, fewer tokens per round, and more real data under the byte cap.

## Verification
- 945 pytest + full shell sweep + smoke (25) green; no test pinned the pretty format.

## Note
Prompt-affecting (tool-result format) — worth the same confirming eval as #337; semantically identical JSON.