### PR TITLE
feat(enrichment): fetch upstream content for forge-hosted, rolling-tag, and OCI-chart bumps

### DIFF
--- a/pr_reviewer/forgejo_backend.py
+++ b/pr_reviewer/forgejo_backend.py
@@ -77,15 +77,16 @@ def _curl(
     # are not guaranteed to end with whitespace (an empty 204 body, or compact
     # JSON without a trailing newline, would otherwise fuse with the code and
     # make it unparseable).
-    cmd: list[str] = [
-        "curl", "-sS",
-        "-X", method.upper(),
-        "-H", f"Authorization: token {token}",
+    cmd: list[str] = ["curl", "-sS", "-X", method.upper()]
+    # Empty token: fetch unauthenticated (don't send our token to other forges).
+    if token:
+        cmd.extend(["-H", f"Authorization: token {token}"])
+    cmd.extend([
         "-H", f"Accept: {accept}",
         "-o", "-",
         "-w", "\n%{http_code}",
         url,
-    ]
+    ])
     if data is not None and method.upper() in ("POST", "PATCH", "PUT"):
         if isinstance(data, bytes):
             body_bytes = data
@@ -493,6 +494,48 @@ def compare_commits(repo_full_name: str, spec: str) -> dict[str, Any] | None:
 
 
 # ---------------------------------------------------------------------------
+# Linked-source enrichment against arbitrary Forgejo/Gitea instances
+# ---------------------------------------------------------------------------
+# The upstream repo may live on a different forge than the PR, so host is an
+# explicit argument (vs platform_*, which use the configured FORGEJO_API_URL).
+
+def _enrich_token_for_host(host: str) -> str:
+    """Token for *host*: the configured instance only, else empty (unauth)."""
+    configured = re.sub(r"^https?://", "", FORGEJO_API_URL).strip("/").lower()
+    return FORGEJO_TOKEN if (configured and host.lower() == configured) else ""
+
+
+def fetch_forge_release(host: str, repo_full_name: str, tag: str) -> dict[str, Any] | None:
+    """Release by tag from a Forgejo/Gitea *host*; None on failure."""
+    owner, repo = _parse_repo(repo_full_name)
+    url = f"https://{host}/api/v1/repos/{owner}/{repo}/releases/tags/{quote(tag, safe='')}"
+    status_code, body = _curl("GET", url, token=_enrich_token_for_host(host))
+    if status_code != 200:
+        return None
+    data = _json_decode(body)
+    if not isinstance(data, dict):
+        return None
+    return {
+        "tag_name": data.get("tag_name", tag),
+        "name": data.get("name", ""),
+        "published_at": data.get("published_at", data.get("created_at", "")),
+        "html_url": data.get("html_url", data.get("url", "")),
+        "body": data.get("body", ""),
+    }
+
+
+def fetch_forge_compare(host: str, repo_full_name: str, spec: str) -> dict[str, Any] | None:
+    """Compare (``base...head``) from a Forgejo/Gitea *host*; None on failure."""
+    owner, repo = _parse_repo(repo_full_name)
+    url = f"https://{host}/api/v1/repos/{owner}/{repo}/compare/{quote(spec, safe='')}"
+    status_code, body = _curl("GET", url, token=_enrich_token_for_host(host))
+    if status_code != 200:
+        return None
+    data = _json_decode(body)
+    return data if isinstance(data, dict) else None
+
+
+# ---------------------------------------------------------------------------
 # PR Files (for classifier)
 # ---------------------------------------------------------------------------
 
@@ -891,6 +934,16 @@ def main() -> None:
     p_compare.add_argument("repo")
     p_compare.add_argument("spec")
 
+    p_enrich_release = sub.add_parser("enrich-release")
+    p_enrich_release.add_argument("host")
+    p_enrich_release.add_argument("repo")
+    p_enrich_release.add_argument("tag")
+
+    p_enrich_compare = sub.add_parser("enrich-compare")
+    p_enrich_compare.add_argument("host")
+    p_enrich_compare.add_argument("repo")
+    p_enrich_compare.add_argument("spec")
+
     p_reviews = sub.add_parser("list-pr-reviews")
     p_reviews.add_argument("repo")
     p_reviews.add_argument("pr_number", type=int)
@@ -941,6 +994,18 @@ def main() -> None:
         print(json.dumps(result, indent=2) if result else "null")
     elif args.command == "compare":
         result = compare_commits(args.repo, args.spec)
+        if result is None:
+            print("null")
+            sys.exit(1)
+        print(json.dumps(result, indent=2))
+    elif args.command == "enrich-release":
+        result = fetch_forge_release(args.host, args.repo, args.tag)
+        if result is None:
+            print("null")
+            sys.exit(1)
+        print(json.dumps(result, indent=2))
+    elif args.command == "enrich-compare":
+        result = fetch_forge_compare(args.host, args.repo, args.spec)
         if result is None:
             print("null")
             sys.exit(1)

--- a/scripts/platform_api.sh
+++ b/scripts/platform_api.sh
@@ -292,3 +292,18 @@ platform_commit_status() {
 github_enrich_api() {
   gh api "$@"
 }
+
+# Linked-source enrichment against an arbitrary upstream forge host. Print the
+# JSON object on stdout, or `null` + nonzero exit when unavailable.
+
+forgejo_enrich_release() {
+  # $1=host $2=owner/repo $3=tag
+  PYTHONPATH="${_PLATFORM_SCRIPT_DIR}/..${PYTHONPATH:+:${PYTHONPATH}}" \
+    python3 -m pr_reviewer.forgejo_backend enrich-release "$1" "$2" "$3"
+}
+
+forgejo_enrich_compare() {
+  # $1=host $2=owner/repo $3=base...head
+  PYTHONPATH="${_PLATFORM_SCRIPT_DIR}/..${PYTHONPATH:+:${PYTHONPATH}}" \
+    python3 -m pr_reviewer.forgejo_backend enrich-compare "$1" "$2" "$3"
+}

--- a/scripts/sections/config.sh
+++ b/scripts/sections/config.sh
@@ -25,6 +25,14 @@ AI_PRIMARY_RETRY_DELAY_SEC="${AI_PRIMARY_RETRY_DELAY_SEC:-15}"
 AI_STREAM="${AI_STREAM:-true}"
 AI_FALLBACK_STREAM="${AI_FALLBACK_STREAM:-$AI_STREAM}"
 ALLOWED_SOURCE_HOSTS="${ALLOWED_SOURCE_HOSTS:-github.com,api.github.com,gitlab.com,registry.terraform.io,artifacthub.io}"
+# Implicitly trust the configured forge host as a linked source.
+if [ -n "${FORGEJO_API_URL:-}" ]; then
+  _self_source_host=$(printf '%s' "$FORGEJO_API_URL" | sed -E 's#^https?://([^/]+).*#\1#' | tr '[:upper:]' '[:lower:]')
+  case ",${ALLOWED_SOURCE_HOSTS}," in
+    *",${_self_source_host},"*) : ;;
+    *) [ -n "$_self_source_host" ] && ALLOWED_SOURCE_HOSTS="${ALLOWED_SOURCE_HOSTS},${_self_source_host}" ;;
+  esac
+fi
 GH_TOKEN="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
 SYSTEM_PROMPT="${SYSTEM_PROMPT:-}"
 SYSTEM_PROMPT_FILE="${SYSTEM_PROMPT_FILE:-}"

