### PR TITLE
test(ci): guard outbound HTTP User-Agent + document adversarial fences (#252)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,6 +131,7 @@ The smoke test validates: GitHub PR data collection, corpus assembly, OpenAI/Ant
 - System prompt priority: inline `system_prompt` > file `system_prompt_file` > bundled default
 - Reserved metadata markers (`<!-- ai-pr-review-fingerprint:... -->`, `<!-- ai-pr-review-sha:... -->`) are stripped from model output before publishing; the precheck reads only the first occurrence of each
 - The `run_command` tool never executes model-supplied shell text — only named argv definitions from a fixed read-only catalog (`git_status_short`, `git_diff_stat`, `git_diff_name_only`)
+- Adversarial fixtures for security boundaries (#252): any sanitizer or fence (untrusted-data delimiters, secret redaction, exfil guards) must have a test that feeds the boundary token / hostile delimiter *itself*, not just benign input — a mock that omits the attack encodes the same blind spot as the code (the #250 fence was escapable by content containing its own closing delimiter). See `tests/test_native_loop_exfil_redteam.py` and the outbound-UA guard (`tests/test_outbound_user_agent.py`) for the pattern; add one when introducing a new fence.
 - Versioning: `v1.x.y` semver tags; feature releases stay on `1.2.x` (`v1.3.0` is reserved for the tool-calling milestone, issue #197)
 
 ## Label taxonomy (`agent/*` and Dispatch workflow labels)

--- a/tests/test_outbound_user_agent.py
+++ b/tests/test_outbound_user_agent.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Regression guard for #252 item 4: the action's urllib-based HTTP helpers
+must set a non-default User-Agent.
+
+urllib's default UA (``Python-urllib/X.Y``) trips CDN bot fences — the konflate
+evidence provider hit a Cloudflare BIC 1010 / 403 with it. The fix is a UA
+header in each helper; this test exercises the real call path so a future
+helper that forgets the header fails here instead of in production.
+"""
+
+import json
+import sys
+import urllib.request
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SCRIPTS_DIR = _REPO_ROOT / "scripts"
+for _p in (_REPO_ROOT, _SCRIPTS_DIR):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+import pytest
+
+from pr_reviewer import tool_executors as te
+
+
+class _FakeResp:
+    def __init__(self, body=b"ok"):
+        self._body = body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def read(self):
+        return self._body
+
+
+def _capture_ua(monkeypatch, body=b"ok"):
+    """Patch urlopen to capture the Request's User-Agent without any network."""
+    seen = {}
+
+    def fake_urlopen(req, timeout=None):
+        # urllib normalizes the header key to "User-agent".
+        seen["ua"] = req.get_header("User-agent")
+        return _FakeResp(body)
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    return seen
+
+
+def test_web_fetch_sets_non_default_user_agent(monkeypatch):
+    seen = _capture_ua(monkeypatch)
+    te.web_fetch("https://example.com/x", ["example.com"])
+    assert seen["ua"] == "ai-pr-reviewer/1.0"
+
+
+def test_web_search_sets_non_default_user_agent(monkeypatch):
+    seen = _capture_ua(monkeypatch, body=json.dumps({"results": []}).encode())
+    te.web_search("anything", "https://search.example/search")
+    assert seen["ua"] == "ai-pr-reviewer/1.0"
+
+
+def test_fetch_url_sets_non_default_user_agent(monkeypatch):
+    seen = _capture_ua(monkeypatch)
+    te.fetch_url("https://example.com/x", ["example.com"])
+    assert seen["ua"] == "ai-pr-reviewer/1.0"
+
+
+@pytest.mark.parametrize("call", [
+    lambda: te.web_fetch("https://example.com/x", ["example.com"]),
+    lambda: te.web_search("q", "https://search.example/search"),
+    lambda: te.fetch_url("https://example.com/x", ["example.com"]),
+])
+def test_user_agent_is_never_the_urllib_default(monkeypatch, call):
+    # The actual bug class: urllib's default UA is rejected by CDN bot checks.
+    seen = _capture_ua(monkeypatch, body=json.dumps({"results": []}).encode())
+    call()
+    assert seen["ua"] and "Python-urllib" not in seen["ua"]
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Closes the remaining #252 CI-hardening items (the golden-fixtures item shipped in #341/#344; actionlint already runs in `ci.yaml`).

## Item 4 — outbound-HTTP User-Agent guard
The urllib helpers (`web_fetch`, `web_search`, `fetch_url`) set `User-Agent: ai-pr-reviewer/1.0` in code, but nothing tested it — and urllib's default UA is what tripped the konflate Cloudflare BIC 403 that motivated #252. `tests/test_outbound_user_agent.py` patches `urlopen` to capture the real `Request` and asserts a non-default UA, so a future helper that forgets the header fails in CI, not prod.

## Item 2 — adversarial-fixture convention
Documented in AGENTS.md: any sanitizer/fence (untrusted-data delimiters, redaction, exfil guards) must have a test that feeds the boundary token / hostile delimiter *itself* — a mock that omits the attack encodes the same blind spot as the code (the #250 fence was escapable by content containing its own delimiter). Points at the existing red-team + UA tests as the pattern.

## Verified
6 new UA tests, full shell sweep, 25 smoke green. Test + doc only — no production code.

Out of scope (flagged separately): the AGENTS.md versioning line is stale (still says "feature releases stay on 1.2.x / v1.3.0 reserved for #197" — we're at v2.0.0).
