### PR TITLE
perf(native-loop): dedup verdict-turn corpus sections; collapse skipped-source boilerplate

### DIFF
--- a/pr_reviewer/conversation.py
+++ b/pr_reviewer/conversation.py
@@ -328,6 +328,73 @@ VERDICT_USER_INSTRUCTION = (
     "Do not issue any tool calls."
 )
 
+# Placeholder emitted for a corpus section dropped by dedupe_verdict_corpus.
+# Callers count occurrences of this literal to log how many sections were
+# dropped, so keep it stable.
+VERDICT_DEDUP_NOTICE = (
+    "(unchanged — provided in full in the first message of this conversation)"
+)
+
+
+def dedupe_verdict_corpus(corpus: str, planning_context: str) -> str:
+    """Drop corpus sections already present verbatim in the planning context.
+
+    The native_loop verdict turn (#372) re-sends the full review corpus as a
+    trailing user message, but the loop's FIRST user message (the planning
+    context, built by ``build_planning_context`` in
+    ``scripts/run_tool_harness.py``) already carries several of that corpus's
+    sections verbatim. This removes only the byte-duplicate sections, replacing
+    each with a one-line placeholder, so the corpus content still reaches the
+    model across the conversation as a whole — the #362 verdict-turn contract
+    invariant "the full corpus reaches the model" is preserved (the model has
+    the dropped bytes in message 1).
+
+    Matching rule (deliberately conservative — a false drop silently loses
+    evidence, which is far worse than re-sending some bytes):
+
+      * Sections are split on level-1 ATX headers only (``"# Title"``), the
+        top-level section delimiter emitted by ``build_review_corpus`` in
+        ``scripts/sections/corpus.sh``. ``"## Source N"`` / ``"### ..."``
+        subheaders inside a section are NOT delimiters and never split it.
+      * A section is dropped ONLY if its full text, modulo trailing whitespace,
+        appears byte-identically inside ``planning_context``. Partial overlap
+        never counts: a truncated or paraphrased copy (e.g. the planner's
+        "PR Diff (head)" excerpt vs the corpus's full "PR Diff (truncated)", or
+        a section whose header/cap differs between the two builders) is NOT a
+        byte match and is therefore sent IN FULL.
+
+    Total and never raises: empty corpus, empty planning context, or a
+    headerless blob all round-trip unchanged (nothing to dedup against, or
+    nothing to match).
+    """
+    if not corpus or not planning_context:
+        return corpus
+    lines = corpus.split("\n")
+    # Level-1 headers only: a line beginning "# " (hash + space). "## "/"### "
+    # start with "#" then "#", so startswith("# ") excludes them.
+    starts = [i for i, ln in enumerate(lines) if ln.startswith("# ")]
+    if not starts:
+        return corpus
+    out: list[str] = []
+    # Any preamble before the first header is not a section — keep it verbatim.
+    if starts[0] > 0:
+        out.extend(lines[: starts[0]])
+    bounds = starts + [len(lines)]
+    for idx in range(len(starts)):
+        seg = lines[bounds[idx] : bounds[idx + 1]]
+        stripped = "\n".join(seg).rstrip()
+        # Substring containment of the rstripped section tolerates trailing
+        # whitespace on the corpus side and extra content after it in the
+        # planning context, while still requiring every internal byte
+        # (header + fences + body) to match — partial overlap can't pass.
+        if stripped and stripped in planning_context:
+            title = seg[0][2:].strip()  # drop the leading "# "
+            out.append(f"## {title}")
+            out.append(VERDICT_DEDUP_NOTICE)
+        else:
+            out.extend(seg)
+    return "\n".join(out)
+
 
 # ---------------------------------------------------------------------------
 # Message normalisation

