### PR TITLE
fix(forgejo): structured gh api for GitHub comments, unified sticky-comment selection

### DIFF
--- a/pr_reviewer/forgejo_backend.py
+++ b/pr_reviewer/forgejo_backend.py
@@ -124,6 +124,30 @@ def _gh(*args: str) -> tuple[int, str]:
     return proc.returncode, proc.stdout.decode("utf-8", errors="replace")
 
 
+def _gh_api_json(method: str, path: str, data: dict[str, Any]) -> tuple[int, str]:
+    """POST/PATCH JSON to the GitHub REST API via ``gh api`` and return
+    (returncode, stdout) — the structured JSON response, not human-oriented
+    text.
+
+    The body is written to a temp file and passed via ``--input`` rather
+    than as a ``-f field=value`` argv entry — the same pattern already used
+    by ``create_pr_review_from_payload`` — because comment bodies can be
+    large markdown blobs.
+    """
+    import tempfile
+
+    with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as tmp:
+        json.dump(data, tmp)
+        tmp_path = tmp.name
+    try:
+        return _gh("api", path, "--method", method, "--input", tmp_path)
+    finally:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+
+
 def _parse_repo(repo_full_name: str) -> tuple[str, str]:
     """Split ``owner/repo`` into (owner, repo)."""
     parts = repo_full_name.split("/", 1)
@@ -140,21 +164,6 @@ def _json_decode(text: str) -> Any:
         return json.loads(text)
     except (json.JSONDecodeError, ValueError):
         return None
-
-
-def _parse_gh_comment_output(output_text: str, body: str) -> dict[str, Any]:
-    """Extract the comment id/URL from ``gh pr comment`` output.
-
-    gh prints the comment URL as .../pull/N#issuecomment-ID (no slash
-    before the fragment). Shared by create_comment and edit_last_comment.
-    """
-    url_match = re.search(r"https?://\S+/pull/[0-9]+#issuecomment-[0-9]+", output_text)
-    comment_id_match = re.search(r"#issuecomment-([0-9]+)", output_text or "")
-    return {
-        "id": int(comment_id_match.group(1)) if comment_id_match else 0,
-        "html_url": url_match.group(0) if url_match else "",
-        "body": body,
-    }
 
 
 # ---------------------------------------------------------------------------
@@ -323,6 +332,24 @@ def _forgejo_comment_to_standard(comment: dict, owner: str, repo: str) -> dict[s
     }
 
 
