### PR TITLE
fix(forgejo): send POST body via stdin; surface publish failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,7 @@ Only three inputs are required: `github_token`, `ai_base_url`, and `ai_model`. E
 | `tool_enable_for_forks` | Allow tool harness on cross-repository PRs | No | `false` |
 | `tool_mcp_servers` | Allowlist of read-only MCP servers for `tool_mode: native_loop`, as a newline/comma list of `name=url`. Read-verb tools are advertised as `mcp__<name>__<tool>`; write-verb tools are refused. Empty = off. Fork-gated like the rest of the harness | No | `""` |
 | `tool_mcp_token` | Optional bearer token sent to every configured MCP server | No | `""` |
+| `tool_mcp_name_prefixes` | Comma-separated list of tool name prefixes to strip before the read-only verb check. Used to handle toolhive-style workload prefixes (`prefixFormat: "{workload}_"`) on aggregated MCP servers — e.g. `github-mcp,talos-mcp`. Empty preserves the default-deny boundary | No | `""` |
 
 </details>
 

--- a/action.yml
+++ b/action.yml
@@ -451,6 +451,10 @@ inputs:
     description: Optional bearer token sent to every configured MCP server (tool_mcp_servers)
     required: false
     default: ""
+  tool_mcp_name_prefixes:
+    description: Comma-separated list of tool name prefixes to strip before the read-only verb check (e.g. toolhive workload prefixes from `prefixFormat: "{workload}_"`). Empty preserves the default-deny boundary.
+    required: false
+    default: ""
   ai_request_timeout_sec:
     description: Timeout in seconds for the primary model API request (curl --max-time)
     required: false
@@ -657,6 +661,7 @@ runs:
         TOOL_MODE: ${{ inputs.tool_mode }}
         TOOL_MCP_SERVERS: ${{ inputs.tool_mcp_servers }}
         TOOL_MCP_TOKEN: ${{ inputs.tool_mcp_token }}
+        TOOL_MCP_NAME_PREFIXES: ${{ inputs.tool_mcp_name_prefixes }}
         TOOL_LOOP_WALL_CLOCK_SEC: ${{ inputs.tool_loop_wall_clock_sec }}
         TOOL_LOOP_SUMMARIZE: ${{ inputs.tool_loop_summarize }}
         TOOL_LOOP_SUMMARIZE_MAX_TOKENS: ${{ inputs.tool_loop_summarize_max_tokens }}
@@ -767,6 +772,7 @@ runs:
         TOOL_MODE: ${{ inputs.tool_mode }}
         TOOL_MCP_SERVERS: ${{ inputs.tool_mcp_servers }}
         TOOL_MCP_TOKEN: ${{ inputs.tool_mcp_token }}
+        TOOL_MCP_NAME_PREFIXES: ${{ inputs.tool_mcp_name_prefixes }}
         TOOL_LOOP_WALL_CLOCK_SEC: ${{ inputs.tool_loop_wall_clock_sec }}
         TOOL_LOOP_SUMMARIZE: ${{ inputs.tool_loop_summarize }}
         TOOL_LOOP_SUMMARIZE_MAX_TOKENS: ${{ inputs.tool_loop_summarize_max_tokens }}

--- a/action.yml
+++ b/action.yml
@@ -452,7 +452,11 @@ inputs:
     required: false
     default: ""
   tool_mcp_name_prefixes:
-    description: Comma-separated list of tool name prefixes to strip before the read-only verb check (e.g. toolhive workload prefixes from `prefixFormat: "{workload}_"`). Empty preserves the default-deny boundary.
+    description: >-
+      Comma-separated list of tool name prefixes to strip before the
+      read-only verb check (e.g. toolhive workload prefixes from
+      `prefixFormat: "{workload}_"`). Empty preserves the default-deny
+      boundary.
     required: false
     default: ""
   ai_request_timeout_sec:

--- a/pr_reviewer/forgejo_backend.py
+++ b/pr_reviewer/forgejo_backend.py
@@ -88,12 +88,12 @@ def _curl(
     ]
     if data is not None and method.upper() in ("POST", "PATCH", "PUT"):
         if isinstance(data, bytes):
-            cmd.extend(["--data-binary", "@-"])
-            proc = subprocess.run(cmd, input=data, capture_output=True)
+            body_bytes = data
         else:
-            body_json = json.dumps(data).encode("utf-8")
+            body_bytes = json.dumps(data).encode("utf-8")
             cmd.extend(["-H", "Content-Type: application/json"])
