### PR TITLE
fix(platform): resolve platform once in the precheck; PLATFORM-aware _is_forgejo_mode

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -695,8 +695,8 @@ runs:
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.github_token }}
-        PLATFORM: ${{ inputs.platform }}
-        FORGEJO_API_URL: ${{ inputs.forgejo_api_url || (github.server_url != 'https://github.com' && github.server_url) || '' }}
+        PLATFORM: ${{ steps.precheck.outputs.resolved_platform }}
+        FORGEJO_API_URL: ${{ steps.precheck.outputs.effective_forgejo_api_url }}
         FORGEJO_TOKEN: ${{ inputs.forgejo_token || inputs.github_token }}
         REPO: ${{ inputs.repo || github.repository }}
         PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
@@ -714,8 +714,8 @@ runs:
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.github_token }}
-        PLATFORM: ${{ inputs.platform }}
-        FORGEJO_API_URL: ${{ inputs.forgejo_api_url || (github.server_url != 'https://github.com' && github.server_url) || '' }}
+        PLATFORM: ${{ steps.precheck.outputs.resolved_platform }}
+        FORGEJO_API_URL: ${{ steps.precheck.outputs.effective_forgejo_api_url }}
         FORGEJO_TOKEN: ${{ inputs.forgejo_token || inputs.github_token }}
         REPO: ${{ inputs.repo || github.repository }}
         PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
@@ -819,8 +819,8 @@ runs:
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.github_token }}
-        PLATFORM: ${{ inputs.platform }}
-        FORGEJO_API_URL: ${{ inputs.forgejo_api_url || (github.server_url != 'https://github.com' && github.server_url) || '' }}
+        PLATFORM: ${{ steps.precheck.outputs.resolved_platform }}
+        FORGEJO_API_URL: ${{ steps.precheck.outputs.effective_forgejo_api_url }}
         FORGEJO_TOKEN: ${{ inputs.forgejo_token || inputs.github_token }}
         REPO: ${{ inputs.repo || github.repository }}
         PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
@@ -1123,8 +1123,8 @@ runs:
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.github_token }}
-        PLATFORM: ${{ inputs.platform }}
-        FORGEJO_API_URL: ${{ inputs.forgejo_api_url || (github.server_url != 'https://github.com' && github.server_url) || '' }}
+        PLATFORM: ${{ steps.precheck.outputs.resolved_platform }}
+        FORGEJO_API_URL: ${{ steps.precheck.outputs.effective_forgejo_api_url }}
         FORGEJO_TOKEN: ${{ inputs.forgejo_token || inputs.github_token }}
         REPO: ${{ inputs.repo || github.repository }}
         PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}

--- a/pr_reviewer/forgejo_backend.py
+++ b/pr_reviewer/forgejo_backend.py
@@ -30,7 +30,9 @@ import sys
 from typing import Any
 from urllib.parse import quote
 
-from pr_reviewer.platform import USER_AGENT
+# Top-level import is safe: platform.py imports forgejo_backend only lazily
+# (inside _gh_api_forgejo), so there is no import cycle in this direction.
+from pr_reviewer.platform import USER_AGENT, resolve_platform
 
 
 # ---------------------------------------------------------------------------
@@ -51,8 +53,36 @@ GH_TOKEN = os.environ.get("GH_TOKEN", os.environ.get("GITHUB_TOKEN", ""))
 
 
 def _is_forgejo_mode() -> bool:
