### PR TITLE
refactor(review): unify primary/fallback/smart model calls behind call_model_tier

### DIFF
--- a/scripts/model_call.sh
+++ b/scripts/model_call.sh
@@ -180,3 +180,112 @@ build_model_request() {
        + (if $stream then {stream_options:{include_usage:true}} else {} end)' > "$output_file"
   fi
 }
+
+# call_model_tier TIER USER_MESSAGE CORPUS_FILE REQUEST_OUT RESPONSE_OUT
+#
+# Single entry point for the primary / fallback / smart model calls, which had
+# drifted apart while copy-pasted into review.sh (#368: divergent retry, stream
+# and truncation handling). Resolves the tier profile — endpoint, model,
+# api_format, key, stream flag, request/connect timeouts, retry budget and base
+# delay — from the existing env prefixes in ONE place, then runs the shared loop:
+#   build_model_request → curl_model → (stream? reassemble_sse_response) → parse_and_validate
+# On success the validated review lands in ai-output.json (via parse_and_validate)
+# exactly as before; returns 0. Returns non-zero once the tier budget is spent.
+#
+# Retry semantics (formerly only the primary's): a parse/validate failure is
+# usually deterministic, so it is capped at 2 attempts; transport/HTTP failures
+# keep the full budget with exponential backoff capped at 120s.
+#
+# Reads globals set by config.sh / classification.sh / review.sh: SYSTEM_PROMPT,
+# STREAM_BOOL, the AI_* / AI_FALLBACK_* / SMART_* profiles and the per-tier retry
+# knobs. truncate_clean / reassemble_sse_response / parse_and_validate live in
+# config.sh and are resolved at call time (this only runs from review.sh).
+call_model_tier() {
+  local tier="$1" user_message="$2" corpus_file="$3" request_out="$4" response_out="$5"
+
+  local base_url model api_format api_key stream label
+  local request_timeout connect_timeout retries retry_delay corpus_for_request
+  case "$tier" in
+    primary)
+      label="Primary"
+      base_url="$AI_BASE_URL"; model="$AI_MODEL"; api_format="$AI_API_FORMAT"; api_key="$AI_API_KEY"
+      stream="$STREAM_BOOL"
+      request_timeout="$AI_REQUEST_TIMEOUT_SEC"; connect_timeout="$AI_CONNECT_TIMEOUT_SEC"
+      retries="$AI_PRIMARY_RETRIES"; retry_delay="$AI_PRIMARY_RETRY_DELAY_SEC"
+      corpus_for_request="$corpus_file"
+      ;;
+    fallback)
+      label="Fallback"
+      base_url="$AI_FALLBACK_BASE_URL"; model="$AI_FALLBACK_MODEL"
+      api_format="$AI_FALLBACK_API_FORMAT"; api_key="$AI_FALLBACK_API_KEY"
+      stream="false"
+      if [[ "$(printf '%s' "$AI_FALLBACK_STREAM" | tr '[:upper:]' '[:lower:]')" == "true" ]]; then
+        stream="true"
+      fi
+      request_timeout="$AI_FALLBACK_REQUEST_TIMEOUT_SEC"; connect_timeout="$AI_FALLBACK_CONNECT_TIMEOUT_SEC"
+      # #368: the fallback used to get exactly ONE attempt (drift from the
+      # primary loop); AI_FALLBACK_RETRIES (default 2) runs it through the same
+      # retry budget.
+      retries="$AI_FALLBACK_RETRIES"; retry_delay="$AI_PRIMARY_RETRY_DELAY_SEC"
+      # #368: clean UTF-8/newline-boundary truncation instead of a bare
+      # `head -c 120000`, which could split a multibyte character.
+      truncate_clean "$corpus_file" review-corpus.fallback.truncated.md 120000
+      corpus_for_request="review-corpus.fallback.truncated.md"
+      ;;
+    smart)
+      label="Smart"
+      base_url="$SMART_BASE_URL"; model="$SMART_MODEL"; api_format="$SMART_API_FORMAT"; api_key="$SMART_API_KEY"
+      stream="$STREAM_BOOL"
+      request_timeout="$AI_REQUEST_TIMEOUT_SEC"; connect_timeout="$AI_CONNECT_TIMEOUT_SEC"
+      retries="$AI_SMART_RETRIES"; retry_delay="$AI_PRIMARY_RETRY_DELAY_SEC"
+      corpus_for_request="$corpus_file"
+      ;;
+    *)
+      echo "call_model_tier: unknown tier '$tier'" >&2
+      return 2
+      ;;
+  esac
+
+  build_model_request \
+    "$api_format" \
+    "$model" \
+    "$SYSTEM_PROMPT" \
+    "$user_message" \
+    "$corpus_for_request" \
+    "$request_out" \
+    "$stream"
+
+  local attempt=1 parse_fails=0 delay="$retry_delay"
+  local parse_fail_cap=2
+  while [ "$attempt" -le "$retries" ]; do
+    echo "${label} model attempt ${attempt}/${retries}: $model @ $base_url ($api_format)"
+    if curl_model "$base_url" "$api_key" "$api_format" "$request_out" "$response_out" "$stream" "$request_timeout" "$connect_timeout"; then
+      if { [[ "$stream" != "true" ]] || reassemble_sse_response "$response_out" "$api_format"; } && \
+        parse_and_validate "$response_out"; then
+        return 0
+      fi
+
+      parse_fails=$((parse_fails + 1))
+      echo "${label} attempt $attempt: response received but parse/validate failed (parse failure ${parse_fails}/${parse_fail_cap})" >&2
+      if [ -s "$response_out" ]; then
+        printf '  response head (first 400 bytes): ' >&2
+        head -c 400 "$response_out" >&2 || true
+        echo >&2
+      fi
+      if [ "$parse_fails" -ge "$parse_fail_cap" ]; then
+        echo "Reached parse-failure cap; not retrying ${tier} further" >&2
+        break
+      fi
+      attempt=$((attempt + 1))
+      sleep "$delay"
+    else
+      # Transport or HTTP error (curl_model already logged the details/body).
+      echo "${label} attempt $attempt failed (connection/HTTP); waiting ${delay}s" >&2
+      attempt=$((attempt + 1))
+      sleep "$delay"
+      delay=$((delay * 2))
+      [ "$delay" -gt 120 ] && delay=120
+    fi
+  done
+  return 1
+}

