### PR TITLE
fix(security): derive fork-ness once, fail closed on degraded PR metadata

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -804,6 +804,7 @@ runs:
         REVIEW_SCOPE: ${{ inputs.review_scope }}
         EFFECTIVE_SCOPE: ${{ steps.precheck.outputs.effective_review_scope }}
         PREVIOUS_HEAD_SHA: ${{ steps.precheck.outputs.previous_head_sha }}
+        IS_FORK_PR: ${{ steps.precheck.outputs.is_fork_pr }}
         TOOL_EVIDENCE_MEMORY: ${{ inputs.tool_evidence_memory }}
       run: bash "${{ github.action_path }}/scripts/run_review.sh"
 
@@ -977,10 +978,13 @@ runs:
             CLEANUP_NATIVE_REVIEWS="$(resolve_cleanup_flag "${CLEANUP_PREVIOUS_NATIVE_REVIEWS:-auto}" "review_verdict")"
             cleanup_native_reviews "$CLEANUP_NATIVE_REVIEWS"
 
-            # Determine if the PR is from a fork. The precheck step already fetched
-            # the PR object; only fall back to the API when its output is missing.
+            # Fork-ness is derived once by the precheck (fail-closed) and
+            # forwarded via IS_FORK_PR. Fall back to the PR object the precheck
+            # saved only when that output is missing; derive_is_fork_pr fails
+            # closed (missing/empty head, missing base, or absent file → fork)
+            # rather than re-fetching the PR object.
             if [ -z "$IS_FORK_PR" ]; then
-              IS_FORK_PR="$(platform_pr_get "$REPO" "$PR_NUMBER" --jq '((.head.repo.full_name // "") != (.base.repo.full_name // ""))' 2>/dev/null || echo false)"
+              IS_FORK_PR="$(derive_is_fork_pr pr-object.json)"
             fi
 
             # Resolve review result