-            proc = subprocess.run(cmd, input=body_json, capture_output=True)
+        cmd.extend(["--data-binary", "@-"])
+        proc = subprocess.run(cmd, input=body_bytes, capture_output=True)
     else:
         proc = subprocess.run(cmd, capture_output=True)
 
@@ -924,9 +924,13 @@ def main() -> None:
     elif args.command == "create-comment":
         result = create_comment(args.repo, args.issue_number, args.body)
         print(json.dumps(result, indent=2) if result else "null")
+        if result is None:
+            sys.exit(1)
     elif args.command == "edit-last-comment":
         result = edit_last_comment(args.repo, args.issue_number, args.body)
         print(json.dumps(result, indent=2) if result else "null")
+        if result is None:
+            sys.exit(1)
     elif args.command == "fetch-issue":
         result = fetch_issue(args.repo, args.issue_number)
         print(json.dumps(result, indent=2) if result else "null")

--- a/pr_reviewer/mcp_client.py
+++ b/pr_reviewer/mcp_client.py
@@ -40,11 +40,18 @@ READ_ONLY_VERBS = frozenset(
 
 
 def is_read_only_tool(name: str) -> bool:
-    """True if a tool name begins with an allowlisted read verb."""
+    """True if a tool name begins with an allowlisted read verb.
+
+    Scans the first three ``_``-segments so toolhive-prefixed tools
+    (e.g. ``github-mcp_list_issues``) still register.
+    """
     if not isinstance(name, str) or not name:
         return False
-    head = name.strip().lower().replace("-", "_").split("_", 1)[0]
-    return head in READ_ONLY_VERBS
+    parts = name.strip().lower().replace("-", "_").split("_", 3)
+    for part in parts[:3]:
+        if part in READ_ONLY_VERBS:
+            return True
+    return False
 
 
 def namespaced_name(server: str, tool: str) -> str:

--- a/pr_reviewer/mcp_client.py
+++ b/pr_reviewer/mcp_client.py
@@ -39,19 +39,22 @@ READ_ONLY_VERBS = frozenset(
 )
 
 
-def is_read_only_tool(name: str) -> bool:
+def is_read_only_tool(name: str, prefixes: tuple[str, ...] = ()) -> bool:
     """True if a tool name begins with an allowlisted read verb.
 
-    Scans the first three ``_``-segments so toolhive-prefixed tools
-    (e.g. ``github-mcp_list_issues``) still register.
+    If a prefix from ``prefixes`` matches the (normalized) leading
+    ``workload_`` segment, it is stripped before the verb check.
     """
     if not isinstance(name, str) or not name:
         return False
-    parts = name.strip().lower().replace("-", "_").split("_", 3)
-    for part in parts[:3]:
-        if part in READ_ONLY_VERBS:
-            return True
-    return False
+    normalized = name.strip().lower().replace("-", "_")
+    for prefix in prefixes:
+        prefix_n = prefix.strip().lower().replace("-", "_").rstrip("_")
+        if prefix_n and normalized.startswith(prefix_n + "_"):
+            normalized = normalized[len(prefix_n) + 1:]
+            break
+    head = normalized.split("_", 1)[0]
+    return head in READ_ONLY_VERBS
 
 
 def namespaced_name(server: str, tool: str) -> str:
@@ -119,11 +122,15 @@ class McpToolset:
     """An initialized connection to one allowlisted MCP server."""
 
     def __init__(self, server: str, url: str, token: str = "", *, timeout: int = 20,
-                 post_fn: Callable | None = None):
+                 post_fn: Callable | None = None, name_prefixes: tuple[str, ...] = ()):
         self.server = server
         self.url = url
         self.token = token
         self.timeout = timeout
+        self._name_prefixes = tuple(
+            p.strip().lower().replace("-", "_").rstrip("_")
+            for p in name_prefixes if p and p.strip()
+        )
         # Runtime lookup of the default so tests can monkeypatch _default_post.
         self._post = post_fn or _default_post
         self._session_id: str | None = None
@@ -168,7 +175,7 @@ class McpToolset:
             if not isinstance(tool, dict):
                 continue
             name = tool.get("name")
-            if not isinstance(name, str) or not is_read_only_tool(name):
+            if not isinstance(name, str) or not is_read_only_tool(name, self._name_prefixes):
                 continue  # default-deny non-read-verb tools
             schema = tool.get("inputSchema")
             if not isinstance(schema, dict):
