### PR TITLE
fix(context): document SHA regex assumption for non-SHA hex tokens

### DIFF
--- a/scripts/sanitize_review_markdown.py
+++ b/scripts/sanitize_review_markdown.py
@@ -39,6 +39,9 @@ _RE_GH_ISSUE_URL = re.compile(
 )
 
 # GitHub commit URLs: https://github.com/owner/repo/commit/<sha>
+# The [0-9a-f]{7,40} pattern matches any lowercase hex token of that length.
+# False positives are prevented by the commit/ URL path prefix, which only
+# appears in legitimate GitHub commit links (not arbitrary hex literals).
 _RE_GH_COMMIT_URL = re.compile(
     r"https?://github\.com/"
     r"([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)/"

--- a/tests/test_sanitize_review_markdown.py
+++ b/tests/test_sanitize_review_markdown.py
@@ -51,6 +51,14 @@ class TestSanitizeCommitUrl:
         result = sanitize_markdown(text)
         assert "upstream owner/repo commit abcdef1234567890abcdef1234567890abcdef12" in result
 
+    def test_non_sha_hex_token_in_commit_url(self):
+        """A non-SHA hex token (e.g., UUID fragment, crypto constant) in a commit URL
+        context is still sanitized: the /commit/ path makes it a SHA by definition."""
+        text = "See https://github.com/owner/repo/commit/deadbabe00cafe123 for details."
+        result = sanitize_markdown(text)
+        assert "upstream owner/repo commit deadbabe00cafe123" in result
+        assert "https://github.com/owner/repo/commit/deadbabe00cafe123" not in result
+
 
 class TestSanitizeCompareUrl:
     """Test GitHub compare URL sanitization."""


### PR DESCRIPTION
Closes #351.

Documents the assumption that `commit/` URL path context prevents false positives from the `[0-9a-f]{7,40}` regex, and adds a test showing the sanitizer treats any hex token in a commit URL as a SHA by definition.

- **Impact:** Low — the `commit/` prefix already provides strong context, but worth documenting for correctness.
- **Tests:** All 971 pass (including the new `test_non_sha_hex_token_in_commit_url`).