### PR TITLE
feat(release): automate releases

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -1,0 +1,89 @@
+name: Manual Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version (for example 2.0.2 or v2.0.2)'
+        required: true
+        type: string
+
+concurrency:
+  group: manual-release
+  cancel-in-progress: false
+
+jobs:
+  publish-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Generate bot token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.BOT_CLIENT_ID }}
+          private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
+
+      - name: Checkout protected main
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: main
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Normalize release metadata
+        id: release
+        env:
+          RAW_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          VERSION="${RAW_VERSION#v}"
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.-]+)?$ ]]; then
+            echo "Invalid version: $RAW_VERSION"
+            exit 1
+          fi
+          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
+          echo "major_tag=v${VERSION%%.*}" >> "$GITHUB_OUTPUT"
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Create immutable version tag
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          SHA: ${{ steps.release.outputs.sha }}
+          TAG: ${{ steps.release.outputs.tag }}
+        run: |
+          set -euo pipefail
+          if EXISTING_SHA=$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$TAG" --jq .object.sha 2>/dev/null); then
+            if [ "$EXISTING_SHA" != "$SHA" ]; then
+              echo "Tag $TAG already points to $EXISTING_SHA"
+              exit 1
+            fi
+          else
+            gh api --method POST "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$TAG" -f sha="$SHA" >/dev/null
+          fi
+
+      - name: Advance floating major tag
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          MAJOR_TAG: ${{ steps.release.outputs.major_tag }}
+          SHA: ${{ steps.release.outputs.sha }}
+        run: |
+          set -euo pipefail
+          if gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$MAJOR_TAG" >/dev/null 2>&1; then
+            gh api --method PATCH "repos/$GITHUB_REPOSITORY/git/refs/tags/$MAJOR_TAG" -f sha="$SHA" -F force=true >/dev/null
+          else
+            gh api --method POST "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$MAJOR_TAG" -f sha="$SHA" >/dev/null
+          fi
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          TAG: ${{ steps.release.outputs.tag }}
+        run: |
+          set -euo pipefail
+          if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "Release $TAG already exists"
+          else
+            gh release create "$TAG" --repo "$GITHUB_REPOSITORY" --title "$TAG" --generate-notes
+          fi

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -43,9 +43,11 @@ jobs:
             echo "Invalid version: $RAW_VERSION"
             exit 1
           fi