@@ -190,7 +197,7 @@ class McpToolset:
         Re-checks the read-only allowlist at call time (defence in depth) and
         refuses any tool not surfaced by connect().
         """
-        if tool not in self._tool_names or not is_read_only_tool(tool):
+        if tool not in self._tool_names or not is_read_only_tool(tool, self._name_prefixes):
             return {"error": f"MCP tool not allowed: {tool}"}
         result, error = self._rpc(
             "tools/call", {"name": tool, "arguments": args or {}}, msg_id=3

--- a/scripts/run_tool_harness.py
+++ b/scripts/run_tool_harness.py
@@ -436,9 +436,13 @@ def run_native_loop(
     # tool_enable_for_forks), so reaching here means MCP is permitted. A server
     # that fails to connect is logged and skipped — never breaks the loop.
     mcp_routes = {}
+    name_prefixes = tuple(
+        p.strip() for p in os.getenv("TOOL_MCP_NAME_PREFIXES", "").split(",") if p.strip()
+    )
     for srv_name, srv_url in parse_server_specs(os.getenv("TOOL_MCP_SERVERS", "")):
         toolset = McpToolset(
-            srv_name, srv_url, os.getenv("TOOL_MCP_TOKEN", ""), timeout=request_timeout
+            srv_name, srv_url, os.getenv("TOOL_MCP_TOKEN", ""),
+            timeout=request_timeout, name_prefixes=name_prefixes,
         )
         try:
             connect_error = toolset.connect()

--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -58,6 +58,30 @@ def test_is_read_only_tool():
         assert not is_read_only_tool(bad)
 
 
+def test_is_read_only_tool_default_deny_boundary():
+    # Regression: write tools whose second _-segment matches a read verb
+    # must stay denied when no prefix is configured. The earlier
+    # any-segment scan admitted these.
+    for bad in ("set_status", "create_view", "update_diff", "refresh_status",
+                "delete_query", "run_search", "set_y", "exec_z"):
+        assert not is_read_only_tool(bad), f"{bad!r} must be denied"
+
+
+def test_is_read_only_tool_strips_known_prefix():
+    prefixes = ("github-mcp",)
+    for ok in ("github-mcp_list_issues", "github-mcp_get_pr", "github-mcp_search"):
+        assert is_read_only_tool(ok, prefixes), f"{ok!r} should be admitted"
+    for bad in ("github-mcp_set_status", "github-mcp_create_view",
+                "github-mcp_update_config", "github-mcp_delete_pr"):
+        assert not is_read_only_tool(bad, prefixes), f"{bad!r} must be denied"
+
+
+def test_is_read_only_tool_prefix_partial_match_rejected():
+    prefixes = ("github-mcp",)
+    assert not is_read_only_tool("github_list_issues", prefixes)
+    assert not is_read_only_tool("github-mcpology_list", prefixes)
+
+
 def test_connect_advertises_only_read_only_namespaced():
     ts = McpToolset("konflate", "http://x/mcp", post_fn=_stub(_KONFLATE_TOOLS))
     assert ts.connect() is None


### PR DESCRIPTION
On the forgejo path, the publish step silently swallowed every API failure: the comment never posted, the job stayed green, no error in the log.

**Root cause**: `forgejo_backend.py:_curl` never passes `--data-binary @-` to curl on the dict-body path. POST/PATCH/PUT requests went out with an empty body, `create_comment` / `edit_last_comment` returned `None`, the CLI dispatcher printed `"null"` and exited 0, and `platform_api.sh` redirects stdout to `/dev/null`. Compounded by the dispatcher's lack of `sys.exit(1)` on `None` for those two subcommands — the other forgejo subcommands (`create-review-json`, `create-native-review`, `dismiss-review`) already do.

**Verified by**: a debug workflow step that ran a raw `curl` POST to the same endpoint with the same token — `http_status=201` immediately, confirming the API, URL, and token were all correct and the action's Python wrapper was the only thing broken.

**Three commits**:
1. `fix(forgejo): send POST body via stdin; surface publish failures` — `_curl` passes `--data-binary @-` unconditionally on the dict path; CLI `main()` `sys.exit(1)`s on `None` for `create-comment` and `edit-last-comment`
2. `feat(mcp): accept tool_name_prefixes to handle toolhive workload prefixes` — `is_read_only_tool` strips a known workload prefix (e.g. `github-mcp_`) before the leading-verb check, so aggregated MCP servers still register. Default-deny boundary preserved (tests assert `set_status`, `create_view`, `update_diff`, `refresh_status`, `delete_query`, `run_search` stay refused). Opt-in via new `tool_mcp_name_prefixes` input (default empty)
3. `docs(readme): document tool_mcp_name_prefixes input`