--- a/scripts/sections/context.sh
+++ b/scripts/sections/context.sh
@@ -96,10 +96,25 @@ head -n 25 urls.all.txt > urls.txt || true
 grep -E '^[+-].*(image:|tag:|version:|chart:|appVersion:|digest:)' pr.diff.truncated > version-hints.txt || true
 head -n 180 version-hints.txt > version-hints.truncated.txt || true
 
-grep -Eo 'ghcr\.io/[^/]+/[^:"@ ]+' version-hints.txt | sort -u > ghcr-images.txt || true
-sedi 's#ghcr\.io/##' ghcr-images.txt
-sedi 's#:.*##' ghcr-images.txt
-sort -u ghcr-images.txt -o ghcr-images.txt
+# ghcr.io image/chart repos for upstream release lookup. Scans the diff (with
+# context) too: a chart `url:` often sits outside the changed +/- lines.
+# Multi-segment chart paths are kept whole; tag/digest stripped.
+{ cat version-hints.txt; grep -Eo '(oci://)?ghcr\.io/[^"'"'"' )]+' pr.diff.truncated 2>/dev/null; } \
+  | grep -Eo 'ghcr\.io/[^/]+(/[^:"@ )]+)+' \
+  | sed -E 's#^ghcr\.io/##; s#[:@].*##' \
+  | sort -u > ghcr-images.txt || true
+
+# Old→new short-SHA pair from <version>-<gitsha> tags, for a commit-compare
+# fallback when upstream cuts no release. Only when the pairing is unambiguous.
+: > compare-shas.txt
+_old_sha=$(grep -E '^-' version-hints.txt | grep -oiE '\b[0-9a-f]{7,40}\b' | grep -iE '[a-f]' | sort -u)
+_new_sha=$(grep -E '^\+' version-hints.txt | grep -oiE '\b[0-9a-f]{7,40}\b' | grep -iE '[a-f]' | sort -u)
+if [ -n "$_old_sha" ] \
+  && [ "$(printf '%s\n' "$_old_sha" | grep -c .)" = "1" ] \
+  && [ "$(printf '%s\n' "$_new_sha" | grep -c .)" = "1" ] \
+  && [ "$_old_sha" != "$_new_sha" ]; then
+  printf '%s %s\n' "$_old_sha" "$_new_sha" > compare-shas.txt
+fi
 
 section_timer_start "manifest-context"
 log "Gathering changed manifest context..."

