### PR TITLE
perf(enrichment): skip Phase-1 fetch for known non-Forgejo hosts

### DIFF
--- a/scripts/sections/enrichment.sh
+++ b/scripts/sections/enrichment.sh
@@ -3,6 +3,12 @@
 # Verbatim in-order slice of the former monolith (#307); relies on globals/helpers
 # set up by the orchestrator. Not executable on its own.
 
+# Known non-Forgejo hosts whose release/compare pages are JS-rendered HTML
+# shells that provide no useful corpus signal (#352). Phase-1's 25s/URL
+# curl would otherwise burn enrichment budget for content that yields
+# nothing. Mirrors the github.com skip below.
+SKIP_ENRICH_HOSTS="gitlab.com bitbucket.org"
+
 section_timer_start "enrichment"
 log "Gathering linked sources..."
 : > linked-sources.md
@@ -27,6 +33,12 @@ if [ -s urls.txt ]; then
     normalized_url="$(printf '%s' "$url" | sed -E 's#^https?://redirect.github.com/#https://github.com/#')"
     rm -f "source.$i.raw"
     host=$(printf '%s' "$normalized_url" | sed -E 's#^https?://([^/]+).*#\1#' | tr '[:upper:]' '[:lower:]')
+    # Skip known non-Forgejo hosts whose release/compare pages are JS-rendered
+    # HTML shells (#352) — emitting a curl config would burn 25s of
+    # enrichment budget for content that yields no corpus signal.
+    case " $SKIP_ENRICH_HOSTS " in
+      *" $host "*) continue ;;
+    esac
     # github.com bodies are JS-app shells; phase 2's gh api branches capture
     # the structured data instead, so don't spend a fetch on them at all.
     if [ "$host" != "github.com" ] && url_host_allowed "$normalized_url"; then
@@ -70,6 +82,10 @@ if [ -s urls.txt ]; then
         # in structured form instead. Skipping the fetch saves both time and
         # ~5KB of corpus boilerplate per URL.
         echo "(Raw HTML fetch skipped for github.com — structured release/compare metadata is captured below when available)" >> linked-sources.md
+      elif case " $SKIP_ENRICH_HOSTS " in *" $host "*) true ;; *) false ;; esac; then
+        # Same optimization for known non-Forgejo hosts (#352): their
+        # release/compare pages are JS-rendered HTML shells too.
+        echo "(Raw HTML fetch skipped for known non-Forgejo host: $host)" >> linked-sources.md
       elif [ -s "source.$i.raw" ]; then
         strip_source_to_text "source.$i.raw" source.tmp 4000
         if [ -s source.tmp ]; then

--- a/tests/test_context_budget.sh
+++ b/tests/test_context_budget.sh
@@ -88,6 +88,16 @@ check "non-github sources go through strip_source_to_text" \
   "$(grep -c 'strip_source_to_text "source.$i.raw"' "$ROOT_DIR/scripts/sections/enrichment.sh")" "1"
 check "github.com is excluded from the parallel prefetch" \
   "$(grep -c '"\$host" != "github.com"' "$ROOT_DIR/scripts/sections/enrichment.sh")" "1"
+check "SKIP_ENRICH_HOSTS constant is defined" \
+  "$(grep -c '^SKIP_ENRICH_HOSTS=' "$ROOT_DIR/scripts/sections/enrichment.sh")" "1"
+check "SKIP_ENRICH_HOSTS list covers gitlab.com" \
+  "$(grep -c 'gitlab.com' "$ROOT_DIR/scripts/sections/enrichment.sh")" "1"
+check "SKIP_ENRICH_HOSTS list covers bitbucket.org" \
+  "$(grep -c 'bitbucket.org' "$ROOT_DIR/scripts/sections/enrichment.sh")" "1"
+check "Phase-1 loop skips SKIP_ENRICH_HOSTS via case + continue" \
+  "$(grep -c 'SKIP_ENRICH_HOSTS' "$ROOT_DIR/scripts/sections/enrichment.sh")" "3"
+check "Phase-2 emits 'known non-Forgejo host' corpus note" \
+  "$(grep -c 'Raw HTML fetch skipped for known non-Forgejo host' "$ROOT_DIR/scripts/sections/enrichment.sh")" "1"
 
 echo ""
 echo "=== Test: no tokens on curl argv in the incremental fetch ==="


### PR DESCRIPTION
## What

Skips the Phase-1 parallel curl fetch for well-known non-Forgejo hosts (`gitlab.com`, `bitbucket.org`) whose release/compare pages are JS-rendered HTML shells that yield no useful corpus signal. Mirrors the existing `github.com` skip.

## Why

Each such URL could burn up to 25s of the 60s enrichment budget for nothing (the curl would succeed but the HTML shell strips to empty/near-empty text). This is the skip-list approach the issue suggests as option 1.

Closes #352.

## Changes

- `scripts/sections/enrichment.sh`: `SKIP_ENRICH_HOSTS` constant; `case`-based `continue` in the Phase-1 curl-config loop; `elif` branch in Phase-2 that emits a corpus note explaining the skip.
- `tests/test_context_budget.sh`: assertions covering the constant, the host coverage, the Phase-1/Phase-2 wiring.

## Verification

- `tests/test_context_budget.sh` — 22/22 pass
- `pytest tests/` — 963/963 pass