-    """Return True when FORGEJO_API_URL is set and non-empty."""
-    return bool(FORGEJO_API_URL)
+    """Return True when the active platform is Forgejo.
+
+    PLATFORM-aware (issue #367): delegates to ``platform.resolve_platform`` so
+    this backend and the shell seam (``platform_api.sh``) never disagree — in
+    particular ``PLATFORM=github`` now forces the GitHub path even when
+    FORGEJO_API_URL is populated (action.yml force-fills it from
+    ``github.server_url`` on non-github hosts, so keying purely off its
+    presence silently curled while the shell used gh).
+
+    Two deliberate deviations from a bare ``resolve_platform()`` call, each
+    needed to preserve existing behaviour:
+
+      * An unset/empty PLATFORM is treated as ``auto`` (not
+        ``resolve_platform``'s ``github`` default). Standalone/test callers
+        that switch to Forgejo purely by setting FORGEJO_API_URL — never
+        PLATFORM — must keep resolving to forgejo.
+      * The Forgejo URL passed in is this module's ``FORGEJO_API_URL``
+        constant (captured at import, monkeypatched by the test suite via
+        ``patch.object(fb, "FORGEJO_API_URL", ...)``) rather than a fresh env
+        read, so attribute patches still flip the mode.
+    """
+    if not FORGEJO_API_URL:
+        # This module cannot operate against Forgejo without a base URL, so
+        # an empty FORGEJO_API_URL always means GitHub mode — even when
+        # resolve_platform's auto rule would infer forgejo from a non-github
+        # GITHUB_SERVER_URL (always set on Forgejo runners). Matches the
+        # pre-#367 behaviour exactly.
+        return False
+    platform = os.environ.get("PLATFORM", "").strip().lower() or "auto"
+    return resolve_platform(platform=platform, forgejo_api_url=FORGEJO_API_URL) == "forgejo"
 
 
 # ---------------------------------------------------------------------------

--- a/pr_reviewer/platform.py
+++ b/pr_reviewer/platform.py
@@ -78,17 +78,34 @@ GH_API_ALLOWED_PREFIXES = (
 )
 
 
-def resolve_platform() -> str:
+def resolve_platform(
+    platform: str | None = None, forgejo_api_url: str | None = None
+) -> str:
     """Resolve PLATFORM (github|forgejo|auto) to a concrete backend name.
 
     Mirrors ``platform_resolve`` in scripts/platform_api.sh: ``auto`` maps to
     forgejo when FORGEJO_API_URL is set or GITHUB_SERVER_URL names a
     non-github.com host (Forgejo Actions runners populate it with the
     instance URL), github otherwise.
+
+    ``platform`` and ``forgejo_api_url`` are optional overrides for the two
+    env vars this function otherwise reads. They exist so a caller that
+    already holds those values can delegate here instead of re-deriving the
+    rule — notably ``forgejo_backend._is_forgejo_mode``, which must consult
+    its monkeypatchable module-level ``FORGEJO_API_URL`` rather than a fresh
+    env read. With no arguments the behaviour is unchanged: an unset PLATFORM
+    still defaults to ``github`` (the documented contract).
     """
-    platform = os.environ.get("PLATFORM", "github").strip().lower() or "github"
+    if platform is None:
+        platform = os.environ.get("PLATFORM", "github")
+    platform = platform.strip().lower() or "github"
     if platform == "auto":
-        if os.environ.get("FORGEJO_API_URL", "").strip():
+        api = (
+            forgejo_api_url
+            if forgejo_api_url is not None
+            else os.environ.get("FORGEJO_API_URL", "")
+        )
+        if api.strip():
             return "forgejo"
         server = os.environ.get("GITHUB_SERVER_URL", "").rstrip("/")
         if server and server != "https://github.com":

--- a/scripts/check_review_needed.sh
+++ b/scripts/check_review_needed.sh
@@ -20,6 +20,25 @@ if [[ -z "$REPO" || -z "$PR_NUMBER" ]]; then
   exit 1
 fi
 
+# ── Platform resolution, once (#367) ──────────────────────────────────
+# Resolve the host platform a single time here — using the shared
+# platform_resolve rule (PLATFORM=github|forgejo|auto; auto → forgejo when
+# FORGEJO_API_URL is set or GITHUB_SERVER_URL names a non-github host) — and
+# emit it as two step outputs. Downstream action.yml steps consume
+# resolved_platform / effective_forgejo_api_url instead of each re-deriving
+# the platform from github.server_url in a copy-pasted expression (which let
+# the shell seam and forgejo_backend disagree). The precheck's own env still
+# carries the `inputs.forgejo_api_url || server_url` fallback, so the
+# explicit-input-wins-then-server-url precedence is captured here, once.
+# Resolution needs no PR data (pure env), so it runs before every early-exit
+# path and is emitted on all of them.
+RESOLVED_PLATFORM="$(platform_resolve)"
+if [[ "$RESOLVED_PLATFORM" == "forgejo" ]]; then
+  EFFECTIVE_FORGEJO_API_URL="${FORGEJO_API_URL:-}"
+else
+  EFFECTIVE_FORGEJO_API_URL=""
+fi
+
 # ── Label-driven re-review (#231) ─────────────────────────────────────
 # A `labeled` pull_request event is the easy re-review trigger: adding the
 # rereview label forces a fresh review (labels are self-authorizing — only