-          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
-          echo "major_tag=v${VERSION%%.*}" >> "$GITHUB_OUTPUT"
-          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          {
+            echo "tag=v$VERSION"
+            echo "major_tag=v${VERSION%%.*}"
+            echo "sha=$(git rev-parse HEAD)"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Create immutable version tag
         env:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,13 +132,7 @@ The smoke test validates: GitHub PR data collection, corpus assembly, OpenAI/Ant
 - Reserved metadata markers (`<!-- ai-pr-review-fingerprint:... -->`, `<!-- ai-pr-review-sha:... -->`) are stripped from model output before publishing; the precheck reads only the first occurrence of each
 - The `run_command` tool never executes model-supplied shell text — only named argv definitions from a fixed read-only catalog (`git_status_short`, `git_diff_stat`, `git_diff_name_only`)
 - Adversarial fixtures for security boundaries (#252): any sanitizer or fence (untrusted-data delimiters, secret redaction, exfil guards) must have a test that feeds the boundary token / hostile delimiter *itself*, not just benign input — a mock that omits the attack encodes the same blind spot as the code (the #250 fence was escapable by content containing its own closing delimiter). See `tests/test_native_loop_exfil_redteam.py` and the outbound-UA guard (`tests/test_outbound_user_agent.py`) for the pattern; add one when introducing a new fence.
-- Versioning: `vX.Y.Z` semver tags with floating major tags — `v1` tracks the 1.3.x line, `v2` tracks 2.x. Latest release: `v2.0.0` (breaking: `plan_execute` tool modes and `ai_fast_*` inputs removed, publish steps collapsed into one)
-
-### Release process
-
-1. Confirm the intended changes are merged and CI is green on `main`.
-2. Open **Actions → Manual Release → Run workflow** and enter a version such as `2.0.2` (`v2.0.2` is also accepted).
-3. The workflow creates the immutable `vX.Y.Z` tag at protected `main`, advances the matching floating major tag, and publishes the GitHub release.
+- Versioning: `vX.Y.Z` semver tags with floating major tags — `v1` tracks the 1.3.x line, `v2` tracks 2.x. Latest release: `v2.0.0` (breaking: `plan_execute` tool modes and `ai_fast_*` inputs removed, publish steps collapsed into one). To release after CI is green on `main`, run **Actions → Manual Release** with the target version; it creates the immutable tag, advances the floating major tag, and publishes the release.
 
 ## Label taxonomy (`agent/*` and Dispatch workflow labels)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,6 +134,12 @@ The smoke test validates: GitHub PR data collection, corpus assembly, OpenAI/Ant
 - Adversarial fixtures for security boundaries (#252): any sanitizer or fence (untrusted-data delimiters, secret redaction, exfil guards) must have a test that feeds the boundary token / hostile delimiter *itself*, not just benign input — a mock that omits the attack encodes the same blind spot as the code (the #250 fence was escapable by content containing its own closing delimiter). See `tests/test_native_loop_exfil_redteam.py` and the outbound-UA guard (`tests/test_outbound_user_agent.py`) for the pattern; add one when introducing a new fence.
 - Versioning: `vX.Y.Z` semver tags with floating major tags — `v1` tracks the 1.3.x line, `v2` tracks 2.x. Latest release: `v2.0.0` (breaking: `plan_execute` tool modes and `ai_fast_*` inputs removed, publish steps collapsed into one)
 
+### Release process
+
+1. Confirm the intended changes are merged and CI is green on `main`.
+2. Open **Actions → Manual Release → Run workflow** and enter a version such as `2.0.2` (`v2.0.2` is also accepted).
+3. The workflow creates the immutable `vX.Y.Z` tag at protected `main`, advances the matching floating major tag, and publishes the GitHub release.
+
 ## Label taxonomy (`agent/*` and Dispatch workflow labels)
 
 Labels are defined in `.github/labels.yaml`. There are two distinct groups that agents interact with:

--- a/README.md
+++ b/README.md
@@ -1070,6 +1070,8 @@ Releases are cut when features or fixes are ready. The `v1.x.y` scheme follows s
 - **Minor** (`x`): new features, backward-compatible changes
 - **Major** (`v1` → `v2`): breaking changes to inputs/outputs or behavior
 
+To publish, run **Actions → Manual Release → Run workflow** with the target version. The workflow tags protected `main`, advances the matching floating major tag (`v1`, `v2`, and so on), and creates the GitHub release.
+
 To stay current, subscribe to [GitHub Releases](https://github.com/misospace/pr-reviewer-action/releases) or enable Renovate to track the `misospace/pr-reviewer-action` dependency.
 
 ## 🔐 Security

--- a/pr_reviewer/classifier.py
+++ b/pr_reviewer/classifier.py
@@ -237,8 +237,7 @@ def _classify_pr_kind(
     has_dep_file = any(
         any(pat.search(f) for pat in DEPENDENCY_PATTERNS) for f in filenames
     )
-    has_version_bump_val = _has_version_bump(diff_text)
-    if has_dep_file or has_version_bump_val:
+    if has_dep_file:
         # But exclude k8s manifests that happen to reference versions
         has_k8s = any(
             any(pat.search(f) for pat in K8S_PATTERNS) for f in filenames

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -115,6 +115,18 @@ class TestPRKindDependencyUpgrade:
         kind = _classify_pr_kind(files, "")
         assert kind == "dependency_upgrade"
 
+    def test_workflow_semver_text_is_not_dependency_upgrade(self):
+        files = [_make_file(".github/workflows/manual-release.yml")]
+        diff = "Release version (for example 2.0.2 or v2.0.2)"
+        kind = _classify_pr_kind(files, diff)
+        assert kind == "app_code"
+
+    def test_source_version_constant_is_not_dependency_upgrade(self):
+        files = [_make_file("src/version.py")]
+        diff = '-VERSION = "1.2.3"\n+VERSION = "1.2.4"'
+        kind = _classify_pr_kind(files, diff)
+        assert kind == "app_code"
+
 
 class TestPRKindK8sManifest:
     @pytest.mark.parametrize("fname", [


### PR DESCRIPTION
Add a tag-only manual release workflow for this unversioned action repository. It creates `vX.Y.Z` from protected `main`, advances the matching floating major tag, and publishes generated notes.

Validated with YAML parsing and `git diff --check`.