### PR TITLE
docs(agents): refresh stale versioning convention for v2.0.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,7 +132,7 @@ The smoke test validates: GitHub PR data collection, corpus assembly, OpenAI/Ant
 - Reserved metadata markers (`<!-- ai-pr-review-fingerprint:... -->`, `<!-- ai-pr-review-sha:... -->`) are stripped from model output before publishing; the precheck reads only the first occurrence of each
 - The `run_command` tool never executes model-supplied shell text — only named argv definitions from a fixed read-only catalog (`git_status_short`, `git_diff_stat`, `git_diff_name_only`)
 - Adversarial fixtures for security boundaries (#252): any sanitizer or fence (untrusted-data delimiters, secret redaction, exfil guards) must have a test that feeds the boundary token / hostile delimiter *itself*, not just benign input — a mock that omits the attack encodes the same blind spot as the code (the #250 fence was escapable by content containing its own closing delimiter). See `tests/test_native_loop_exfil_redteam.py` and the outbound-UA guard (`tests/test_outbound_user_agent.py`) for the pattern; add one when introducing a new fence.
-- Versioning: `v1.x.y` semver tags; feature releases stay on `1.2.x` (`v1.3.0` is reserved for the tool-calling milestone, issue #197)
+- Versioning: `vX.Y.Z` semver tags with floating major tags — `v1` tracks the 1.3.x line, `v2` tracks 2.x. Latest release: `v2.0.0` (breaking: `plan_execute` tool modes and `ai_fast_*` inputs removed, publish steps collapsed into one)
 
 ## Label taxonomy (`agent/*` and Dispatch workflow labels)
 


### PR DESCRIPTION
The AGENTS.md versioning bullet still claimed feature releases stay on `1.2.x` and `v1.3.0` was reserved for #197. Since then v1.3.0, v1.3.1, and v2.0.0 all shipped.

Updates it to current reality: semver `vX.Y.Z` tags with floating major tags (`v1` tracks 1.3.x, `v2` tracks 2.x); latest is `v2.0.0` (breaking — plan_execute modes and ai_fast_* inputs removed, publish steps collapsed).

Doc-only. Full sweep green (952 pytest, shell, 25 smoke).