### PR TITLE
feat(prompt): system_prompt_mode=append (compose, don't copy)

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ Only three inputs are required: `github_token`, `ai_base_url`, and `ai_model`. E
 |-------|-------------|----------|---------|
 | `system_prompt` | Optional system prompt override | No | bundled prompt |
 | `system_prompt_file` | File in the reviewed repo to use as the full system prompt | No | `""` |
+| `system_prompt_mode` | How a supplied prompt combines with the bundled default: `replace` (verbatim) or `append` (repo addendum on the conditionally-assembled default — no need to copy/re-sync the default) | No | `replace` |
 | `standards_file` | Explicit standards file path; takes priority over candidates | No | `""` |
 | `standards_file_candidates` | Candidate files checked in order; first found is used | No | `AGENTS.md,agents.md,CLAUDE.md,claude.md,.github/ai-review-rules.md,.github/ai-review-rules.txt` |
 
@@ -999,6 +1000,7 @@ on_model_failure: notice   # visible explanation instead of a long red check
 - The tool harness planner uses the primary `ai_api_format`; fallback settings apply only to the final review call.
 - `system_prompt` takes precedence over `system_prompt_file`.
 - `system_prompt_file` takes precedence over the bundled generic prompt.
+- With `system_prompt_mode: append`, the supplied prompt does not replace the default — it is appended to the conditionally-assembled bundled default as a repo-specific addendum, so you can add conventions without copying (and re-syncing) the whole default.
 - `standards_file` is optional; if blank, the action checks `standards_file_candidates` in order and uses the first file found. `AGENTS.md` is checked first by default, then `CLAUDE.md`, making the action compatible with both Claude Code and non-Claude Code setups.
 - By default, the action computes a stable patch fingerprint with `git patch-id --stable` and skips the LLM call when that fingerprint matches the most recent managed review comment. This avoids token spend on rebases and other history-only changes.
 - `publish_review_comment` uses `gh pr comment --edit-last --create-if-none`, so the comment is managed by the token identity used in the workflow.

--- a/action.yml
+++ b/action.yml
@@ -231,6 +231,15 @@ inputs:
     description: Optional file path in the reviewed repository to use as the full system prompt
     required: false
     default: ""
+  system_prompt_mode:
+    description: >-
+      How a supplied system_prompt / system_prompt_file combines with the bundled
+      default. 'replace' (default) uses the supplied prompt verbatim. 'append'
+      keeps the conditionally-assembled bundled default and appends the supplied
+      prompt as a repo-specific addendum — so consumers add conventions without
+      copying (and re-syncing) the whole default.
+    required: false
+    default: "replace"
   standards_file:
     description: Repository standards file path for conventions and policy context
     required: false
@@ -635,6 +644,7 @@ runs:
         ANTHROPIC_VERSION: ${{ inputs.anthropic_version }}
         SYSTEM_PROMPT: ${{ inputs.system_prompt }}
         SYSTEM_PROMPT_FILE: ${{ inputs.system_prompt_file }}
+        SYSTEM_PROMPT_MODE: ${{ inputs.system_prompt_mode }}
         STANDARDS_FILE: ${{ inputs.standards_file }}
         STANDARDS_FILE_CANDIDATES: ${{ inputs.standards_file_candidates }}
         CONTEXT_LIMIT_MODE: ${{ inputs.context_limit_mode }}
@@ -741,6 +751,7 @@ runs:
         ALLOWED_SOURCE_HOSTS: ${{ inputs.allowed_source_hosts }}
         SYSTEM_PROMPT: ${{ inputs.system_prompt }}
         SYSTEM_PROMPT_FILE: ${{ inputs.system_prompt_file }}
+        SYSTEM_PROMPT_MODE: ${{ inputs.system_prompt_mode }}
         STANDARDS_FILE: ${{ inputs.standards_file }}
         STANDARDS_FILE_CANDIDATES: ${{ inputs.standards_file_candidates }}
         CONTEXT_LIMIT_MODE: ${{ inputs.context_limit_mode }}

--- a/scripts/sections/config.sh
+++ b/scripts/sections/config.sh
@@ -28,6 +28,10 @@ ALLOWED_SOURCE_HOSTS="${ALLOWED_SOURCE_HOSTS:-github.com,api.github.com,gitlab.c
 GH_TOKEN="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
 SYSTEM_PROMPT="${SYSTEM_PROMPT:-}"
 SYSTEM_PROMPT_FILE="${SYSTEM_PROMPT_FILE:-}"
+SYSTEM_PROMPT_MODE="${SYSTEM_PROMPT_MODE:-replace}"
+# A supplied prompt held for append mode, composed onto the default after
+# fragment assembly (see apply_system_prompt_fragments).
+SYSTEM_PROMPT_ADDENDUM=""
 STANDARDS_FILE="${STANDARDS_FILE:-}"
 STANDARDS_FILE_CANDIDATES="${STANDARDS_FILE_CANDIDATES:-AGENTS.md,agents.md,CLAUDE.md,claude.md,.github/ai-review-rules.md,.github/ai-review-rules.txt}"
 CONTEXT_LIMIT_MODE="${CONTEXT_LIMIT_MODE:-normal}"
@@ -312,21 +316,32 @@ resolve_standards_file() {
 }
 
 resolve_system_prompt() {
+  # Resolve any user-supplied prompt (inline takes precedence over file).
+  local user=""
   if [[ -n "$SYSTEM_PROMPT" ]]; then
-    return
-  fi
-
-  if [[ -n "$SYSTEM_PROMPT_FILE" ]]; then
+    user="$SYSTEM_PROMPT"
+  elif [[ -n "$SYSTEM_PROMPT_FILE" ]]; then
     if [[ ! -f "$SYSTEM_PROMPT_FILE" ]]; then
       error "SYSTEM_PROMPT_FILE does not exist: $SYSTEM_PROMPT_FILE"
       exit 1
     fi
-    SYSTEM_PROMPT="$(<"$SYSTEM_PROMPT_FILE")"
+    user="$(<"$SYSTEM_PROMPT_FILE")"
+  fi
+
+  # replace mode (default): a supplied prompt is used verbatim — no default,
+  # no fragments. append mode (or no supplied prompt at all): start from the
+  # bundled default so the conditional fragments apply; in append mode the
+  # supplied prompt is held and appended after assembly as a repo addendum.
+  if [[ -n "$user" && "$SYSTEM_PROMPT_MODE" != "append" ]]; then
+    SYSTEM_PROMPT="$user"
     return
   fi
 
   SYSTEM_PROMPT="$(<"$SCRIPT_DIR/default_system_prompt.txt")"
   SYSTEM_PROMPT_IS_DEFAULT=1
+  if [[ -n "$user" ]]; then
+    SYSTEM_PROMPT_ADDENDUM="$user"
+  fi
 }
 
 # Conditionally assemble the bundled default system prompt: substitute the
@@ -353,6 +368,12 @@ apply_system_prompt_fragments() {
     fi
     SYSTEM_PROMPT="${SYSTEM_PROMPT/\{\{VERSION_BUMP_GUIDANCE\}\}/$vb}"
     SYSTEM_PROMPT="${SYSTEM_PROMPT/\{\{IMAGE_DIGEST_GUIDANCE\}\}/$dg}"
+  fi
+  # append mode: compose the supplied prompt onto the assembled default as a
+  # repo-specific addendum, so a consumer adds conventions without copying (and
+  # re-syncing) the whole bundled default.
+  if [[ -n "${SYSTEM_PROMPT_ADDENDUM:-}" ]]; then
+    SYSTEM_PROMPT="${SYSTEM_PROMPT}"$'\n\n'"${SYSTEM_PROMPT_ADDENDUM}"
   fi
   export SYSTEM_PROMPT
 }

--- a/tests/test_system_prompt_fragments.sh
+++ b/tests/test_system_prompt_fragments.sh
@@ -74,6 +74,44 @@ RECON="${RECON/\{\{IMAGE_DIGEST_GUIDANCE\}\}/$DG}"
 check_contains "reconstructed prompt has both guidance blocks" "$RECON" "HOST PLATFORM"
 check_contains "reconstructed prompt has digest block" "$RECON" "digest-only image"
 
+# Extract resolve_system_prompt to test replace vs append mode end-to-end.
+RFUNCS="$(mktemp)"
+python3 - "$SCRIPT_DIR/sections/config.sh" "$RFUNCS" <<'PY'
+import re, sys
+src = open(sys.argv[1]).read()
+m = re.search(r"^resolve_system_prompt\(\) \{\n(.*?)\n\}", src, re.S | re.M)
+if not m:
+    sys.exit("could not extract resolve_system_prompt")
+open(sys.argv[2], "w").write("resolve_system_prompt() {\n%s\n}\n" % m.group(1))
+PY
+# shellcheck source=/dev/null
+source "$RFUNCS"; rm -f "$RFUNCS"
+
+echo "=== replace mode (default): a supplied prompt is used verbatim, no default ==="
+OUT="$(
+  SYSTEM_PROMPT="MY CUSTOM PROMPT" SYSTEM_PROMPT_FILE="" SYSTEM_PROMPT_MODE="replace"
+  SYSTEM_PROMPT_ADDENDUM="" SYSTEM_PROMPT_IS_DEFAULT=0
+  resolve_system_prompt
+  printf 'prompt=%s|default=%s|addendum=%s' "$SYSTEM_PROMPT" "${SYSTEM_PROMPT_IS_DEFAULT:-0}" "${SYSTEM_PROMPT_ADDENDUM:-}"
+)"
+check_contains "replace uses the supplied prompt verbatim" "$OUT" "prompt=MY CUSTOM PROMPT|"
+check_contains "replace does not flag the default" "$OUT" "|default=0|"
+check_contains "replace stashes no addendum" "$OUT" "|addendum="
+
+echo "=== append mode: supplied prompt composes onto the assembled default ==="
+OUT="$( cd "$WORK"
+  printf '{"pr_kind":"app_code"}' > classification.json
+  SYSTEM_PROMPT="REPO ADDENDUM SENTINEL" SYSTEM_PROMPT_FILE="" SYSTEM_PROMPT_MODE="append"
+  SYSTEM_PROMPT_ADDENDUM="" SYSTEM_PROMPT_IS_DEFAULT=0
+  resolve_system_prompt
+  apply_system_prompt_fragments
+  printf '%s' "$SYSTEM_PROMPT"
+)"
+check_contains "append keeps the base output schema" "$OUT" "Return STRICT JSON"
+check_contains "append composes the repo addendum on the end" "$OUT" "REPO ADDENDUM SENTINEL"
+check_not_contains "append on app_code still drops irrelevant V3" "$OUT" "HOST PLATFORM"
+check_not_contains "append leaves no unsubstituted placeholder" "$OUT" "{{"
+
 echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Fast-follow to #339. **Stacked on #339** (base auto-retargets to main once #339 merges).

## Why
home-ops uses `system_prompt_file`, which today fully *replaces* the default — so its file pastes the **entire** bundled default verbatim and then adds `## Home-ops conventions`. Its own header says it "must be kept in sync with upstream," and it has already drifted (stale `packages[]` schema, missing the classification block). Replace-only forces every customizing consumer to fork + re-sync the whole prompt.

## Change
- New input `system_prompt_mode: replace | append` (default `replace`, fully backward-compatible).
- `append`: the supplied prompt is appended to the **conditionally-assembled** default (so #339's fragments still apply) as a repo addendum. Consumers keep only their conventions and inherit the live default.

## Follow-up (separate home-ops PR)
Once this ships: trim home-ops's `pr-review.instructions.md` to just `## Home-ops conventions`, set `system_prompt_mode: append`, bump the pin → no more drift, and it picks up the conditional-prompt savings.

## Verification
945 pytest + full shell sweep + smoke (25); `test_system_prompt_fragments.sh` extended to 19 assertions covering replace (verbatim) and append (composes default+fragments+addendum, drops irrelevant blocks, no placeholder leak).