### PR TITLE
docs(agents): replace stale saffron-lane label table with ad-hoc agent/<name> convention

### DIFF
--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -66,11 +66,6 @@
 - name: blocked
   color: "e11d21"
   description: Progress is blocked.
-# Stable Agents
-- name: agent/saffron-normal
-  color: "1d76db"
-  description: Stable normal-lane Saffron worker.
-- name: agent/saffron-escalated
-  color: "0052cc"
-  description: Stable escalated-lane Saffron worker.
+# agent/<name> identity labels are created ad hoc at claim time (see AGENTS.md
+# "Label taxonomy") and are deliberately not enumerated here.
 # Repo-specific labels can be appended below. Unknown labels are not pruned.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,7 +136,7 @@ The smoke test validates: GitHub PR data collection, corpus assembly, OpenAI/Ant
 
 ## Label taxonomy (`agent/*` and Dispatch workflow labels)
 
-Labels are defined in `.github/labels.yaml`. There are two distinct groups that agents interact with:
+Workflow labels are defined in `.github/labels.yaml`; agent identity labels are created ad hoc (see below). There are two distinct groups that agents interact with:
 
 ### Dispatch / operational labels
 These are managed by the Dispatch system (dispatch.jory.dev) and are the source of truth for issue workflow state. Agents read and set these to claim and advance work.
@@ -154,12 +154,7 @@ These are managed by the Dispatch system (dispatch.jory.dev) and are the source 
 | `blocked` | Externally blocked; agent should not pick up |
 
 ### Agent identity labels
-These tag which Dispatch worker lane handled the issue and are set by the Dispatch orchestrator, not by agents themselves.
-
-| Label | Meaning |
-|---|---|
-| `agent/saffron-normal` | Processed by the normal-lane Saffron worker (default untagged issues) |
-| `agent/saffron-escalated` | Processed by the escalated-lane Saffron worker (`needs-escalation` issues) |
+`agent/<name>` labels tag which agent or operator holds the claim on an issue (for example `agent/foreman-coder`, `agent/joryirving`, `agent/saffron`). They are created ad hoc at claim time by Dispatch or by the claiming agent, not enumerated in `.github/labels.yaml`. An issue in `status/in-progress` carries exactly one `agent/*` label; reassigning work means swapping it.
 
 ### Re-review label
 `ai-review` is a repo-internal label: adding it to an open PR triggers a fresh AI review run regardless of fingerprint. It is removed automatically by the action after publishing. This label is **not** a Dispatch workflow label.


### PR DESCRIPTION
Closes #388.

## Summary
- Replace the stale `agent/saffron-normal` / `agent/saffron-escalated` table in `AGENTS.md` with the actual convention: `agent/<name>` identity labels are created ad hoc at claim time (e.g. `agent/foreman-coder`, `agent/joryirving`) and are not enumerated in `labels.yaml`.
- Drop the matching stale entries from `.github/labels.yaml` (label sync has `delete-other-labels: false`, so live labels are unaffected).

## Notes
- Supersedes `foreman/wl-misospace-pr-reviewer-action-388/issue-388`, which scrubbed the Dispatch references instead — those are accurate (Dispatch is the live workflow-state system), so they stay. The audit finding's "Worker Cron Rules section" does not exist in the file.