+def _latest_marker_comment(
+    comments: list[dict[str, Any]], marker: str
+) -> dict[str, Any] | None:
+    """Return the most recently updated comment containing *marker*, or None.
+
+    Shared by both backends so "sticky comment" selection means the same
+    thing regardless of platform: the latest comment containing the marker
+    — not gh's platform-specific "last comment authored by the current
+    user" (``--edit-last``), which picks a different comment on multi-bot
+    repos and diverges from the Forgejo behaviour.
+    """
+    matching = [c for c in comments if marker in (c.get("body") or "")]
+    if not matching:
+        return None
+    matching.sort(key=lambda c: c.get("updated_at", ""), reverse=True)
+    return matching[0]
+
+
 def create_comment(
     repo_full_name: str,
     issue_number: int,
@@ -351,17 +378,23 @@ def create_comment(
             "body": data.get("body", body),
         }
 
-    # GitHub via gh CLI. Plain creation — ``--create-if-none`` is only valid
-    # together with ``--edit-last`` and is a flag-parse error on its own.
-    status_code, body_text = _gh(
-        "pr", "comment", str(issue_number),
-        "--repo", repo_full_name,
-        "--body", body,
+    # GitHub via gh CLI, hitting the REST endpoint directly rather than
+    # ``gh pr comment`` — that subcommand's stdout is a human-oriented URL
+    # string that a gh wording change can silently degrade to an unparsable
+    # blob. The REST endpoint returns real JSON we can decode structurally.
+    status_code, body_text = _gh_api_json(
+        "POST", f"repos/{owner}/{repo}/issues/{issue_number}/comments", {"body": body},
     )
     if status_code != 0 or not body_text.strip():
         return None
-
-    return _parse_gh_comment_output(body_text, body)
+    data = _json_decode(body_text)
+    if data is None:
+        return None
+    return {
+        "id": data.get("id", 0),
+        "html_url": data.get("html_url", ""),
+        "body": data.get("body", body),
+    }
 
 
 def edit_last_comment(
@@ -370,57 +403,58 @@ def edit_last_comment(
     new_body: str,
     marker: str = COMMENT_MARKER,
 ) -> dict[str, Any] | None:
-    """Edit the last comment containing *marker*, or create a new one.
+    """Edit the latest comment containing *marker*, or create a new one.
 
     This implements the "sticky comment" pattern used by the review action:
     if a comment with the marker exists, edit it in place; otherwise create
-    a new comment.
+    a new comment. Both backends select the target comment the same way
+    (see ``_latest_marker_comment``) so which comment gets updated no
+    longer depends on platform.
 
     Returns the comment dict with ``id`` and ``html_url``, or ``None`` on failure.
     """
     owner, repo = _parse_repo(repo_full_name)
+    comments = list_comments(repo_full_name, issue_number)
+    target = _latest_marker_comment(comments, marker)
+
+    if target is None:
+        # No matching comment — create a new one.
+        return create_comment(repo_full_name, issue_number, new_body)
 
     if _is_forgejo_mode():
-        # List comments and find the latest one containing the marker
-        comments = list_comments(repo_full_name, issue_number)
-        matching = [c for c in comments if marker in (c.get("body") or "")]
+        status_code, body_text = _curl(
+            "PATCH",
+            f"{FORGEJO_API_URL}/api/v1/repos/{owner}/{repo}/issues/comments/{target['id']}",
+            data={"body": new_body},
+        )
+        if status_code != 200:
+            return None
+        data = _json_decode(body_text)
+        if data is None:
+            return None
+        return {
+            "id": target["id"],
+            "html_url": data.get("html_url", ""),
+            "body": new_body,
+        }
 
-        if matching:
-            # Sort by updated_at descending to get the latest
-            matching.sort(key=lambda c: c.get("updated_at", ""), reverse=True)
-            target = matching[0]
-
-            status_code, body_text = _curl(
-                "PATCH",
-                f"{FORGEJO_API_URL}/api/v1/repos/{owner}/{repo}/issues/comments/{target['id']}",
-                data={"body": new_body},
-            )
-            if status_code != 200:
-                return None
-            data = _json_decode(body_text)
-            if data is None:
-                return None
-            return {
-                "id": target["id"],
-                "html_url": data.get("html_url", ""),
-                "body": new_body,
-            }
-
-        # No matching comment — create a new one
-        return create_comment(repo_full_name, issue_number, new_body)
-
-    # GitHub via gh CLI
-    status_code, body_text = _gh(
-        "pr", "comment", str(issue_number),
-        "--repo", repo_full_name,
-        "--edit-last",
-        "--body", new_body,
+    # GitHub via gh CLI — PATCH the located comment's REST resource directly
+    # (structured JSON in, structured JSON out), instead of ``gh pr comment
+    # --edit-last`` which both scrapes stdout text and edits a different
+    # comment (the last one authored by the current gh user).
+    status_code, body_text = _gh_api_json(
+        "PATCH", f"repos/{owner}/{repo}/issues/comments/{target['id']}", {"body": new_body},
     )
-    if status_code != 0:
-        # --edit-last fails when no comment exists; fall back to create
-        return create_comment(repo_full_name, issue_number, new_body)
-
-    return _parse_gh_comment_output(body_text, new_body)
+    if status_code != 0 or not body_text.strip():
+        return None
+    data = _json_decode(body_text)
+    if data is None:
+        return None
+    return {
+        "id": data.get("id", target["id"]),
+        "html_url": data.get("html_url", ""),
+        "body": data.get("body", new_body),
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_forgejo_backend.py
+++ b/tests/test_forgejo_backend.py
@@ -548,10 +548,12 @@ class TestGitHubMode(unittest.TestCase):
     """GitHub mode must invoke gh with arguments the real CLI accepts.
 
     These mock ``_gh`` (no live network calls from unit tests) and assert
-    the exact invocation: the original implementation passed ``gh pr view
-    --json`` field names that don't exist (user/head/base/merged_at) and a
-    ``--create-if-none`` flag that is invalid without ``--edit-last`` — both
-    invisible to tests that only checked the fallback result.
+    the exact invocation: the original ``get_pr_metadata`` implementation
+    passed ``gh pr view --json`` field names that don't exist
+    (user/head/base/merged_at) — invisible to tests that only checked the
+    fallback result. Comment creation/editing similarly used to shell out
+    to ``gh pr comment`` and regex-scrape its human-oriented stdout; these
+    tests assert the structured ``gh api`` JSON path instead.
     """
 
     GH_REST_PR = {
@@ -587,28 +589,80 @@ class TestGitHubMode(unittest.TestCase):
 
         self.assertEqual(result, "")
 
-    def test_create_comment_does_not_pass_create_if_none(self):
-        # --create-if-none is only valid with --edit-last; plain creation
-        # must not send it.
-        url = "https://github.com/misospace/pr-reviewer-action/pull/42#issuecomment-77"
+    def test_create_comment_posts_via_gh_api_json(self):
+        # create_comment must hit the REST endpoint via ``gh api`` and parse
+        # the structured JSON response — not scrape ``gh pr comment`` stdout.
+        gh_comment = {
+            "id": 77,
+            "html_url": "https://github.com/misospace/pr-reviewer-action/pull/42#issuecomment-77",
+            "body": "hello",
+        }
         with patch.object(fb, "FORGEJO_API_URL", ""), \
-             patch.object(fb, "_gh", return_value=(0, url + "\n")) as mock_gh:
+             patch.object(fb, "_gh", return_value=(0, json.dumps(gh_comment))) as mock_gh:
             result = fb.create_comment("misospace/pr-reviewer-action", 42, "hello")
 
         args = mock_gh.call_args[0]
-        self.assertNotIn("--create-if-none", args)
+        self.assertEqual(args[0], "api")
+        self.assertEqual(args[1], "repos/misospace/pr-reviewer-action/issues/42/comments")
+        self.assertIn("--method", args)
+        self.assertEqual(args[args.index("--method") + 1], "POST")
+        self.assertIn("--input", args)
         self.assertEqual(result["id"], 77)
-        self.assertEqual(result["html_url"], url)
+        self.assertEqual(result["html_url"], gh_comment["html_url"])
 
-    def test_edit_last_comment_parses_gh_url(self):
-        # gh prints .../pull/N#issuecomment-ID — no slash before the fragment.
-        url = "https://github.com/misospace/pr-reviewer-action/pull/42#issuecomment-88"
+    def test_create_comment_malformed_json_returns_none(self):
         with patch.object(fb, "FORGEJO_API_URL", ""), \
-             patch.object(fb, "_gh", return_value=(0, url + "\n")):
+             patch.object(fb, "_gh", return_value=(0, "not json")):
+            result = fb.create_comment("misospace/pr-reviewer-action", 42, "hello")
+
+        self.assertIsNone(result)
+
+    def test_edit_last_comment_finds_latest_marker_and_patches(self):
+        # gh mode must select the comment the same way Forgejo mode does:
+        # the latest comment containing the marker, not "last comment by
+        # the current gh user" (--edit-last).
+        gh_comments = [
+            {"id": 1, "body": f"{COMMENT_MARKER}\nold", "updated_at": "2026-06-11T11:30:00Z"},
+            {"id": 2, "body": "no marker here", "updated_at": "2026-06-11T11:40:00Z"},
+        ]
+        patched = {"id": 1, "html_url": "https://github.com/misospace/pr-reviewer-action/pull/42#issuecomment-1", "body": "updated"}
+
+        def _fake_gh(*args):
+            if args[:2] == ("api", "repos/misospace/pr-reviewer-action/issues/42/comments"):
+                # list_comments consumes gh's --jq output, which is one JSON
+                # object per line (JSONL), not a JSON array.
+                return 0, "\n".join(json.dumps(c) for c in gh_comments)
+            self.assertEqual(args[0], "api")
+            self.assertEqual(args[1], "repos/misospace/pr-reviewer-action/issues/comments/1")
+            self.assertIn("--method", args)
+            self.assertEqual(args[args.index("--method") + 1], "PATCH")
+            self.assertIn("--input", args)
+            return 0, json.dumps(patched)
+
+        with patch.object(fb, "FORGEJO_API_URL", ""), \
+             patch.object(fb, "_gh", side_effect=_fake_gh):
             result = fb.edit_last_comment("misospace/pr-reviewer-action", 42, "updated")
 
-        self.assertEqual(result["id"], 88)
-        self.assertEqual(result["html_url"], url)
+        self.assertEqual(result["id"], 1)
+        self.assertEqual(result["html_url"], patched["html_url"])
+
+    def test_edit_last_comment_falls_back_to_create_when_no_marker(self):
+        created = {"id": 3, "html_url": "https://github.com/misospace/pr-reviewer-action/pull/42#issuecomment-3", "body": "fresh"}
+
+        def _fake_gh(*args):
+            # The list (no --method) and the create (--method POST) both
+            # target .../issues/42/comments, so disambiguate on --method.
+            if args[:2] == ("api", "repos/misospace/pr-reviewer-action/issues/42/comments") \
+                    and "--method" not in args:
+                return 0, json.dumps([])
+            return 0, json.dumps(created)
+
+        with patch.object(fb, "FORGEJO_API_URL", ""), \
+             patch.object(fb, "_gh", side_effect=_fake_gh):
+            result = fb.edit_last_comment("misospace/pr-reviewer-action", 42, "fresh")
+
+        self.assertEqual(result["id"], 3)
+        self.assertEqual(result["html_url"], created["html_url"])
 
 
 


### PR DESCRIPTION
Closes #374.

## Summary
- GitHub `create_comment`/`edit_last_comment` now POST/PATCH `repos/…/issues/…/comments` via `gh api --input <tmpfile>` and parse the JSON response — the `gh pr comment` stdout regex-scraping (`_parse_gh_comment_output`) is deleted.
- Sticky-comment selection is now identical on both platforms: latest comment containing the marker (shared `_latest_marker_comment`), replacing GitHub's `--edit-last` ("last comment by the gh user"), which picked a different comment on multi-bot repos.

## Verification
- `pytest tests/` — 1053 passed; all `tests/test_*.sh` suites pass

## Notes
- Two deliberate behavior changes on the GitHub path: marker-based selection (above), and a failed PATCH now returns `None` instead of falling back to creating a duplicate comment — matching the Forgejo branch.
- `scripts/platform_api.sh` still uses `gh pr comment --edit-last` for shell consumers; left for the platform-seam consolidation (#367/#368 territory).