--- a/scripts/sections/config.sh
+++ b/scripts/sections/config.sh
@@ -22,6 +22,11 @@ AI_FALLBACK_MODEL="${AI_FALLBACK_MODEL:-}"
 AI_FALLBACK_API_KEY="${AI_FALLBACK_API_KEY:-}"
 AI_PRIMARY_RETRIES="${AI_PRIMARY_RETRIES:-8}"
 AI_PRIMARY_RETRY_DELAY_SEC="${AI_PRIMARY_RETRY_DELAY_SEC:-15}"
+# Per-tier retry budgets for call_model_tier (#368). Fallback/smart share the
+# primary's base retry delay (AI_PRIMARY_RETRY_DELAY_SEC). Fallback defaults to
+# 2 (was a single hard-coded attempt before the pipelines were unified).
+AI_FALLBACK_RETRIES="${AI_FALLBACK_RETRIES:-2}"
+AI_SMART_RETRIES="${AI_SMART_RETRIES:-2}"
 AI_STREAM="${AI_STREAM:-true}"
 AI_FALLBACK_STREAM="${AI_FALLBACK_STREAM:-$AI_STREAM}"
 ALLOWED_SOURCE_HOSTS="${ALLOWED_SOURCE_HOSTS:-github.com,api.github.com,gitlab.com,registry.terraform.io,artifacthub.io}"