@@ -45,6 +64,8 @@ if [[ "${GITHUB_EVENT_NAME:-}" == "pull_request" && -f "${GITHUB_EVENT_PATH:-}" 
         echo "base_sha="
         echo "is_fork_pr="
         echo "diff_fingerprint="
+        echo "resolved_platform=$RESOLVED_PLATFORM"
+        echo "effective_forgejo_api_url=$EFFECTIVE_FORGEJO_API_URL"
       } >> "$OUTPUT_FILE"
       exit 0
     fi
@@ -299,6 +320,8 @@ if [[ "$should_review" == "false" ]]; then
     echo "diff_fingerprint=$broad_fingerprint"
     echo "should_review=$should_review"
     echo "skip_reason=$skip_reason"
+    echo "resolved_platform=$RESOLVED_PLATFORM"
+    echo "effective_forgejo_api_url=$EFFECTIVE_FORGEJO_API_URL"
   } >> "$OUTPUT_FILE"
   exit 0
 fi
@@ -518,3 +541,7 @@ echo "is_fork_pr=$IS_FORK_PR" >> "$OUTPUT_FILE"
 echo "diff_fingerprint=$broad_fingerprint" >> "$OUTPUT_FILE"
 echo "should_review=$should_review" >> "$OUTPUT_FILE"
 echo "skip_reason=$skip_reason" >> "$OUTPUT_FILE"
+
+# Platform resolution (resolved once near the top; see the #367 block).
+echo "resolved_platform=$RESOLVED_PLATFORM" >> "$OUTPUT_FILE"
+echo "effective_forgejo_api_url=$EFFECTIVE_FORGEJO_API_URL" >> "$OUTPUT_FILE"

--- a/tests/test_action_inputs.py
+++ b/tests/test_action_inputs.py
@@ -151,6 +151,36 @@ def test_action_yml_has_no_duplicate_env_keys():
     )
 
 
+def test_platform_resolution_centralized_in_precheck():
+    """Platform resolution lives in one place — the precheck (issue #367).
+
+    The ``github.server_url``→FORGEJO_API_URL fallback expression must appear
+    exactly once (the precheck step env, the only step with no precheck to
+    consume). Every downstream step reads the precheck's resolved_platform /
+    effective_forgejo_api_url outputs instead of re-deriving the platform,
+    which is what let the shell seam and forgejo_backend disagree.
+    """
+    content = (_REPO_ROOT / "action.yml").read_text()
+    fallback = "github.server_url != 'https://github.com'"
+    count = content.count(fallback)
+    assert count == 1, (
+        "the server_url→FORGEJO_API_URL fallback expression must appear exactly "
+        f"once (precheck only); found {count}. Downstream steps should consume "
+        "steps.precheck.outputs.resolved_platform / effective_forgejo_api_url."
+    )
+    assert "steps.precheck.outputs.resolved_platform" in content, (
+        "downstream steps must consume the precheck's resolved_platform output"
+    )
+    assert "steps.precheck.outputs.effective_forgejo_api_url" in content, (
+        "downstream steps must consume the precheck's effective_forgejo_api_url output"
+    )
+    # The lone remaining fallback must be paired with PLATFORM: inputs.platform
+    # (the precheck still takes raw inputs; it is the resolver, not a consumer).
+    assert "PLATFORM: ${{ inputs.platform }}" in content, (
+        "the precheck step must still resolve from the raw platform input"
+    )
+
+
 def test_comment_marker_input_exists():
     """Verify comment_marker input is declared (regression test for #113)."""
     action_inputs = parse_action_inputs()

