### PR TITLE
fix(mcp): correct tool-name docs, log loop outcome, resolve separator aliases

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -441,7 +441,8 @@ inputs:
       Optional allowlist of read-only MCP servers for tool_mode=native_loop, as a
       newline/comma list of name=url (e.g. konflate=https://konflate.example/mcp).
       Their read-verb tools (list/get/read/…) are advertised as
-      mcp_<name>_<tool>; write-verb tools are refused. Empty = off (default).
+      mcp__<name>__<tool> (double underscores); write-verb tools are refused.
+      Empty = off (default).
       Fork-gated like the rest of the harness (tool_enable_for_forks). Only
       host-bearing http(s) URLs are accepted (HTTPS recommended); other schemes
       are dropped.

--- a/scripts/run_tool_harness.py
+++ b/scripts/run_tool_harness.py
@@ -62,6 +62,25 @@ def normalize_repo_name(value):
     return f"{owner}/{repo}"
 
 
+def resolve_mcp_tool_name(tool_name, mcp_routes):
+    """Resolve a model-emitted MCP tool name to an advertised route.
+
+    Exact matches pass through. A name that only differs in separators —
+    e.g. ``mcp_konflate_get_pr_summary`` for the advertised
+    ``mcp__konflate__get_pr_summary`` (steering prompts written against the
+    pre-fix docs used single underscores) — resolves iff exactly one
+    advertised route collapses to the same form. Ambiguity or no match
+    returns None; only already-advertised (allowlisted, read-only-filtered)
+    routes are ever returned.
+    """
+    if tool_name in mcp_routes:
+        return tool_name
+    wanted = re.sub(r"[^a-z0-9]", "", tool_name.lower())
+    matches = [k for k in mcp_routes
+               if re.sub(r"[^a-z0-9]", "", k.lower()) == wanted]
+    return matches[0] if len(matches) == 1 else None
+
+
 def env_int(name, default_value, min_value):
     raw = os.getenv(name, str(default_value)).strip()
     try:
@@ -485,12 +504,25 @@ def run_native_loop(
         # Route mcp__server__tool to the MCP client; everything else falls
         # through to the built-in read-only executor unchanged. MCP output is
         # masked + capped exactly like built-in tool output (untrusted corpus).
-        if split_namespaced(tool_name):
-            toolset = mcp_routes.get(tool_name)
-            if toolset is None:
+        # A separator-mangled variant of an advertised name (e.g. the
+        # single-underscore mcp_server_tool a steering prompt may carry) is
+        # resolved when unambiguous — the route set is still the allowlisted,
+        # read-only-filtered one, so this loosens nothing.
+        if split_namespaced(tool_name) or (
+            mcp_routes and tool_name.startswith("mcp_")
+        ):
+            routed = resolve_mcp_tool_name(tool_name, mcp_routes)
+            if routed is None:
+                advertised = ", ".join(sorted(mcp_routes)) or "(none configured)"
                 return {"tool": tool_name, "status": "error",
-                        "result": {"error": f"Unknown MCP tool: {tool_name}"}}
-            _, bare_tool = split_namespaced(tool_name)
+                        "result": {"error": (
+                            f"Unknown MCP tool: {tool_name}. "
+                            f"Advertised MCP tools: {advertised}")}}
+            if routed != tool_name:
+                print(f"  MCP tool name '{tool_name}' resolved to '{routed}'",
+                      file=sys.stderr)
+            toolset = mcp_routes[routed]
+            _, bare_tool = split_namespaced(routed)
             res = toolset.call(bare_tool, args if isinstance(args, dict) else {})
             if res.get("error"):
                 return {"tool": tool_name, "status": "error", "result": {"error": res["error"]}}
@@ -554,7 +586,21 @@ def run_native_loop(
         summarize_fn=summarize_fn,
     )
 
+    # One always-printed outcome line: "it silently did nothing" is exactly the
+    # failure mode operators can't diagnose from an otherwise-quiet log.
+    print(
+        f"  native_loop: {len(outcome.executed)} tool call(s) executed in "
+        f"{outcome.rounds} round(s), {outcome.tool_calls_issued} issued "
+        f"(stop: {outcome.stop_reason})",
+        file=sys.stderr,
+    )
     if outcome.degraded:
+        print(
+            "  native_loop degraded: the model issued no tool calls"
+            + (f" ({outcome.error})" if outcome.error else "")
+            + " — reviewing the corpus directly (no evidence gathered)",
+            file=sys.stderr,
+        )
         result["native_loop_degraded"] = outcome.stop_reason
         if outcome.error:
             result["native_loop_error"] = outcome.error

--- a/tests/test_run_native_loop_wiring.py
+++ b/tests/test_run_native_loop_wiring.py
@@ -602,3 +602,49 @@ def test_native_loop_advertises_and_routes_mcp_tool(monkeypatch, tmp_path):
     harness = json.loads((tmp_path / "tool-harness.json").read_text())
     mcp_calls = [tc for tc in harness.get("tool_calls", []) if tc["tool"] == "mcp__konflate__get_pr_diff"]
     assert mcp_calls and mcp_calls[0]["status"] == "ok"
+
+
+class TestResolveMcpToolName:
+    """Separator-tolerant MCP tool-name resolution (#245 follow-up).
+
+    Steering prompts written against the pre-fix action.yml docs used
+    single-underscore names (mcp_server_tool); the loop resolves those to the
+    advertised mcp__server__tool route when unambiguous, and never invents a
+    route outside the allowlisted set.
+    """
+
+    ROUTES = {
+        "mcp__konflate__get_pr_summary": object(),
+        "mcp__konflate__get_pr_diff": object(),
+    }
+
+    def test_exact_name_passes_through(self):
+        assert (
+            rth.resolve_mcp_tool_name("mcp__konflate__get_pr_diff", self.ROUTES)
+            == "mcp__konflate__get_pr_diff"
+        )
+
+    def test_single_underscore_alias_resolves(self):
+        assert (
+            rth.resolve_mcp_tool_name("mcp_konflate_get_pr_summary", self.ROUTES)
+            == "mcp__konflate__get_pr_summary"
+        )
+
+    def test_case_and_hyphen_variants_resolve(self):
+        assert (
+            rth.resolve_mcp_tool_name("MCP__Konflate__get-pr-diff", self.ROUTES)
+            == "mcp__konflate__get_pr_diff"
+        )
+
+    def test_unknown_name_returns_none(self):
+        assert rth.resolve_mcp_tool_name("mcp__konflate__render_diff", self.ROUTES) is None
+
+    def test_ambiguous_collapse_returns_none(self):
+        routes = {
+            "mcp__srv__get_x": object(),
+            "mcp__srv__getx": object(),  # collapses identically
+        }
+        assert rth.resolve_mcp_tool_name("mcp_srv_get_x", routes) is None
+
+    def test_empty_routes_returns_none(self):
+        assert rth.resolve_mcp_tool_name("mcp_konflate_get_pr_diff", {}) is None


### PR DESCRIPTION
Field-debugged from a third-party deployment (bjw-s/home-ops) where Konflate MCP connected and advertised 3 tools but the review never used them.

## Summary
- **Docs bug (root cause):** `action.yml`'s `tool_mcp_servers` description said tools are advertised as `mcp_<name>_<tool>`; the code advertises `mcp__<name>__<tool>` (README was already correct). A steering prompt written against the input docs pushed the model toward names that don't exist.
- **Observability:** the harness now always prints one outcome line (`native_loop: N tool call(s) executed in M round(s), K issued (stop: …)`) and an explicit `native_loop degraded: the model issued no tool calls…` line — previously a zero-call loop was fully silent in the step log.
- **Self-correction:** a model-emitted MCP name that only differs in separators/case (`mcp_konflate_get_pr_summary`) resolves to the advertised route when the collapse is unambiguous; anything else gets a refusal that lists the advertised MCP names so the model can retry correctly. Only already-advertised (allowlisted, read-verb-filtered) routes are ever resolved — the default-deny boundary is unchanged.

## Verification
- 6 new unit tests for `resolve_mcp_tool_name` (exact, single-underscore, case/hyphen, unknown, ambiguous-collapse, empty); full pytest (1166) + all bash suites pass.
- The MCP transport/verb-filter/anthropic-tool-calling path was separately validated live against a real Konflate + LiteLLM/MiniMax stack with the action's own client code.