### PR TITLE
refactor(forgejo): consolidate seam jq passthrough + harden compare (#258)

### DIFF
--- a/scripts/platform_api.sh
+++ b/scripts/platform_api.sh
@@ -29,6 +29,17 @@
 # preserved by keeping each wrapper a thin exec of the original command —
 # wrappers must not capture-and-echo, which would launder an error body into
 # a success-shaped stdout.
+#
+# Known Forgejo divergences from the GitHub REST shape (callers must degrade,
+# never assume the field exists — golden fixtures in tests/fixtures/forgejo/
+# pin the real shapes):
+#   - compare: payload carries only commits/files/total_commits; it OMITS
+#     GitHub's status/ahead_by/behind_by/url/html_url. A `--jq '.url'` on the
+#     compare therefore yields empty on Forgejo (callers already fall back).
+#   - check-runs: no such API — platform_check_runs returns an empty struct;
+#     the CI signal comes from platform_commit_status instead.
+#   - graphql / collaborator_permission: GitHub-only; the forgejo path fails
+#     loudly (_forgejo_unimplemented), and call sites gate on this per #227.
 
 # Guard against double-sourcing (publish_helpers.sh and the caller may both
 # source this).
@@ -86,19 +97,34 @@ _forgejo_unimplemented() {
   return 1
 }
 
+_forgejo_jq() {
+  # Run a forgejo_backend CLI subcommand, then apply an optional trailing
+  # `--jq <expr>` to the JSON it prints — mirroring `gh api --jq` so a single
+  # call site works on either platform. $1=subcommand; the rest are the
+  # subcommand's positional args, optionally followed by `--jq <expr>`.
+  # NB: a `--jq` projection only yields data for fields the forgejo payload
+  # actually carries (see the divergence notes in the header) — e.g. `.url`
+  # on a compare is empty because Forgejo's compare object omits it.
+  local sub="$1"; shift
+  local jqexpr="" args=()
+  while [[ $# -gt 0 ]]; do
+    if [[ "$1" == "--jq" && $# -ge 2 ]]; then jqexpr="$2"; shift 2; continue; fi
+    args+=("$1"); shift
+  done
+  if [[ -n "$jqexpr" ]]; then
+    _forgejo_py "$sub" "${args[@]}" | jq -r "$jqexpr"
+  else
+    _forgejo_py "$sub" "${args[@]}"
+  fi
+}
+
 # ── Core PR I/O ─────────────────────────────────────────────────────────
 
 platform_pr_get() {
   # $1=repo $2=pr_number [extra gh api flags, e.g. --jq] → PR object
   # (GitHub REST shape, or the --jq projection) on stdout
   if _platform_is_forgejo; then
-    local repo="$1" num="$2"
-    shift 2
-    if [[ "${1:-}" == "--jq" && -n "${2:-}" ]]; then
-      _forgejo_py get-pr-metadata "$repo" "$num" | jq -r "$2"
-    else
-      _forgejo_py get-pr-metadata "$repo" "$num"
-    fi
+    _forgejo_jq get-pr-metadata "$@"
   else
     local repo="$1" num="$2"
     shift 2
@@ -155,7 +181,7 @@ platform_compare() {
   # $1=repo $2=base...head spec [extra gh api flags, e.g. --jq] → compare
   # object (or the --jq projection) on stdout
   if _platform_is_forgejo; then
-    _forgejo_py compare "$1" "$2"
+    _forgejo_jq compare "$@"
   else
     local repo="$1" spec="$2"
     shift 2

--- a/scripts/sections/config.sh
+++ b/scripts/sections/config.sh
@@ -155,7 +155,10 @@ fetch_incremental_patch() {
   local compare_url
   compare_url="$(platform_compare "$REPO" "${previous_head}...${current_head}" --jq '.url' 2>/dev/null || echo "")"
 
-  if [[ -n "$compare_url" ]]; then
+  # Only fetch when we actually got a URL: Forgejo's compare object omits `url`
+  # (jq -r yields the string "null"), and a gh error body could leave junk —
+  # either way, skip the diff fetch rather than curl a non-URL.
+  if [[ "$compare_url" == http://* || "$compare_url" == https://* ]]; then
     # The token goes through a 0600 curl --config file rather than argv (same
     # treatment as model API keys in model_call.sh) so it never appears in
     # /proc/<pid>/cmdline on shared runners.

--- a/tests/test_platform_api.sh
+++ b/tests/test_platform_api.sh
@@ -133,6 +133,15 @@ check "unimplemented forgejo op names itself" \
   "$(echo "$RESULT" | grep -c "not yet implemented")" "1"
 RESULT="$(run_seam forgejo "" '_forgejo_py(){ echo "forgejo $*"; }; platform_compare o/r aaa...bbb' "https://forgejo.example.com")"
 check "forgejo compare uses backend cli" "$RESULT" "forgejo compare o/r aaa...bbb"
+# --jq passthrough: the forgejo path applies a trailing --jq to the backend's
+# JSON, mirroring `gh api --jq`, so one call site works on either platform.
+RESULT="$(run_seam forgejo "" '_forgejo_py(){ echo "{\"total_commits\":3}"; }; platform_compare o/r aaa...bbb --jq .total_commits' "https://forgejo.example.com")"
+check "forgejo compare --jq projects a present field" "$RESULT" "3"
+RESULT="$(run_seam forgejo "" '_forgejo_py(){ echo "{\"head\":{\"sha\":\"deadbeef\"}}"; }; platform_pr_get o/r 7 --jq .head.sha' "https://forgejo.example.com")"
+check "forgejo pr_get --jq projects a nested field" "$RESULT" "deadbeef"
+# Documented divergence: Forgejo's compare omits .url, so jq -r yields "null".
+RESULT="$(run_seam forgejo "" '_forgejo_py(){ echo "{\"total_commits\":3}"; }; platform_compare o/r aaa...bbb --jq .url' "https://forgejo.example.com")"
+check "forgejo compare --jq on an absent field yields null" "$RESULT" "null"
 RESULT="$(run_seam forgejo "" '_forgejo_py(){ echo "forgejo $*"; }; platform_pr_reviews o/r 7' "https://forgejo.example.com")"
 check "forgejo pr reviews uses backend cli" "$RESULT" "forgejo list-pr-reviews o/r 7"
 RESULT="$(run_seam forgejo "" '_forgejo_py(){ echo "forgejo $*"; }; platform_review_create_json o/r 7 req.json' "https://forgejo.example.com")"


### PR DESCRIPTION
First slice of the 2.0.1 dual-backend consolidation (#258). On inspecting the seam I found it's already cleanly layered (`platform_api.sh` dispatch → `forgejo_backend.py` impl → `publish_helpers.sh` consumer), not duplicated — and the #341 golden fixtures already neutralized the recurring field-shape bug class. So this is targeted hardening, not a rewrite.

## Changes
- **Consolidate the `--jq` passthrough.** `platform_pr_get` and `platform_compare` each needed to forward a trailing `--jq` to the forgejo backend (mirroring `gh api --jq`). They're now one helper, `_forgejo_jq`. This **fixes `platform_compare` silently dropping `--jq`** on the forgejo path.
- **Guard the incremental-diff fetch.** `fetch_incremental_diff` only curls `compare_url` when it's an `http(s)://` URL. Forgejo's compare object omits `url`, so `jq -r '.url'` yields the string `"null"` — previously that passed the `-n` check and triggered a doomed curl. (It was equally broken pre-change, which returned the whole JSON blob.)
- **Document known Forgejo divergences** in the `platform_api.sh` header: compare omits `status`/`ahead_by`/`behind_by`/`url`; no check-runs/graphql/collaborator APIs. Future seam changes shouldn't re-trip these.

## Verified
- 42 seam tests (3 new: compare `--jq` present-field, pr_get `--jq` nested-field, compare `--jq` absent-field → `"null"` documenting the divergence)
- Full shell sweep (bash 3 + 4), 952 pytest, 25 smoke — green
- github path unchanged (existing byte-for-byte dispatch assertions still pass)