--- a/pr_reviewer/forgejo_backend.py
+++ b/pr_reviewer/forgejo_backend.py
@@ -824,7 +824,9 @@ def is_fork_pr(repo_full_name: str, pr_number: int) -> bool:
     """
     metadata = get_pr_metadata(repo_full_name, pr_number)
     if metadata is None:
-        return False
+        # Total fetch failure: origin unknown -> fail closed, same as the
+        # shell derivation (derive_is_fork_pr in platform_api.sh).
+        return True
 
     head_full = ((metadata.get("head") or {}).get("repo") or {}).get("full_name") or ""
     base_full = ((metadata.get("base") or {}).get("repo") or {}).get("full_name") or ""

--- a/scripts/check_review_needed.sh
+++ b/scripts/check_review_needed.sh
@@ -481,7 +481,7 @@ if ! platform_pr_get "$REPO" "$PR_NUMBER" > pr-object.json 2>/dev/null; then
 fi
 CURRENT_HEAD_SHA="$(jq -r '.head.sha // ""' pr-object.json 2>/dev/null || echo "")"
 CURRENT_BASE_SHA="$(jq -r '.base.sha // ""' pr-object.json 2>/dev/null || echo "")"
-IS_FORK_PR="$(jq -r '((.head.repo.full_name // "") != (.base.repo.full_name // ""))' pr-object.json 2>/dev/null || echo "")"
+IS_FORK_PR="$(derive_is_fork_pr pr-object.json)"
 
 # Resolve effective review scope
 resolve_review_scope "$REVIEW_SCOPE" "$LAST_HEAD_SHA" "$LAST_BASE_SHA" \

--- a/scripts/platform_api.sh
+++ b/scripts/platform_api.sh
@@ -307,3 +307,25 @@ forgejo_enrich_compare() {
   PYTHONPATH="${_PLATFORM_SCRIPT_DIR}/..${PYTHONPATH:+:${PYTHONPATH}}" \
     python3 -m pr_reviewer.forgejo_backend enrich-compare "$1" "$2" "$3"
 }
+
+# ── Fork detection (single fail-closed derivation, #370) ────────────────
+# Echo "true" if the PR originates from a fork, else "false". Reads the saved
+# PR object (default: pr-object.json, written once by the precheck).
+#
+# This is the ONE place fork-ness is derived on the shell path. It mirrors
+# pr_reviewer.forgejo_backend.is_fork_pr: a missing/empty head.repo.full_name
+# is treated as a fork (a present head against a missing base is already
+# caught by head != base). Fork-ness gates the tool harness / evidence
+# providers / MCP against untrusted PR content while repo tokens are
+# available, so an unknown origin MUST fail closed. Degraded input all yields
+# "true": an empty `{}` object (the precheck writes `{}` when the PR fetch
+# fails), a missing base, or an unparseable / absent file (jq errors → the
+# `|| echo true` fallback).
+derive_is_fork_pr() {
+  local pr_object_file="${1:-pr-object.json}"
+  jq -r '
+    (.head.repo.full_name // "") as $head
+    | (.base.repo.full_name // "") as $base
+    | if $head == "" then true else ($head != $base) end
+  ' "$pr_object_file" 2>/dev/null || echo true
+}

--- a/scripts/sections/classification.sh
+++ b/scripts/sections/classification.sh
@@ -65,13 +65,10 @@ section_timer_end
 
 section_timer_start "evidence-providers"
 log "Running optional evidence providers..."
-if [[ "$IS_FORK_PR" == "true" ]] && [[ "$(printf '%s' "$EVIDENCE_ENABLE_FOR_FORKS" | tr '[:upper:]' '[:lower:]')" != "true" ]]; then
-  cat > evidence-providers.md <<'EOF'
-Evidence providers were skipped for a cross-repository pull request. Set evidence_enable_for_forks=true to override.
-EOF
-  cat > evidence-providers.json <<'EOF'
-{"configured": false, "has_blocker": false, "providers": [], "skipped": true, "skip_reason": "fork-pr"}
-EOF
+if gate_feature_for_forks "$EVIDENCE_ENABLE_FOR_FORKS" \
+    evidence-providers.md "Evidence providers were skipped for a cross-repository pull request. Set evidence_enable_for_forks=true to override." \
+    evidence-providers.json '{"configured": false, "has_blocker": false, "providers": [], "skipped": true, "skip_reason": "fork-pr"}'; then
+  : # fork PR without evidence_enable_for_forks — skip artifacts already written
 else
   if ! python3 "$SCRIPT_DIR/run_evidence_providers.py"; then
     error "Evidence provider execution failed"

--- a/scripts/sections/common.sh
+++ b/scripts/sections/common.sh
@@ -35,3 +35,22 @@ section_timer_end() {
   elapsed=$(( $(date +%s) - start_ts ))
   log "PERF: section=$name elapsed=${elapsed}s"
 }
+
+# Fork gate for a per-feature capability that runs untrusted PR content (#370).
+# When the PR is a fork and the feature is not explicitly enabled for forks,
+# write the paired skip artifacts (.md + .json) and return 0 (gated → skip).
+# Otherwise write nothing and return 1 (caller runs the feature). Consumes the
+# fail-closed $IS_FORK_PR resolved once in context.sh.
+#
+# Args: $1 enable-for-forks flag value  $2 md path   $3 md content
+#       $4 json path                    $5 json content
+gate_feature_for_forks() {
+  local enable_flag="$1" md_path="$2" md_content="$3" json_path="$4" json_content="$5"
+  if [[ "${IS_FORK_PR:-}" == "true" ]] \
+    && [[ "$(printf '%s' "$enable_flag" | tr '[:upper:]' '[:lower:]')" != "true" ]]; then
+    printf '%s\n' "$md_content" > "$md_path"
+    printf '%s\n' "$json_content" > "$json_path"
+    return 0
+  fi
+  return 1
+}

--- a/scripts/sections/context.sh
+++ b/scripts/sections/context.sh
@@ -18,7 +18,13 @@ fi
 jq '{number, title, body, headRefOid: .head.sha, baseRefName: .base.ref, headRefName: .head.ref, author: {login: (.user.login // "")}, changedFiles: .changed_files, additions, deletions, url: .html_url}' \
   pr-object.json > pr.json
 
-IS_FORK_PR="$(jq -r '((.head.repo.full_name // "") != (.base.repo.full_name // ""))' pr-object.json 2>/dev/null || echo false)"
+# Fork-ness is derived once by the precheck (fail-closed) and forwarded via the
+# IS_FORK_PR env. Derive locally only when the env is genuinely absent — e.g. a
+# standalone smoke test or manual run with no precheck step — and then with the
+# same fail-closed rule.
+if [[ -z "${IS_FORK_PR:-}" ]]; then
+  IS_FORK_PR="$(derive_is_fork_pr pr-object.json)"
+fi
 if [[ "$IS_FORK_PR" == "true" ]]; then
   log "Detected cross-repository pull request"
 fi

--- a/scripts/sections/corpus.sh
+++ b/scripts/sections/corpus.sh
@@ -195,13 +195,10 @@ section_timer_end
 
 case "$(printf '%s' "$TOOL_MODE" | tr '[:upper:]' '[:lower:]')" in native_loop) TOOL_HARNESS_ENABLED="true" ;; *) TOOL_HARNESS_ENABLED="false" ;; esac
 if [[ "$TOOL_HARNESS_ENABLED" == "true" ]]; then
-  if [[ "$IS_FORK_PR" == "true" ]] && [[ "$(printf '%s' "$TOOL_ENABLE_FOR_FORKS" | tr '[:upper:]' '[:lower:]')" != "true" ]]; then
-    cat > tool-harness.md <<'EOF'
-Tool harness was skipped for a cross-repository pull request. Set tool_enable_for_forks=true to override.
-EOF
-    cat > tool-harness.json <<'EOF'
-{"mode":"native_loop","planned_request_count":0,"executed_request_count":0,"tool_results":[],"skipped":true,"skip_reason":"fork-pr"}
-EOF
+  if gate_feature_for_forks "$TOOL_ENABLE_FOR_FORKS" \
+      tool-harness.md "Tool harness was skipped for a cross-repository pull request. Set tool_enable_for_forks=true to override." \
+      tool-harness.json '{"mode":"native_loop","planned_request_count":0,"executed_request_count":0,"tool_results":[],"skipped":true,"skip_reason":"fork-pr"}'; then
+    : # fork PR without tool_enable_for_forks — skip artifacts already written
   else
     log "Running tool harness in mode: $TOOL_MODE"
     if ! python3 "$SCRIPT_DIR/run_tool_harness.py"; then

--- a/tests/test_check_review_needed.sh
+++ b/tests/test_check_review_needed.sh
@@ -353,6 +353,53 @@ check "PR object fetched exactly once" "$PULLS_FETCHES" "1"
 DIFF_FETCHES="$(grep -c '^pr diff' /tmp/testfp_gh_calls.log || true)"
 check "diff fetched exactly once" "$DIFF_FETCHES" "1"
 
+# ── Test 15: fork PR (different head repo) → is_fork_pr=true ──────────
+echo ""
+echo "=== Test 15: cross-repo (fork) PR → is_fork_pr=true ==="
+cat > /tmp/testfp_pr_object.json <<'JSONEOF'
+{
+  "number": 42,
+  "head": {"sha": "aaaa111122223333aaaa111122223333aaaa1111", "ref": "feature", "repo": {"full_name": "attacker/repo"}},
+  "base": {"sha": "bbbb111122223333bbbb111122223333bbbb1111", "ref": "main", "repo": {"full_name": "test/repo"}}
+}
+JSONEOF
+set_empty_comments
+RESULT="$(run_precheck)"
+check "fork PR forwards is_fork_pr=true" "$(echo "$RESULT" | grep '^is_fork_pr=' | head -1 | cut -d= -f2)" "true"
+
+# ── Test 16: missing head.repo → fail closed (treated as fork) ───────
+echo ""
+echo "=== Test 16: missing head.repo metadata → is_fork_pr=true (fail closed) ==="
+cat > /tmp/testfp_pr_object.json <<'JSONEOF'
+{
+  "number": 42,
+  "head": {"sha": "aaaa111122223333aaaa111122223333aaaa1111", "ref": "feature"},
+  "base": {"sha": "bbbb111122223333bbbb111122223333bbbb1111", "ref": "main", "repo": {"full_name": "test/repo"}}
+}
+JSONEOF
+set_empty_comments
+RESULT="$(run_precheck)"
+check "missing head.repo fails closed to is_fork_pr=true" "$(echo "$RESULT" | grep '^is_fork_pr=' | head -1 | cut -d= -f2)" "true"
+
+# ── Test 17: degraded/empty PR object → fail closed ──────────────────
+echo ""
+echo "=== Test 17: empty PR object (degraded fetch) → is_fork_pr=true (fail closed) ==="
+cat > /tmp/testfp_pr_object.json <<'JSONEOF'
+{}
+JSONEOF
+set_empty_comments
+RESULT="$(run_precheck)"
+check "empty PR object fails closed to is_fork_pr=true" "$(echo "$RESULT" | grep '^is_fork_pr=' | head -1 | cut -d= -f2)" "true"
+
+# Restore the default same-repo PR object for any later additions.
+cat > /tmp/testfp_pr_object.json <<'JSONEOF'
+{
+  "number": 42,
+  "head": {"sha": "aaaa111122223333aaaa111122223333aaaa1111", "ref": "feature", "repo": {"full_name": "test/repo"}},
+  "base": {"sha": "bbbb111122223333bbbb111122223333bbbb1111", "ref": "main", "repo": {"full_name": "test/repo"}}
+}
+JSONEOF
+
 echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="
 

--- a/tests/test_forgejo_backend.py
+++ b/tests/test_forgejo_backend.py
@@ -713,6 +713,12 @@ class TestIsForkPr(unittest.TestCase):
         with self._meta(DELETED_FORK_PR_META):
             self.assertTrue(fb.is_fork_pr("misospace/pr-reviewer-action", 44))
 
+    def test_fetch_failure_fails_closed(self):
+        # Total metadata-fetch failure → origin unknown → fork (fail closed),
+        # matching the shell derivation (derive_is_fork_pr).
+        with patch.object(fb, "get_pr_metadata", return_value=None):
+            self.assertTrue(fb.is_fork_pr("misospace/pr-reviewer-action", 45))
+
 
 class TestCurlStatusParsing(unittest.TestCase):
     """_curl appends '\\n%{http_code}' and must parse bodies of any shape."""

--- a/tests/test_tool_harness_enforcement.sh
+++ b/tests/test_tool_harness_enforcement.sh
@@ -396,11 +396,20 @@ fi
 echo ""
 echo "=== Evidence Provider Fork Enablement ==="
 
-# Helper: returns "skip" or "run" based on the fork enablement logic from run_review.sh
+# Exercise the SHARED gate_feature_for_forks helper (scripts/sections/common.sh)
+# that both classification.sh and corpus.sh call — not a local re-implementation —
+# so this pins the real fork-gating behavior. Returns "skip"/"run".
+# shellcheck source=../scripts/sections/common.sh
+source "$_TEST_DIR/../scripts/sections/common.sh"
+
 should_skip_evidence() {
   local is_fork_pr="$1"
   local evidence_enable_for_forks="${2:-false}"
-  if [[ "$is_fork_pr" == "true" ]] && [[ "$(printf '%s' "$evidence_enable_for_forks" | tr '[:upper:]' '[:lower:]')" != "true" ]]; then
+  local md="$TMPDIR/gate.md" json="$TMPDIR/gate.json"
+  rm -f "$md" "$json"
+  if IS_FORK_PR="$is_fork_pr" gate_feature_for_forks "$evidence_enable_for_forks" \
+      "$md" "skipped for a fork" \
+      "$json" '{"configured": false, "has_blocker": false, "providers": [], "skipped": true, "skip_reason": "fork-pr"}'; then
     echo "skip"
   else
     echo "run"
@@ -442,6 +451,24 @@ check "same-repo PR, evidence_enable_for_forks=true -> run" "$result" "run"
 # Same-repo PR (not fork) with empty — should run
 result="$(should_skip_evidence "false" "")"
 check "same-repo PR, evidence_enable_for_forks=empty -> run" "$result" "run"
+
+# gate_feature_for_forks writes BOTH paired skip artifacts when it gates.
+rm -f "$TMPDIR/gate.md" "$TMPDIR/gate.json"
+IS_FORK_PR="true" gate_feature_for_forks "false" \
+  "$TMPDIR/gate.md" "skipped for a fork" \
+  "$TMPDIR/gate.json" '{"skipped": true, "skip_reason": "fork-pr"}' || true
+check "gate writes .md skip artifact" "$(test -s "$TMPDIR/gate.md" && echo yes || echo no)" "yes"
+check "gate writes .json skip artifact" "$(test -s "$TMPDIR/gate.json" && echo yes || echo no)" "yes"
+check "gate .json skip artifact is valid JSON" \
+  "$(jq -r '.skip_reason' "$TMPDIR/gate.json" 2>/dev/null)" "fork-pr"
+
+# When NOT gated (same-repo), it writes neither artifact.
+rm -f "$TMPDIR/gate.md" "$TMPDIR/gate.json"
+IS_FORK_PR="false" gate_feature_for_forks "false" \
+  "$TMPDIR/gate.md" "skipped for a fork" \
+  "$TMPDIR/gate.json" '{"skipped": true}' || true
+check "gate writes no .md when not gated" "$(test -e "$TMPDIR/gate.md" && echo yes || echo no)" "no"
+check "gate writes no .json when not gated" "$(test -e "$TMPDIR/gate.json" && echo yes || echo no)" "no"
 
 
 echo ""


### PR DESCRIPTION
Closes #370.

## Summary
- One shell-side fork derivation: `derive_is_fork_pr` in `platform_api.sh`, mirroring the Python reference policy — missing/empty `head.repo`, missing base, empty `{}` object, or unreadable file all yield **fork**. The precheck computes it once and outputs it; `context.sh` and the publish step consume the env and only fall back to the same fail-closed helper (the publish step's redundant PR re-fetch is deleted).
- The three copy-pasted jq expressions failed **open** in the degraded cases: a failed PR fetch writes `{}` to `pr-object.json`, and `"" != ""` → "not a fork" — so the tool harness / evidence providers / MCP would run against untrusted content with tokens live. All shell paths now fail closed.
- Per-feature gating dedup: shared `gate_feature_for_forks` helper writes the paired skip artifacts; `classification.sh` (evidence providers) and `corpus.sh` (tool harness) call it instead of hand-rolled blocks (artifact contents byte-identical).
- The Python reference `is_fork_pr` had its own dormant fail-open (`metadata is None → False`, no production callers) — now returns True with a pinning test.

## Verification
- New tests: precheck fail-closed cases (cross-repo / missing head / empty object), gate helper writes both artifacts, Python fetch-failure fail-closed
- Full pytest (1052) + all bash suites pass

## Notes
- Intended behavior change: PRs whose head-repo metadata is missing or whose PR fetch degraded are now treated as forks (features skip unless `*_enable_for_forks`). Clearly same-repo / clearly-fork PRs behave exactly as before.