--- a/scripts/sections/enrichment.sh
+++ b/scripts/sections/enrichment.sh
@@ -8,7 +8,8 @@ log "Gathering linked sources..."
 : > linked-sources.md
 if [ -s urls.txt ]; then
   ENRICHMENT_START_TS=$(date +%s)
-  TARGET_VERSION="$(jq -r '.title' pr.json | sed -n 's/.*→ *v\?\([0-9][0-9.]*\).*/\1/p' | head -n1)"
+  # New version = last version token in the title (arrow-glyph agnostic).
+  TARGET_VERSION="$(jq -r '.title' pr.json | grep -oE 'v?[0-9]+(\.[0-9]+)+' | tail -n1 | sed 's/^v//')"
   if [ -z "$TARGET_VERSION" ]; then
     TARGET_VERSION="$(grep -Eo 'v?[0-9]+\.[0-9]+\.[0-9]+' version-hints.truncated.txt 2>/dev/null | sed 's/^v//' | tail -n1 || true)"
   fi
@@ -141,6 +142,40 @@ if [ -s urls.txt ]; then
       fi
     fi
 
+    # Forge-hosted sources (same URL shapes as GitHub): query /api/v1.
+    # github.com is handled above; a non-Forgejo host returns non-JSON → degrade.
+    case "$host" in github.com) ;; *) if url_host_allowed "$normalized_url"; then
+      if [[ "$normalized_url" =~ ^https?://([^/]+)/([^/]+)/([^/]+)/releases/tag/([^/?#]+) ]]; then
+        fg_host="${BASH_REMATCH[1]}"; fg_owner="${BASH_REMATCH[2]}"
+        fg_repo="${BASH_REMATCH[3]}"; fg_tag="${BASH_REMATCH[4]}"
+        echo >> linked-sources.md
+        echo "### Forge Release Metadata: $fg_host $fg_owner/$fg_repo@$fg_tag" >> linked-sources.md
+        if enrichment_budget_ok && forgejo_enrich_release "$fg_host" "$fg_owner/$fg_repo" "$fg_tag" > forge-release.json 2>/dev/null && [ "$(jq -r 'type' forge-release.json 2>/dev/null)" = "object" ]; then
+          echo '```json' >> linked-sources.md
+          head -c 6000 forge-release.json >> linked-sources.md
+          echo >> linked-sources.md
+          echo '```' >> linked-sources.md
+        else
+          echo "(Could not fetch release metadata from $fg_host for tag $fg_tag)" >> linked-sources.md
+        fi
+      fi
+      if [[ "$normalized_url" =~ ^https?://([^/]+)/([^/]+)/([^/]+)/compare/([^?#]+)$ ]]; then
+        fg_host="${BASH_REMATCH[1]}"; fg_owner="${BASH_REMATCH[2]}"
+        fg_repo="${BASH_REMATCH[3]}"; fg_spec="${BASH_REMATCH[4]}"
+        echo >> linked-sources.md
+        echo "### Forge Compare Metadata: $fg_host $fg_owner/$fg_repo@$fg_spec" >> linked-sources.md
+        if enrichment_budget_ok && forgejo_enrich_compare "$fg_host" "$fg_owner/$fg_repo" "$fg_spec" > forge-compare.json 2>/dev/null && [ "$(jq -r 'type' forge-compare.json 2>/dev/null)" = "object" ]; then
+          jq -c '{total_commits,commits:[.commits[]?|{sha,commit:{message}}],files:[.files[]?|{filename,status,additions,deletions}]}' forge-compare.json > forge-compare.filtered.json 2>/dev/null || cp forge-compare.json forge-compare.filtered.json
+          echo '```json' >> linked-sources.md
+          head -c 7000 forge-compare.filtered.json >> linked-sources.md
+          echo >> linked-sources.md
+          echo '```' >> linked-sources.md
+        else
+          echo "(Could not fetch compare metadata from $fg_host for $fg_spec)" >> linked-sources.md
+        fi
+      fi
+    fi ;; esac
+
     if [[ "$normalized_url" =~ ^https?://github\.com/([^/]+)/([^/?#]+) ]]; then
       owner="${BASH_REMATCH[1]}"
       repo="${BASH_REMATCH[2]}"
@@ -218,11 +253,16 @@ if [ -s urls.txt ]; then
         continue
       fi
 
-      owner="${img_repo%/*}"
-      repo="${img_repo#*/}"
-      if [ -z "$owner" ] || [ -z "$repo" ] || [[ "$owner" == *"/"* ]]; then
+      # Source repo = first + last segment (home-operations/charts/tuppr →
+      # home-operations/tuppr).
+      owner="${img_repo%%/*}"
+      repo="${img_repo##*/}"
+      if [ -z "$owner" ] || [ -z "$repo" ] || [ "$owner" = "$img_repo" ]; then
         continue
       fi
+
+      # Clear prior iteration's files so they don't mask this image's result.
+      rm -f ghcr-release.json ghcr-release.filtered.json ghcr-compare.json ghcr-compare.filtered.json ghcr-compare.files.json
 
       echo >> linked-sources.md
       echo "### GitHub Release Lookup via ghcr.io Path: $owner/$repo" >> linked-sources.md
@@ -239,11 +279,33 @@ if [ -s urls.txt ]; then
             break
           fi
         done
-        if [ ! -s ghcr-release.json ] || [ ! -s ghcr-release.filtered.json ]; then
+        if [ ! -s ghcr-release.filtered.json ]; then
           echo "(No release found for $owner/$repo at version $TARGET_VERSION via ghcr.io path inference)" >> linked-sources.md
         fi
       else
         echo "(TARGET_VERSION not set; skipping release lookup for $owner/$repo)" >> linked-sources.md
+      fi
+
+      # No release for this version: fall back to a commit compare of the
+      # old→new tag SHAs.
+      if [ ! -s ghcr-release.filtered.json ] && [ -s compare-shas.txt ]; then
+        read -r cmp_old cmp_new < compare-shas.txt
+        if [ -n "$cmp_old" ] && [ -n "$cmp_new" ] && enrichment_budget_ok \
+          && github_enrich_api "repos/$owner/$repo/compare/$cmp_old...$cmp_new" > ghcr-compare.json 2>/dev/null \
+          && [ -n "$(jq -r '.status // empty' ghcr-compare.json 2>/dev/null)" ]; then
+          echo "#### Commit compare $cmp_old...$cmp_new (no release published for this version)" >> linked-sources.md
+          jq -c '{html_url,status,ahead_by,total_commits,commits:[.commits[]?|{sha,commit:{message}}]}' ghcr-compare.json > ghcr-compare.filtered.json
+          echo '```json' >> linked-sources.md
+          head -c 6000 ghcr-compare.filtered.json >> linked-sources.md
+          echo >> linked-sources.md
+          echo '```' >> linked-sources.md
+          jq -c '[.files[]?|{filename,status,additions,deletions,changes}]' ghcr-compare.json > ghcr-compare.files.json
+          echo "#### Changed Files" >> linked-sources.md
+          echo '```json' >> linked-sources.md
+          head -c 5000 ghcr-compare.files.json >> linked-sources.md
+          echo >> linked-sources.md
+          echo '```' >> linked-sources.md
+        fi
       fi
     done < ghcr-images.txt
   fi

--- a/tests/test_forgejo_backend.py
+++ b/tests/test_forgejo_backend.py
@@ -818,5 +818,81 @@ class TestGetCommitStatus(unittest.TestCase):
         self.assertIsNone(result)
 
 
+class TestForgeEnrichment(unittest.TestCase):
+    """Cross-host linked-source enrichment (release-by-tag / compare)."""
+
+    _RELEASE = {
+        "tag_name": "v0.4.21",
+        "name": "v0.4.21",
+        "published_at": "2026-06-28T00:00:00Z",
+        "html_url": "https://codeberg.org/o/r/releases/tag/v0.4.21",
+        "body": "patch bump",
+    }
+    _COMPARE = {"total_commits": 2, "commits": [{"sha": "a"}], "files": [{"filename": "x"}]}
+
+    @_PATCH_FORGEJO
+    def test_release_normalises_to_github_subset(self, mock_curl):
+        url_map = {"https://codeberg.org/api/v1/repos/o/r/releases/tags/v0.4.21": (200, json.dumps(self._RELEASE))}
+        mock_curl.side_effect = _make_curl_mock(url_map)
+        result = fb.fetch_forge_release("codeberg.org", "o/r", "v0.4.21")
+        self.assertEqual(result["tag_name"], "v0.4.21")
+        self.assertEqual(result["body"], "patch bump")
+        self.assertEqual(sorted(result), ["body", "html_url", "name", "published_at", "tag_name"])
+
+    @_PATCH_FORGEJO
+    def test_release_not_found_returns_none(self, mock_curl):
+        mock_curl.side_effect = _make_curl_mock({})
+        self.assertIsNone(fb.fetch_forge_release("codeberg.org", "o/r", "v9.9.9"))
+
+    @_PATCH_FORGEJO
+    def test_compare_returns_raw_object(self, mock_curl):
+        url_map = {"https://codeberg.org/api/v1/repos/o/r/compare/a...b": (200, json.dumps(self._COMPARE))}
+        mock_curl.side_effect = _make_curl_mock(url_map)
+        result = fb.fetch_forge_compare("codeberg.org", "o/r", "a...b")
+        self.assertEqual(result["total_commits"], 2)
+
+    @_PATCH_FORGEJO
+    def test_compare_failure_returns_none(self, mock_curl):
+        mock_curl.side_effect = _make_curl_mock({})
+        self.assertIsNone(fb.fetch_forge_compare("codeberg.org", "o/r", "missing...head"))
+
+    def test_token_sent_only_to_configured_instance(self):
+        # Token goes to the configured host only, never to other forges.
+        with patch.object(fb, "FORGEJO_API_URL", "https://git.example.com"), \
+             patch.object(fb, "FORGEJO_TOKEN", "SECRET"):
+            self.assertEqual(fb._enrich_token_for_host("git.example.com"), "SECRET")
+            self.assertEqual(fb._enrich_token_for_host("codeberg.org"), "")
+
+    def test_release_uses_host_token_guard(self):
+        # fetch_forge_release must pass the empty token for a foreign host.
+        seen = {}
+
+        def _spy(method, url, token=None, **kwargs):
+            seen["token"] = token
+            return 200, json.dumps(self._RELEASE)
+
+        with patch.object(fb, "FORGEJO_API_URL", "https://git.example.com"), \
+             patch.object(fb, "FORGEJO_TOKEN", "SECRET"), \
+             patch.object(fb, "_curl", side_effect=_spy):
+            fb.fetch_forge_release("codeberg.org", "o/r", "v1")
+        self.assertEqual(seen["token"], "")
+
+    def test_curl_omits_auth_header_when_token_empty(self):
+        # An empty token must not produce an Authorization header.
+        captured = {}
+
+        class _Proc:
+            stdout = b'{}\n200'
+            returncode = 0
+
+        def _fake_run(cmd, **kwargs):
+            captured["cmd"] = cmd
+            return _Proc()
+
+        with patch.object(fb.subprocess, "run", side_effect=_fake_run):
+            fb._curl("GET", "https://codeberg.org/api/v1/x", token="")
+        self.assertFalse(any(str(c).startswith("Authorization") for c in captured["cmd"]))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_platform_api.sh
+++ b/tests/test_platform_api.sh
@@ -115,6 +115,13 @@ check "platform_commit_status" \
 check "github_enrich_api passthrough" \
   "$(run_seam github "" 'github_enrich_api repos/up/stream/releases?per_page=8')" \
   "gh api repos/up/stream/releases?per_page=8"
+# Forge enrichment helpers dispatch to the backend CLI for any host.
+check "forgejo_enrich_release dispatches to backend cli" \
+  "$(run_seam github "" 'python3(){ echo "py $*"; }; forgejo_enrich_release codeberg.org o/r v1')" \
+  "py -m pr_reviewer.forgejo_backend enrich-release codeberg.org o/r v1"
+check "forgejo_enrich_compare dispatches to backend cli" \
+  "$(run_seam github "" 'python3(){ echo "py $*"; }; forgejo_enrich_compare codeberg.org o/r a...b')" \
+  "py -m pr_reviewer.forgejo_backend enrich-compare codeberg.org o/r a...b"
 
 check "forgejo backend falls back from GITHUB_TOKEN to GH_TOKEN" \
   "$(FORGEJO_API_URL= GITHUB_TOKEN= GH_TOKEN=from-gh python3 - <<'PYEOF'


### PR DESCRIPTION
## Problem

Renovate dependency-bump PRs were approved with the *content of the update* never reviewed — the upstream changelog/diff was consistently reported as "could not be fetched / skipped". Four distinct gaps caused this:

1. **Self-hosted forge sources blocked.** Linked-source URLs on a self-hosted Forgejo were dropped as "not on the allowlist", even though the instance is the configured platform.
2. **Forge sources only HTML-scraped.** Even when allowlisted, non-github sources (self-hosted Forgejo, codeberg.org) only got a raw-HTML fetch — a JS shell with no real content — because structured enrichment was hardcoded to `gh api`.
3. **Rolling `<date>-<sha>` image tags.** Projects like SearXNG publish no GitHub Releases/tags, so the `releases/tags/<version>` lookup 404s. The actual changes are reachable via a commit compare of the two SHAs embedded in the old→new image tags, which was never attempted.
4. **OCIRepository Helm-chart bumps.** The `oci://ghcr.io/...` source sits on an unchanged `url:` line (so it was never extracted), and chart paths carry an extra segment (`owner/charts/<name>`) that the owner/repo inference mishandled. The real source repo (`owner/<name>`) was never queried.

## Changes

- **config.sh** — the configured `FORGEJO_API_URL` host is implicitly trusted as a linked-source host (no need to repeat it in `allowed_source_hosts`).
- **forgejo_backend.py** — `fetch_forge_release` / `fetch_forge_compare` against an arbitrary Forgejo/Gitea instance host, plus `enrich-release` / `enrich-compare` CLI subcommands. The configured token is sent **only** to the configured instance; any other forge is queried unauthenticated so the credential never leaks off-instance. `_curl` omits the auth header when no token is set.
- **platform_api.sh** — `forgejo_enrich_release` / `forgejo_enrich_compare` helpers (upstream forge, so they don't gate on `PLATFORM`).
- **context.sh** — extract `oci://ghcr.io/...` chart sources from the diff (with context lines); emit an unambiguous old→new short-SHA pair for `<version>-<gitsha>` tags (digests excluded).
- **enrichment.sh** — query Forgejo/Gitea `/api/v1` for non-github release/compare URLs; commit-compare fallback when a ghcr release lookup misses; infer chart source repo as `owner=first / repo=last` segment; arrow-glyph-agnostic `TARGET_VERSION` parsing (Renovate emits `➔`, not just `→`).

## Testing

- Full suite green: **970 pytest + all shell suites**. Added 7 backend tests (release/compare normalization, not-found degradation, the token-leak guard, empty-token header omission) and 2 platform-seam dispatch tests.
- Live-verified against real APIs: Codeberg release/compare payload shapes match the normalization; SearXNG `f8ffbf36f...357662d86` → 3 commits / 6 files; `home-operations/tuppr@0.2.8` exists; token guard returns empty for codeberg.org and the configured token for the self-host.