--- a/pr_reviewer/linked_sources.py
+++ b/pr_reviewer/linked_sources.py
@@ -118,6 +118,11 @@ def render_linked_sources(
             releases_cache[key] = data if isinstance(data, list) else None
         return releases_cache[key]
 
+    # Hosts whose source produced only a skip notice and no enrichment (#372):
+    # each such source would otherwise emit a full "## Source N" block of pure
+    # boilerplate. They are collapsed into one trailing summary line instead.
+    skipped_hosts: list[str] = []
+
     for i, url in enumerate(urls[:25], 1):
         if not budget.ok():
             break
@@ -125,6 +130,11 @@ def render_linked_sources(
         normalized = normalize_url(url)
         host = _extract_host(normalized)
 
+        # Mark where this source's section begins so a source that yields
+        # nothing but a skip notice can be dropped wholesale (#372). The
+        # section keeps its original 1-based `i` (tied to the fetch-phase index
+        # and the `fetched` map) — non-skipped sources are never renumbered.
+        src_start = len(lines)
         lines.append(f"## Source {i}")
         lines.append(f"URL: {url}")
         if normalized != url:
@@ -132,6 +142,7 @@ def render_linked_sources(
         lines.append("")
         lines.append("### Fetched Content (truncated)")
 
+        is_skip = False
         if host_allowed(normalized, allowed_hosts):
             if host == "github.com":
                 lines.append(
@@ -139,6 +150,7 @@ def render_linked_sources(
                 )
             elif host in SKIP_FETCH_HOSTS:
                 lines.append(f"(Raw HTML fetch skipped for known non-Forgejo host: {host})")
+                is_skip = True
             elif i in fetched and fetched[i]:
                 text = strip_source_to_text(fetched[i])
                 if text:
@@ -152,6 +164,11 @@ def render_linked_sources(
                 lines.append(f"(Failed to fetch allowlisted URL content from {host})")
         else:
             lines.append(f"(Skipped non-allowlisted URL: {host})")
+            is_skip = True
+
+        # Enrichment appended from here on; `is_skip` with no enrichment beyond
+        # this point means the section is pure boilerplate and gets collapsed.
+        enrich_start = len(lines)
 
         # GitHub release metadata
         cls = classify_url(normalized)
@@ -260,6 +277,26 @@ def render_linked_sources(
                 seen_repos.add(repo_key)
                 repo_candidates.append(repo_key)
 
+        # A pure skip notice with no enrichment (nothing non-blank appended
+        # since `enrich_start`) is dropped: rewind this section's lines and
+        # record its host for the collapsed summary (#372). github.com is never
+        # `is_skip`, so its sections (and any release/compare metadata) always
+        # survive. repo candidates are collected above regardless, so Phase 3
+        # enrichment for github.com repos is unaffected.
+        if is_skip and not any(ln.strip() for ln in lines[enrich_start:]):
+            del lines[src_start:]
+            skipped_hosts.append(host)
+        else:
+            lines.append("")
+
+    if skipped_hosts:
+        # One trailing line for every collapsed source, hosts deduped + sorted.
+        n = len(skipped_hosts)
+        uniq = ", ".join(sorted(set(skipped_hosts)))
+        lines.append(
+            f"({n} source{'s' if n != 1 else ''} skipped — "
+            f"non-allowlisted or non-fetchable hosts: {uniq})"
+        )
         lines.append("")
 
     # Phase 3: GitHub releases enrichment for candidate repos

--- a/scripts/run_tool_harness.py
+++ b/scripts/run_tool_harness.py
@@ -372,8 +372,10 @@ def run_native_loop(
         sys.path.insert(0, repo_root)
     from pr_reviewer.conversation import (  # noqa: PLC0415
         TOOL_SCHEMAS,
+        VERDICT_DEDUP_NOTICE,
         WEB_SEARCH_SCHEMA,
         Conversation,
+        dedupe_verdict_corpus,
     )
     from pr_reviewer.tool_loop import (  # noqa: PLC0415
         adaptive_loop_budgets,
@@ -631,7 +633,28 @@ def run_native_loop(
                 else ""
             )
             if verdict_corpus:
-                conversation.add_user(_VERDICT_CLOSING_INSTRUCTION + verdict_corpus)
+                # #372: the loop's first user message (corpus_text — the
+                # planning context) already carries several corpus sections
+                # verbatim. Drop only those byte-duplicates so the verdict turn
+                # doesn't re-send ~50KB the model already has. Dedup is
+                # section-exact and conservative (partial/truncated overlaps are
+                # kept in full), so the #362 contract invariant "the full corpus
+                # reaches the model" still holds — the dropped bytes live in
+                # message 1. Path A (bash single-shot review) has no prior
+                # context and is untouched.
+                deduped_corpus = dedupe_verdict_corpus(verdict_corpus, corpus_text)
+                dropped = deduped_corpus.count(VERDICT_DEDUP_NOTICE)
+                if dropped:
+                    saved = len(verdict_corpus.encode("utf-8")) - len(
+                        deduped_corpus.encode("utf-8")
+                    )
+                    print(
+                        f"  native_loop: verdict-corpus dedup dropped {dropped} "
+                        f"section(s) already in the planning context "
+                        f"({saved} bytes saved)",
+                        file=sys.stderr,
+                    )
+                conversation.add_user(_VERDICT_CLOSING_INSTRUCTION + deduped_corpus)
                 temp_raw = os.getenv("AI_TEMPERATURE", "").strip()
                 temperature = float(temp_raw) if temp_raw else None
                 rf = os.getenv("AI_RESPONSE_FORMAT", "off").strip().lower()

--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -13,8 +13,10 @@ sys.path.insert(0, str(_REPO_ROOT))
 from pr_reviewer.conversation import (  # noqa: E402
     APPROX_BYTES_PER_TOKEN,
     TOOL_SCHEMAS,
+    VERDICT_DEDUP_NOTICE,
     WEB_SEARCH_SCHEMA,
     Conversation,
+    dedupe_verdict_corpus,
     truncate_text,
 )
 
@@ -822,6 +824,80 @@ class TestReassemblerShapeIngest:
         )
         events = [e for e in c.events if e["kind"] == "assistant_tool_calls"]
         assert events[0]["calls"][0]["name"] == "git_grep"
+
+
+class TestDedupeVerdictCorpus:
+    """dedupe_verdict_corpus (#372): drop only byte-identical corpus sections
+    that already appear verbatim in the planning context; keep everything else
+    in full so the #362 "full corpus reaches the model" invariant survives."""
+
+    def test_identical_section_is_dropped_with_placeholder(self):
+        section = "# Version Hints from Diff\n```text\nimg: app-1.2.3\n```"
+        planning = "# PR Classification\n{}\n\n" + section
+        corpus = (
+            "# PR Diff (truncated)\n```diff\n+full diff here\n```\n\n"
+            + section
+            + "\n"
+        )
+        out = dedupe_verdict_corpus(corpus, planning)
+        # The duplicate section collapses to a placeholder...
+        assert VERDICT_DEDUP_NOTICE in out
+        assert "## Version Hints from Diff" in out
+        assert "img: app-1.2.3" not in out
+        # ...while a section absent from the planning context is kept in full.
+        assert "+full diff here" in out
+
+    def test_truncated_partial_section_kept_in_full(self):
+        # The planner sends only a HEAD excerpt of the diff; the corpus carries
+        # the full diff. Partial overlap must NEVER count as a match.
+        planning = "# PR Diff (head)\n```diff\n+line one\n```"
+        corpus = "# PR Diff (truncated)\n```diff\n+line one\n+line two\n+line three\n```\n"
+        out = dedupe_verdict_corpus(corpus, planning)
+        assert out == corpus
+        assert VERDICT_DEDUP_NOTICE not in out
+
+    def test_zero_overlap_returns_input_unchanged(self):
+        corpus = "# A\nalpha\n\n# B\nbeta\n"
+        assert dedupe_verdict_corpus(corpus, "nothing in common here") == corpus
+
+    def test_empty_corpus_and_empty_planning(self):
+        assert dedupe_verdict_corpus("", "planning") == ""
+        assert dedupe_verdict_corpus("# A\nbody", "") == "# A\nbody"
+
+    def test_headerless_corpus_round_trips(self):
+        blob = "just some text\nwith no level-1 headers\n## not level 1\n"
+        assert dedupe_verdict_corpus(blob, blob) == blob
+
+    def test_subheaders_do_not_split_sections(self):
+        # "## Source N" inside a section must not be treated as a delimiter: the
+        # whole "# Linked Sources" section matches as one unit.
+        section = "# Linked Sources\n## Source 1\nURL: https://x\n### Fetched\nbody"
+        planning = "prefix\n\n" + section + "\n\nsuffix"
+        out = dedupe_verdict_corpus(section + "\n", planning)
+        assert out.count("## Source 1") == 0  # collapsed, not split out
+        assert VERDICT_DEDUP_NOTICE in out
+        assert out.startswith("## Linked Sources")
+
+    def test_section_order_preserved_for_kept_sections(self):
+        s_dup = "# Version Hints from Diff\n```text\nv1\n```"
+        corpus = (
+            "# First\nfirst body\n\n"
+            + s_dup
+            + "\n\n# Last\nlast body\n"
+        )
+        out = dedupe_verdict_corpus(corpus, "planning ... " + s_dup + " ... more")
+        # Kept sections keep their relative order; the middle one collapsed.
+        assert out.index("# First") < out.index("## Version Hints from Diff")
+        assert out.index("## Version Hints from Diff") < out.index("# Last")
+
+    def test_trailing_whitespace_tolerated(self):
+        # The corpus section has trailing blank lines the planning copy lacks;
+        # they must not defeat the match ("modulo trailing whitespace").
+        section = "# Evidence Providers\nbody line"
+        corpus = section + "\n\n\n"
+        planning = "x\n" + section + "\ny"
+        out = dedupe_verdict_corpus(corpus, planning)
+        assert VERDICT_DEDUP_NOTICE in out
 
 
 if __name__ == "__main__":

--- a/tests/test_enrichment.py
+++ b/tests/test_enrichment.py
@@ -502,6 +502,69 @@ class TestRunEnrichmentMain:
         assert md == ""
 
 
+class TestSkippedSourceCollapse:
+    """render_linked_sources (#372): sources that yield only a skip notice are
+    collapsed into ONE trailing summary line instead of a full ## Source N
+    block. Fetched / enriched sources keep their numbering and full sections."""
+
+    def _render(self, monkeypatch, urls, allowed_hosts, fetch_map=None):
+        from pr_reviewer import linked_sources
+
+        fetch_map = fetch_map or {}
+
+        def fake_fetch(url, timeout=25):
+            return fetch_map.get(url)
+
+        monkeypatch.setattr(linked_sources, "fetch_url", fake_fetch)
+        monkeypatch.setattr(linked_sources, "gh_api_call", lambda *a, **k: None)
+        budget = linked_sources.BudgetTracker(max_seconds=60)
+        return linked_sources.render_linked_sources(
+            urls, set(allowed_hosts), None, "", [], None, budget
+        )
+
+    def test_multiple_skipped_hosts_collapse_to_one_sorted_line(self, monkeypatch):
+        md = self._render(
+            monkeypatch,
+            ["https://evil.com/a", "https://bad.net/b", "https://evil.com/c"],
+            allowed_hosts=[],  # nothing allowlisted → all three are skips
+        )
+        # No per-source boilerplate for any of them.
+        assert "## Source" not in md
+        assert "(Skipped non-allowlisted URL" not in md
+        # One summary line, count = number of skipped sources, hosts deduped+sorted.
+        assert (
+            "(3 sources skipped — non-allowlisted or non-fetchable hosts: "
+            "bad.net, evil.com)"
+        ) in md
+
+    def test_mixed_skipped_and_fetched_ordering(self, monkeypatch):
+        md = self._render(
+            monkeypatch,
+            ["https://example.com/page", "https://evil.com/x"],
+            allowed_hosts=["example.com"],
+            fetch_map={"https://example.com/page": b"<html>hello world</html>"},
+        )
+        # The allowlisted fetched source keeps its full section and its index.
+        assert "## Source 1" in md
+        assert "URL: https://example.com/page" in md
+        # The skipped source's "## Source 2" block is gone, folded into summary.
+        assert "## Source 2" not in md
+        assert (
+            "(1 source skipped — non-allowlisted or non-fetchable hosts: evil.com)"
+            in md
+        )
+
+    def test_no_skipped_sources_leaves_summary_absent(self, monkeypatch):
+        md = self._render(
+            monkeypatch,
+            ["https://example.com/page"],
+            allowed_hosts=["example.com"],
+            fetch_map={"https://example.com/page": b"<html>hi</html>"},
+        )
+        assert "## Source 1" in md
+        assert "skipped —" not in md
+
+
 class TestSelectTargetVersionLastWins:
     """Regression: select_target_version fallback matches tail -n1 semantics."""
 


### PR DESCRIPTION
Refs #372 (see closing comment there for what this does and doesn't cover).

## Summary
- `dedupe_verdict_corpus(corpus, planning_context)` in `conversation.py`: the native-loop verdict turn drops corpus sections whose bytes already appear verbatim in the loop's first user message, replacing each with a one-line placeholder. Matching is deliberately conservative — level-1 sections only, byte-exact (modulo trailing whitespace); partial/truncated overlap never counts, so no evidence can be lost (dropped bytes provably exist in message 1, preserving the #362 "corpus reaches the model" invariant). Path A (bash single-shot review) untouched.
- `linked_sources.py`: sources that yield only a skip notice (non-allowlisted / known-skip hosts) no longer emit a full `## Source N` block; all collapse into one trailing summary line with hosts deduped + sorted. Kept sources keep their numbering.
- One `native_loop:` stderr line reports sections dropped + bytes saved when dedup fires.

## Honest scope note
Measured against the actual builders, most planner sections are *not* byte-identical to their corpus counterparts (different jq projections, caps, titles — e.g. `PR Diff (head)` is a prefix of the full diff, which conservative matching correctly keeps). So dedup savings are real but modest (typically Version Hints + small identical sections); the skip-notice collapse is the unconditional win on link-heavy Renovate PRs. Closing the full ~12k-token gap would require aligning the planner/corpus builders — a deliberate model-input change left out of this PR.

## Verification
- Full pytest suite (1200 passed) + all `tests/test_*.sh` green.
- New tests: 8 dedup cases (partial-overlap kept, headerless round-trip, order preserved, whitespace tolerance) + 3 skip-collapse cases. `test_verdict_contract_equivalence.py` unaffected (asserts structural invariants, not corpus bytes).
- No live eval run: dedup only removes bytes already in the same conversation, and the collapse removes pure boilerplate — flag if you want an N≥3 eval against home-ops#7462 before merge anyway.