--- a/scripts/sections/review.sh
+++ b/scripts/sections/review.sh
@@ -111,55 +111,12 @@ if [[ "$(printf '%s' "$TOOL_MODE" | tr '[:upper:]' '[:lower:]')" == "native_loop
 fi
 
 if [ "$NATIVE_VERDICT_USED" -ne 1 ]; then
-build_model_request \
-  "$AI_API_FORMAT" \
-  "$AI_MODEL" \
-  "$SYSTEM_PROMPT" \
-  "$USER_MESSAGE" \
-  review-corpus.truncated.md \
-  ai-request.primary.json \
-  "$STREAM_BOOL"
-
-PRIMARY_OK=0
-ATTEMPT=1
-PARSE_FAILS=0
-# A response that arrives but won't parse/validate is usually deterministic at
-# temperature 0.1 — re-sending the same corpus rarely helps. Cap those attempts
-# low and fall through to the fallback model instead of burning the full
-# transport-retry budget. Transport/HTTP failures keep the full budget.
-PARSE_FAIL_CAP=2
-RETRY_DELAY="$AI_PRIMARY_RETRY_DELAY_SEC"
-while [ "$ATTEMPT" -le "$AI_PRIMARY_RETRIES" ]; do
-  echo "Primary model attempt ${ATTEMPT}/${AI_PRIMARY_RETRIES}: $AI_MODEL @ $AI_BASE_URL ($AI_API_FORMAT)"
-  if curl_model "$AI_BASE_URL" "$AI_API_KEY" "$AI_API_FORMAT" ai-request.primary.json ai-response.primary.json "$STREAM_BOOL" "$AI_REQUEST_TIMEOUT_SEC" "$AI_CONNECT_TIMEOUT_SEC"; then
-    if { [[ "$STREAM_BOOL" != "true" ]] || reassemble_sse_response ai-response.primary.json "$AI_API_FORMAT"; } && \
-      parse_and_validate ai-response.primary.json; then
-      PRIMARY_OK=1
-      break
-    fi
-
-    PARSE_FAILS=$((PARSE_FAILS + 1))
-    echo "Primary attempt $ATTEMPT: response received but parse/validate failed (parse failure ${PARSE_FAILS}/${PARSE_FAIL_CAP})" >&2
-    if [ -s ai-response.primary.json ]; then
-      printf '  response head (first 400 bytes): ' >&2
-      head -c 400 ai-response.primary.json >&2 || true
-      echo >&2
-    fi
-    if [ "$PARSE_FAILS" -ge "$PARSE_FAIL_CAP" ]; then
-      echo "Reached parse-failure cap; not retrying primary further" >&2
-      break
-    fi
-    ATTEMPT=$((ATTEMPT + 1))
-    sleep "$RETRY_DELAY"
-  else
-    # Transport or HTTP error (curl_model already logged the details/body).
-    echo "Primary attempt $ATTEMPT failed (connection/HTTP); waiting ${RETRY_DELAY}s" >&2
-    ATTEMPT=$((ATTEMPT + 1))
-    sleep "$RETRY_DELAY"
-    RETRY_DELAY=$((RETRY_DELAY * 2))
-    [ "$RETRY_DELAY" -gt 120 ] && RETRY_DELAY=120
+  # Standard corpus review on the primary tier. call_model_tier owns the retry
+  # loop, streaming and truncation shared by all three tiers (#368).
+  PRIMARY_OK=0
+  if call_model_tier primary "$USER_MESSAGE" review-corpus.truncated.md ai-request.primary.json ai-response.primary.json; then
+    PRIMARY_OK=1
   fi
-done
 fi  # NATIVE_VERDICT_USED guard
 
 # On total model failure, either fail the step (default, preserves prior
@@ -228,25 +185,9 @@ else
 
   if [ "$TRY_FALLBACK" -eq 1 ]; then
   echo "Primary model unavailable after retries; trying fallback: $AI_FALLBACK_MODEL @ $AI_FALLBACK_BASE_URL ($AI_FALLBACK_API_FORMAT)" >&2
-  head -c 120000 review-corpus.md > review-corpus.fallback.truncated.md
-
-  FALLBACK_STREAM_BOOL="false"
-  if [[ "$(printf '%s' "$AI_FALLBACK_STREAM" | tr '[:upper:]' '[:lower:]')" == "true" ]]; then
-    FALLBACK_STREAM_BOOL="true"
-  fi
-
-  build_model_request \
-    "$AI_FALLBACK_API_FORMAT" \
-    "$AI_FALLBACK_MODEL" \
-    "$SYSTEM_PROMPT" \
-    "$USER_MESSAGE" \
-    review-corpus.fallback.truncated.md \
-    ai-request.fallback.json \
-    "$FALLBACK_STREAM_BOOL"
-
-  if curl_model "$AI_FALLBACK_BASE_URL" "$AI_FALLBACK_API_KEY" "$AI_FALLBACK_API_FORMAT" ai-request.fallback.json ai-response.fallback.json "$FALLBACK_STREAM_BOOL" "$AI_FALLBACK_REQUEST_TIMEOUT_SEC" "$AI_FALLBACK_CONNECT_TIMEOUT_SEC" && \
-    { [[ "$FALLBACK_STREAM_BOOL" != "true" ]] || reassemble_sse_response ai-response.fallback.json "$AI_FALLBACK_API_FORMAT"; } && \
-    parse_and_validate ai-response.fallback.json; then
+  # call_model_tier truncates review-corpus.md into review-corpus.fallback.truncated.md
+  # with the clean UTF-8 helper (not head -c) and honours AI_FALLBACK_RETRIES (#368).
+  if call_model_tier fallback "$USER_MESSAGE" review-corpus.md ai-request.fallback.json ai-response.fallback.json; then
     ANALYSIS_ENGINE="$(annotate_analysis_engine "$AI_FALLBACK_MODEL@$AI_FALLBACK_BASE_URL ($AI_FALLBACK_API_FORMAT)" fallback)"
     echo "Fallback model succeeded" >&2
   else
@@ -307,27 +248,10 @@ print('yes ' + ','.join(reasons) if escalate else 'no')
   escalated_user="$USER_MESSAGE
 This is an ESCALATED review: a preliminary review was judged insufficient (${ESCALATION_REASONS}). Review thoroughly and address every required check explicitly."
 
-  build_model_request \
-    "$SMART_API_FORMAT" \
-    "$SMART_MODEL" \
-    "$SYSTEM_PROMPT" \
-    "$escalated_user" \
-    review-corpus.truncated.md \
-    ai-request.smart.json \
-    "$STREAM_BOOL"
-
-  local attempt smart_ok=0
-  for attempt in 1 2; do
-    echo "Smart model attempt ${attempt}/2: $SMART_MODEL @ $SMART_BASE_URL ($SMART_API_FORMAT)"
-    if curl_model "$SMART_BASE_URL" "$SMART_API_KEY" "$SMART_API_FORMAT" ai-request.smart.json ai-response.smart.json "$STREAM_BOOL" "$AI_REQUEST_TIMEOUT_SEC" "$AI_CONNECT_TIMEOUT_SEC"; then
-      if { [[ "$STREAM_BOOL" != "true" ]] || reassemble_sse_response ai-response.smart.json "$SMART_API_FORMAT"; } && \
-        parse_and_validate ai-response.smart.json; then
-        smart_ok=1
-        break
-      fi
-    fi
-    sleep "$AI_PRIMARY_RETRY_DELAY_SEC"
-  done
+  local smart_ok=0
+  if call_model_tier smart "$escalated_user" review-corpus.truncated.md ai-request.smart.json ai-response.smart.json; then
+    smart_ok=1
+  fi
 
   if [[ "$smart_ok" -eq 1 ]]; then
     REVIEW_ROUTE="escalated"

--- a/tests/test_classification_steering.sh
+++ b/tests/test_classification_steering.sh
@@ -95,8 +95,11 @@ check "at most 12 check bullets" "$(printf '%s\n' "$MSG" | grep -c '^- check ')"
 
 echo ""
 echo "=== Test: wiring in the review section module and system prompt ==="
-check "primary request uses the steered message" \
-  "$(grep -c '"\$USER_MESSAGE" \\' "$ROOT_DIR/scripts/sections/review.sh")" "2"
+# The steered USER_MESSAGE reaches the model on both the primary and fallback
+# tiers (the smart tier sends escalated_user, which embeds it). The inline
+# build_model_request calls became call_model_tier call sites in #368.
+check "primary/fallback requests use the steered message" \
+  "$(grep -c 'call_model_tier \(primary\|fallback\) "\$USER_MESSAGE"' "$ROOT_DIR/scripts/sections/review.sh")" "2"
 PROMPT="$(cat "$ROOT_DIR/scripts/default_system_prompt.txt")"
 check_contains "system prompt references the PR Classification section" \
   "$PROMPT" "# PR Classification"

--- a/tests/test_model_call.sh
+++ b/tests/test_model_call.sh
@@ -254,5 +254,97 @@ check "anthropic keeps max_tokens" "$(jq 'has("max_tokens")' "$REQ")" "true"
 check "anthropic ignores response_format" "$(jq 'has("response_format")' "$REQ")" "false"
 
 echo ""
+echo "=== call_model_tier: unified per-tier pipeline (#368) ==="
+# call_model_tier lives in model_call.sh but calls parse_and_validate /
+# reassemble_sse_response / truncate_clean, which are defined in
+# scripts/sections/config.sh. Stub the first two (behaviour is controlled via
+# MOCK_PARSE_RC); extract the REAL truncate_clean so the fallback truncation is
+# exercised faithfully (this is drift bug #368: fallback must not head -c).
+parse_and_validate() { return "${MOCK_PARSE_RC:-0}"; }
+reassemble_sse_response() { return 0; }
+python3 - "$ROOT_DIR/scripts/sections/config.sh" "$TMPDIR/truncate_clean.sh" <<'PY'
+import re, sys
+src = open(sys.argv[1]).read()
+m = re.search(r"^truncate_clean\(\) \{\n(.*?)\n\}", src, re.S | re.M)
+if not m:
+    sys.exit("could not extract truncate_clean")
+open(sys.argv[2], "w").write("truncate_clean() {\n%s\n}\n" % m.group(1))
+PY
+# shellcheck source=/dev/null
+source "$TMPDIR/truncate_clean.sh"
+
+# Baseline profile env; each test overrides MOCK_CURL_MODE / MOCK_PARSE_RC (and
+# occasionally a retry knob) inside its own command-substitution subshell so the
+# assignments never leak between tests.
+export SYSTEM_PROMPT="sys" STREAM_BOOL="false"
+export AI_BASE_URL="http://primary/v1" AI_MODEL="primary-model" AI_API_FORMAT="openai" AI_API_KEY=""
+export AI_REQUEST_TIMEOUT_SEC="5" AI_CONNECT_TIMEOUT_SEC="2"
+export AI_PRIMARY_RETRIES="8" AI_PRIMARY_RETRY_DELAY_SEC="0"
+export AI_SMART_RETRIES="2"
+export SMART_BASE_URL="http://smart/v1" SMART_MODEL="smart-model" SMART_API_FORMAT="openai" SMART_API_KEY=""
+export AI_FALLBACK_BASE_URL="http://fb/v1" AI_FALLBACK_MODEL="fb-model" AI_FALLBACK_API_FORMAT="openai" AI_FALLBACK_API_KEY=""
+export AI_FALLBACK_STREAM="false" AI_FALLBACK_REQUEST_TIMEOUT_SEC="5" AI_FALLBACK_CONNECT_TIMEOUT_SEC="2"
+export AI_FALLBACK_RETRIES="2"
+
+CT_CORPUS="$TMPDIR/ct_corpus.md"; printf '# corpus\nbody\n' > "$CT_CORPUS"
+
+echo ""
+echo "=== Test: primary tier resolves the AI_* profile, succeeds on attempt 1 ==="
+rc=0
+LOG="$(PATH="$TMPDIR/bin:$PATH" MOCK_CURL_MODE=ok MOCK_PARSE_RC=0 \
+  call_model_tier primary "usr" "$CT_CORPUS" "$TMPDIR/req.p.json" "$TMPDIR/resp.p.json" 2>&1)" || rc=$?
+check "primary returns 0 on success" "$rc" "0"
+check "primary attempt names the AI_* profile" \
+  "$(printf '%s' "$LOG" | grep -c 'Primary model attempt 1/8: primary-model @ http://primary/v1 (openai)')" "1"
+
+echo ""
+echo "=== Test: smart tier resolves the SMART_* profile and its retry budget ==="
+rc=0
+LOG="$(PATH="$TMPDIR/bin:$PATH" MOCK_CURL_MODE=ok MOCK_PARSE_RC=0 \
+  call_model_tier smart "usr" "$CT_CORPUS" "$TMPDIR/req.s.json" "$TMPDIR/resp.s.json" 2>&1)" || rc=$?
+check "smart returns 0 on success" "$rc" "0"
+check "smart attempt names the SMART_* profile and /2 budget" \
+  "$(printf '%s' "$LOG" | grep -c 'Smart model attempt 1/2: smart-model @ http://smart/v1 (openai)')" "1"
+
+echo ""
+echo "=== Test: transport failures keep the full retry budget ==="
+rc=0
+LOG="$(PATH="$TMPDIR/bin:$PATH" MOCK_CURL_MODE=transport AI_PRIMARY_RETRIES=3 \
+  call_model_tier primary "usr" "$CT_CORPUS" "$TMPDIR/req.x.json" "$TMPDIR/resp.x.json" 2>&1)" || rc=$?
+check "primary returns non-zero after exhaustion" "$([ "$rc" -ne 0 ] && echo yes || echo no)" "yes"
+check "primary made exactly 3 attempts on transport errors" \
+  "$(printf '%s' "$LOG" | grep -c 'Primary model attempt')" "3"
+
+echo ""
+echo "=== Test: parse failures are capped at 2 attempts despite a large budget ==="
+rc=0
+LOG="$(PATH="$TMPDIR/bin:$PATH" MOCK_CURL_MODE=ok MOCK_PARSE_RC=1 AI_PRIMARY_RETRIES=8 \
+  call_model_tier primary "usr" "$CT_CORPUS" "$TMPDIR/req.pf.json" "$TMPDIR/resp.pf.json" 2>&1)" || rc=$?
+check "primary returns non-zero when the response never validates" \
+  "$([ "$rc" -ne 0 ] && echo yes || echo no)" "yes"
+check "primary stopped at the parse-failure cap (2 attempts, not 8)" \
+  "$(printf '%s' "$LOG" | grep -c 'Primary model attempt')" "2"
+check "parse-failure cap is logged" \
+  "$(printf '%s' "$LOG" | grep -c 'Reached parse-failure cap')" "1"
+
+echo ""
+echo "=== Test: fallback tier truncates the corpus cleanly (no mid-multibyte split) ==="
+FBDIR="$TMPDIR/fb"; mkdir -p "$FBDIR"
+# A 3-byte char (☃ = e2 98 83) straddling the 120000-byte cap: a bare
+# `head -c 120000` would keep a partial byte sequence (invalid UTF-8);
+# truncate_clean must decode-and-drop it. The trailing newline sits past the
+# cap so no line-boundary cut masks the multibyte handling.
+{ head -c 119999 /dev/zero | tr '\0' 'a'; printf '\xe2\x98\x83\n'; } > "$FBDIR/review-corpus.md"
+(
+  cd "$FBDIR"
+  PATH="$TMPDIR/bin:$PATH" MOCK_CURL_MODE=ok MOCK_PARSE_RC=0 \
+    call_model_tier fallback "usr" review-corpus.md ai-request.fallback.json ai-response.fallback.json >/dev/null 2>&1
+) || true
+check "fallback wrote review-corpus.fallback.truncated.md" \
+  "$([ -s "$FBDIR/review-corpus.fallback.truncated.md" ] && echo yes || echo no)" "yes"
+check "fallback truncated corpus is valid UTF-8 (truncate_clean, not head -c)" \
+  "$(python3 -c 'open("'"$FBDIR"'/review-corpus.fallback.truncated.md",encoding="utf-8").read(); print("ok")')" "ok"
+
+echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="
 [ "$FAIL" -eq 0 ]

--- a/tests/test_verdict_contract.sh
+++ b/tests/test_verdict_contract.sh
@@ -39,9 +39,12 @@ echo ""
 echo "=== review.sh routes Path A vs the native (Path B) verdict ==="
 check_contains "native verdict short-circuits the standard call" "$REVIEW" "native_loop_verdict_produced // false"
 check_contains "standard review call is guarded by NATIVE_VERDICT_USED" "$REVIEW" 'if [ "$NATIVE_VERDICT_USED" -ne 1 ]; then'
-check_contains "Path A builds the request via build_model_request" "$REVIEW" "build_model_request \\"
-check_contains "Path A sends the reviewer SYSTEM_PROMPT" "$REVIEW" '"$SYSTEM_PROMPT" \'
-check_contains "Path A sends the corpus file" "$REVIEW" "review-corpus.truncated.md \\"
+# build_model_request + SYSTEM_PROMPT moved into call_model_tier (model_call.sh)
+# when the three tier pipelines were unified (#368); the primary call site names
+# the corpus file as the tier argument.
+check_contains "Path A builds the request via build_model_request" "$MODEL_CALL" "build_model_request \\"
+check_contains "Path A sends the reviewer SYSTEM_PROMPT" "$MODEL_CALL" '"$SYSTEM_PROMPT" \'
+check_contains "Path A sends the corpus file" "$REVIEW" "call_model_tier primary \"\$USER_MESSAGE\" review-corpus.truncated.md"
 
 echo ""
 echo "=== Path A response_format is off|json_object|json_schema (shared modes) ==="


### PR DESCRIPTION
Closes #368.

## Summary
- One `call_model_tier <tier> …` in `model_call.sh` replaces the three copy-pasted pipelines in `review.sh` (primary retry loop, fallback one-shot, smart escalation loop). It resolves the tier profile (endpoint/model/format/key/stream/timeouts/retries) in one place and runs the shared loop: build → curl → SSE reassembly → parse/validate, with the primary's retry semantics (parse-fail cap 2, exponential backoff capped at 120s).
- Fixes the two drift bugs: the fallback corpus is now truncated via `truncate_clean` (UTF-8/newline-safe) instead of a bare `head -c 120000`, and the fallback gets a real retry budget (`AI_FALLBACK_RETRIES`, default 2, env-only — no new action inputs) instead of exactly one attempt.
- Routing-off primary-success runs stay byte-identical (same request payload, log format, engine string, step outputs). Escalation gating, `PRIMARY_OK` semantics, native-verdict short-circuit, and the `ai-output.primary.json` save/restore are untouched.
- Folding `curl_model` into `pr_reviewer/transport.py` is an explicit non-goal (deferred to 2.x follow-up).

## Verification
- Full pytest (1189) + all `tests/test_*.sh` green.
- New `test_model_call.sh` coverage: per-tier profile resolution, transport-failure budget exhaustion, parse-fail cap, and a fallback truncation case with a multibyte char straddling the 120000-byte cap (validates as UTF-8).
- Two pinned-string tests retargeted: `test_verdict_contract.sh` (build_model_request/SYSTEM_PROMPT pins moved to model_call.sh) and `test_classification_steering.sh` (steered-message pin now counts the call_model_tier call sites).