--- a/tests/test_check_review_needed.sh
+++ b/tests/test_check_review_needed.sh
@@ -81,6 +81,9 @@ run_precheck() {
   (
     cd "$WORKDIR" || exit 1
     PATH="$TMPDIR/bin:$PATH" \
+    PLATFORM="${PLATFORM:-}" \
+    FORGEJO_API_URL="${FORGEJO_API_URL:-}" \
+    GITHUB_SERVER_URL="${GITHUB_SERVER_URL:-}" \
     REPO="test/repo" \
     PR_NUMBER=42 \
     GITHUB_OUTPUT="$output_file" \
@@ -399,6 +402,31 @@ cat > /tmp/testfp_pr_object.json <<'JSONEOF'
   "base": {"sha": "bbbb111122223333bbbb111122223333bbbb1111", "ref": "main", "repo": {"full_name": "test/repo"}}
 }
 JSONEOF
+
+# ── Test 18: precheck emits resolved platform outputs (#367) ──────────
+echo ""
+echo "=== Test 18: platform resolution outputs on the review path ==="
+set_empty_comments
+unset PLATFORM FORGEJO_API_URL GITHUB_SERVER_URL 2>/dev/null || true
+RESULT="$(run_precheck)"
+check "resolved_platform=github by default" "$(echo "$RESULT" | grep '^resolved_platform=' | head -1 | cut -d= -f2)" "github"
+check "effective_forgejo_api_url empty on github" "$(echo "$RESULT" | grep '^effective_forgejo_api_url=' | head -1 | cut -d= -f2-)" ""
+
+# PLATFORM=github must win even when FORGEJO_API_URL is force-filled — the
+# exact seam that used to disagree between the shell path and forgejo_backend.
+PLATFORM=github FORGEJO_API_URL="https://forge.example.com" RESULT="$(run_precheck)"
+check "PLATFORM=github forces github despite FORGEJO_API_URL" "$(echo "$RESULT" | grep '^resolved_platform=' | head -1 | cut -d= -f2)" "github"
+check "effective_forgejo_api_url empty when forced github" "$(echo "$RESULT" | grep '^effective_forgejo_api_url=' | head -1 | cut -d= -f2-)" ""
+
+# Test 19: forgejo resolution is emitted even on the label-skip early exit
+# (no PR fetch / network) — resolution is pure env.
+echo ""
+echo "=== Test 19: forgejo resolution on the unrelated-label early exit ==="
+printf '%s' '{"action":"labeled","label":{"name":"bug"}}' > "$TMPDIR/event-other.json"
+RESULT="$(PLATFORM=auto FORGEJO_API_URL="https://forge.example.com" GITHUB_EVENT_NAME=pull_request GITHUB_EVENT_PATH="$TMPDIR/event-other.json" run_precheck)"
+check "unrelated-label path still emits should_review=false" "$(echo "$RESULT" | grep '^should_review=' | head -1 | cut -d= -f2)" "false"
+check "auto+FORGEJO_API_URL resolves to forgejo" "$(echo "$RESULT" | grep '^resolved_platform=' | head -1 | cut -d= -f2)" "forgejo"
+check "effective_forgejo_api_url forwarded when forgejo" "$(echo "$RESULT" | grep '^effective_forgejo_api_url=' | head -1 | cut -d= -f2-)" "https://forge.example.com"
 
 echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="

--- a/tests/test_forgejo_backend.py
+++ b/tests/test_forgejo_backend.py
@@ -1173,5 +1173,52 @@ class TestDiffPositions(unittest.TestCase):
         })
 
 
+class TestIsForgejoMode(unittest.TestCase):
+    """_is_forgejo_mode is PLATFORM-aware (issue #367).
+
+    Previously it keyed purely off FORGEJO_API_URL being non-empty, so a
+    PLATFORM=github deployment on a non-github host (where action.yml
+    force-fills FORGEJO_API_URL from github.server_url) silently curled while
+    the shell seam used gh. It now delegates to resolve_platform.
+    """
+
+    def test_platform_github_overrides_forgejo_url(self):
+        # The regression: explicit PLATFORM=github must win over a populated URL.
+        with patch.object(fb, "FORGEJO_API_URL", FORGEJO_BASE), \
+             patch.dict(os.environ, {"PLATFORM": "github"}, clear=False):
+            self.assertFalse(fb._is_forgejo_mode())
+
+    def test_platform_forgejo_explicit(self):
+        with patch.object(fb, "FORGEJO_API_URL", FORGEJO_BASE), \
+             patch.dict(os.environ, {"PLATFORM": "forgejo"}, clear=False):
+            self.assertTrue(fb._is_forgejo_mode())
+
+    def test_url_only_still_forgejo(self):
+        # No PLATFORM set → treated as auto → a populated FORGEJO_API_URL
+        # (the monkeypatched module attribute) still flips to forgejo. This is
+        # the behaviour the whole existing test suite relies on.
+        with patch.object(fb, "FORGEJO_API_URL", FORGEJO_BASE), \
+             patch.dict(os.environ, {}, clear=True):
+            self.assertTrue(fb._is_forgejo_mode())
+
+    def test_empty_url_stays_github_even_on_forgejo_runner(self):
+        # Forgejo Actions runners always set GITHUB_SERVER_URL to the instance
+        # URL. Without a FORGEJO_API_URL this module cannot build API URLs, so
+        # it must stay in GitHub mode rather than curl an empty base (the
+        # auto rule's server_url inference must not leak in here).
+        with patch.object(fb, "FORGEJO_API_URL", ""), \
+             patch.dict(os.environ, {"GITHUB_SERVER_URL": "https://forgejo.example.com"}, clear=True):
+            self.assertFalse(fb._is_forgejo_mode())
+
+    def test_default_github_when_no_url(self):
+        with patch.object(fb, "FORGEJO_API_URL", ""), \
+             patch.dict(os.environ, {}, clear=True):
+            self.assertFalse(fb._is_forgejo_mode())
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -55,6 +55,40 @@ class TestResolvePlatform(unittest.TestCase):
                 resolve_platform()
 
 
+class TestResolvePlatformOverrides(unittest.TestCase):
+    """The optional overrides added for #367 (forgejo_backend delegation)."""
+
+    def test_platform_override_beats_env(self):
+        # An explicit platform argument is authoritative over the env var.
+        with _env(PLATFORM="forgejo"):
+            self.assertEqual(resolve_platform(platform="github"), "github")
+
+    def test_forgejo_api_url_override_drives_auto(self):
+        # auto + a non-empty forgejo_api_url override → forgejo, regardless of
+        # the (unset) FORGEJO_API_URL env var.
+        with _env(PLATFORM="", FORGEJO_API_URL="", GITHUB_SERVER_URL="https://github.com"):
+            self.assertEqual(
+                resolve_platform(platform="auto", forgejo_api_url="https://f.example"),
+                "forgejo",
+            )
+
+    def test_empty_forgejo_api_url_override_falls_back_to_server(self):
+        # An empty override means "no configured Forgejo URL"; the server-host
+        # inference still applies on auto.
+        with _env(GITHUB_SERVER_URL="https://forgejo.example.com"):
+            self.assertEqual(
+                resolve_platform(platform="auto", forgejo_api_url=""), "forgejo"
+            )
+        with _env(GITHUB_SERVER_URL="https://github.com"):
+            self.assertEqual(
+                resolve_platform(platform="auto", forgejo_api_url=""), "github"
+            )
+
+    def test_empty_platform_override_defaults_to_github(self):
+        with _env(PLATFORM="forgejo"):
+            self.assertEqual(resolve_platform(platform=""), "github")
+
+
 class TestGhArgv(unittest.TestCase):
     def test_github_argv_is_byte_identical(self):
         with _env(PLATFORM="github"):


### PR DESCRIPTION
Closes #367.

## Summary
- The precheck resolves the platform once (via the existing `platform_resolve` rule) and emits `resolved_platform` + `effective_forgejo_api_url` step outputs on all three exit paths; the four downstream action.yml sites consume those outputs instead of each re-pasting the `inputs.forgejo_api_url || server_url` expression (which now lives only on the precheck step).
- `forgejo_backend._is_forgejo_mode()` delegates to `resolve_platform` instead of keying purely off `FORGEJO_API_URL` — fixing the disagreement where `PLATFORM=github` on a non-github host used gh on the shell seam while every backend function silently curled. Unset PLATFORM is treated as auto, and an empty `FORGEJO_API_URL` always means GitHub mode (the module can't build Forgejo URLs without a base — keeps Forgejo runners' ambient `GITHUB_SERVER_URL` from flipping URL-less callers).
- `resolve_platform` gains optional `platform`/`forgejo_api_url` override params; no-arg behavior unchanged.

## Verification
- New tests: PLATFORM=github override, URL-only auto, empty-URL-on-forgejo-runner, precheck output emission on the network-free early-exit path, and a lint that the server_url fallback expression appears exactly once in action.yml.
- Full pytest (1063) + all bash suites pass; action.yml parses.

## Notes
- Behavior fix by design: with `PLATFORM=github` on a non-github server, downstream steps now receive an empty `FORGEJO_API_URL` instead of the force-filled server URL.
- Expect a trivial merge with #384 (both touch action.yml env lines) — whichever lands second rebases clean.