### PR TITLE
perf(context): parallelize advisory phases, fan out enrichment API calls, collapse repo-impact scans

### DIFF
--- a/pr_reviewer/linked_sources.py
+++ b/pr_reviewer/linked_sources.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import json
 import re
 import sys
+import threading
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from urllib.parse import urlparse
@@ -103,20 +104,80 @@ def render_linked_sources(
             for fut in as_completed(futures):
                 fetched[futures[fut]] = fut.result()
 
+    # Thread-safe memo for every `gh api` result. Each gh_api_call is its own
+    # subprocess (~0.2s spawn + RTT); on link-heavy Renovate PRs, issuing the
+    # Phase 2-4 calls one-at-a-time blows the wall-clock budget and remaining
+    # sources get silently dropped. The prewarm below fans the INDEPENDENT
+    # calls out concurrently into this cache; the render loop is then served
+    # from it, so parallelism changes only WHEN a call runs, never the
+    # deterministic source-ordered output. The lock also makes the per-repo
+    # releases cache (#366) safe against the prewarm threads racing it.
+    api_lock = threading.Lock()
+    api_cache: dict[str, dict | list | None] = {}
+
+    def cached_gh_api(endpoint: str) -> dict | list | None:
+        with api_lock:
+            if endpoint in api_cache:
+                return api_cache[endpoint]
+        data = gh_api_call(endpoint, gh_token)  # network outside the lock
+        with api_lock:
+            return api_cache.setdefault(endpoint, data)
+
+    def get_releases(owner: str, repo: str) -> list | None:
+        # One releases fetch per unique repo (#366), shared between the per-URL
+        # "Recent Releases" rendering (Phase 2) and the releases enrichment
+        # (Phase 3); dedup + thread-safety come from cached_gh_api.
+        data = cached_gh_api(f"repos/{owner}/{repo}/releases?per_page=30")
+        return data if isinstance(data, list) else None
+
+    # Prewarm: enumerate the independent Phase 2-4 endpoints in source order and
+    # fetch them concurrently. Budget is consulted ONLY on the main thread (here
+    # at the submission boundary and in the render loop), so BudgetTracker needs
+    # no lock. Branch-dependent calls (tags-on-no-match, ghcr compare fallback)
+    # are left for the render loop to fetch on demand — they are rare and their
+    # cache miss simply falls through to a live call.
+    prewarm_endpoints: list[str] = []
+    _seen_prewarm: set[str] = set()
+    _gh_repo_keys: set[str] = set()
+
+    def _queue(endpoint: str) -> None:
+        if endpoint not in _seen_prewarm:
+            _seen_prewarm.add(endpoint)
+            prewarm_endpoints.append(endpoint)
+
+    for url in urls[:25]:
+        normalized = normalize_url(url)
+        cls = classify_url(normalized)
+        if cls and cls["type"] == "github_release":
+            _queue(f"repos/{cls['owner']}/{cls['repo']}/releases/tags/{cls['tag']}")
+            _queue(f"repos/{cls['owner']}/{cls['repo']}/releases?per_page=30")
+        elif cls and cls["type"] == "github_compare":
+            _queue(f"repos/{cls['owner']}/{cls['repo']}/compare/{cls['compare_spec']}")
+        gh_match = re.match(r"https?://github\.com/([^/]+)/([^/?#]+)", normalized)
+        if gh_match:
+            _gh_repo_keys.add(f"{gh_match.group(1)}/{gh_match.group(2)}")
+            _queue(f"repos/{gh_match.group(1)}/{gh_match.group(2)}/releases?per_page=30")
+
+    if target_version:
+        for img_repo in ghcr_images:
+            if img_repo in _gh_repo_keys:
+                continue
+            owner = img_repo.split("/")[0]
+            repo = img_repo.rsplit("/", 1)[-1]
+            if not owner or not repo or owner == img_repo:
+                continue
+            for tag_prefix in (f"v{target_version}", target_version):
+                _queue(f"repos/{owner}/{repo}/releases/tags/{tag_prefix}")
+
+    if prewarm_endpoints and budget.ok():
+        with ThreadPoolExecutor(max_workers=min(8, len(prewarm_endpoints))) as pool:
+            futures = [pool.submit(cached_gh_api, e) for e in prewarm_endpoints]
+            for fut in as_completed(futures):
+                fut.result()  # cached_gh_api fails soft; never raises
+
     # Phase 2: render each URL section
     repo_candidates: list[str] = []
     seen_repos: set[str] = set()
-
-    # One releases fetch per unique repo, shared between the per-URL "Recent
-    # Releases" rendering (Phase 2) and the releases enrichment (Phase 3).
-    releases_cache: dict[str, list | None] = {}
-
-    def get_releases(owner: str, repo: str) -> list | None:
-        key = f"{owner}/{repo}"
-        if key not in releases_cache:
-            data = gh_api_call(f"repos/{owner}/{repo}/releases?per_page=30", gh_token)
-            releases_cache[key] = data if isinstance(data, list) else None
-        return releases_cache[key]
 
     # Hosts whose source produced only a skip notice and no enrichment (#372):
     # each such source would otherwise emit a full "## Source N" block of pure
@@ -176,9 +237,8 @@ def render_linked_sources(
             lines.append("")
             lines.append(f"### GitHub Release Metadata: {cls['owner']}/{cls['repo']}@{cls['tag']}")
             if budget.ok():
-                data = gh_api_call(
-                    f"repos/{cls['owner']}/{cls['repo']}/releases/tags/{cls['tag']}",
-                    gh_token,
+                data = cached_gh_api(
+                    f"repos/{cls['owner']}/{cls['repo']}/releases/tags/{cls['tag']}"
                 )
                 if isinstance(data, dict):
                     filtered = _pick(data, ("tag_name", "name", "published_at", "html_url", "body"))
@@ -205,9 +265,8 @@ def render_linked_sources(
             lines.append("")
             lines.append(f"### GitHub Compare Metadata: {cls['owner']}/{cls['repo']}@{cls['compare_spec']}")
             if budget.ok():
-                data = gh_api_call(
-                    f"repos/{cls['owner']}/{cls['repo']}/compare/{cls['compare_spec']}",
-                    gh_token,
+                data = cached_gh_api(
+                    f"repos/{cls['owner']}/{cls['repo']}/compare/{cls['compare_spec']}"
                 )
                 if isinstance(data, dict):
                     filtered = {
@@ -337,7 +396,7 @@ def render_linked_sources(
                     else:
                         lines.append(f"(No release tags matched target version {target_version} in {repo_key})")
                         if budget.ok():
-                            tags = gh_api_call(f"repos/{owner}/{repo}/tags?per_page=50", gh_token)
+                            tags = cached_gh_api(f"repos/{owner}/{repo}/tags?per_page=50")
                             if isinstance(tags, list):
                                 tag_list = [_pick(t, ("name", "commit")) for t in tags]
                                 lines.append("#### Recent Tags")
@@ -371,7 +430,7 @@ def render_linked_sources(
                 for tag_prefix in (f"v{target_version}", target_version):
                     if not budget.ok():
                         break
-                    data = gh_api_call(f"repos/{owner}/{repo}/releases/tags/{tag_prefix}", gh_token)
+                    data = cached_gh_api(f"repos/{owner}/{repo}/releases/tags/{tag_prefix}")
                     if isinstance(data, dict):
                         lines.append(f"#### Matched via ghcr.io path: {owner}/{repo}@{tag_prefix}")
                         filtered = _pick(data, ("tag_name", "name", "published_at", "html_url", "body"))
@@ -391,7 +450,7 @@ def render_linked_sources(
             # Compare SHA fallback
             if not found_release and compare_shas and budget.ok():
                 cmp_old, cmp_new = compare_shas
-                data = gh_api_call(f"repos/{owner}/{repo}/compare/{cmp_old}...{cmp_new}", gh_token)
+                data = cached_gh_api(f"repos/{owner}/{repo}/compare/{cmp_old}...{cmp_new}")
                 if isinstance(data, dict) and data.get("status"):
                     lines.append(f"#### Commit compare {cmp_old}...{cmp_new} (no release published for this version)")
                     filtered = {

--- a/scripts/sections/classification.sh
+++ b/scripts/sections/classification.sh
@@ -5,10 +5,12 @@
 
 section_timer_start "image-digests"
 log "Gathering image digest provenance..."
-if ! python3 "$SCRIPT_DIR/image_digest_analysis.py"; then
-  error "Image digest analysis failed"
-  echo "Image digest provenance analysis failed for this run." > image-digest-context.md
-fi
+# Advisory phase parallelized in #371: writes only image-digest-context.md
+# (consumed later at build_review_corpus). Launched in the background here and
+# harvested in corpus.sh; its output is buffered to a per-phase log. Failure
+# handling is deferred to harvest_advisory_phases, preserving the old fallback.
+python3 "$SCRIPT_DIR/image_digest_analysis.py" >image-digest.phase.log 2>&1 &
+IMAGE_DIGEST_PID=$!
 section_timer_end
 
 section_timer_start "repo-impact-history"
@@ -23,33 +25,77 @@ log "Gathering repository impact and history..."
   | sort -u > terms.all.txt || true
 head -n 14 terms.all.txt > terms.txt || true
 
-: > repo-impact.md
-: > repo-history.md
+# Read the (already deduped + capped) terms into an ordered array so the
+# combined scan and the assembled output share one fixed term order.
+impact_terms=()
+while IFS= read -r term; do
+  [ -n "$term" ] && impact_terms+=("$term")
+done < terms.txt
 
-if [ -s terms.txt ]; then
-  while IFS= read -r term; do
-    [ -z "$term" ] && continue
+if [ "${#impact_terms[@]}" -gt 0 ]; then
+  # #371: collapse the former per-term scans (up to 14 × git grep + 14 × git log
+  # = 28 sequential passes) into ONE combined worktree grep plus concurrent
+  # history scans. Terms come from `grep -Eo '[a-z0-9._/-]{...}'`, so the only
+  # ERE metacharacter they can contain is '.'; escaping it lets us combine them
+  # into a single alternation that matches each term literally (and keeps one
+  # term from corrupting the pattern). Output stays per-term attributable and
+  # deterministic: attribution and assembly always follow impact_terms order.
+  alt=""
+  hist_pids=()
+  for ti in "${!impact_terms[@]}"; do
+    esc="$(printf '%s' "${impact_terms[$ti]}" | sed 's/\./\\./g')"
+    if [ -z "$alt" ]; then alt="$esc"; else alt="$alt|$esc"; fi
 
+    # Launch each bounded history scan concurrently; assembled in term order
+    # below, so completion order never affects the deterministic output.
     {
-      echo "## Term: $term"
-      echo
-      echo "### git grep hits"
-      echo '```text'
-      git grep -n -- "$term" -- . 2>/dev/null | head -n 60 || true
-      echo '```'
-      echo
-    } >> repo-impact.md
-
-    {
-      echo "## Term: $term"
+      echo "## Term: ${impact_terms[$ti]}"
       echo
       echo "### git log context"
       echo '```text'
-      git log --oneline --decorate --grep="$term" -n 10 || true
+      git log --oneline --decorate --grep="${impact_terms[$ti]}" -n 10 2>/dev/null || true
       echo '```'
       echo
-    } >> repo-history.md
-  done < terms.txt
+    } > "repo-history.part.$ti" &
+    hist_pids+=("$!")
+  done
+
+  # ONE combined worktree scan instead of one `git grep` per term. -I skips
+  # binary files: their `Binary file X matches` lines carry no line number, so
+  # they cannot be content-attributed to a term in the combined model — and
+  # they are pure noise in a text corpus. Every remaining line is `path:lineno:
+  # content`, which re-attributes byte-exactly to the old per-term matching.
+  git grep -nEI -e "$alt" -- . 2>/dev/null > repo-impact.combined.txt || true
+
+  # Re-attribute the single combined result to each term in fixed order,
+  # matching only the file CONTENT (after the `path:lineno:` prefix that
+  # `git grep -n` prints) so attribution matches the old per-term grep, and
+  # keeping the 60-hit cap per term.
+  : > repo-impact.md
+  for ti in "${!impact_terms[@]}"; do
+    esc="$(printf '%s' "${impact_terms[$ti]}" | sed 's/\./\\./g')"
+    {
+      echo "## Term: ${impact_terms[$ti]}"
+      echo
+      echo "### git grep hits"
+      echo '```text'
+      awk -v pat="$esc" '{ c=$0; sub(/^[^:]*:[0-9]+:/, "", c); if (c ~ pat) print }' \
+        repo-impact.combined.txt | head -n 60 || true
+      echo '```'
+      echo
+    } >> repo-impact.md
+  done
+
+  # Reap the concurrent history scans, then assemble in fixed term order.
+  for pid in "${hist_pids[@]}"; do
+    wait "$pid" || true
+  done
+  : > repo-history.md
+  for ti in "${!impact_terms[@]}"; do
+    cat "repo-history.part.$ti" >> repo-history.md
+    rm -f "repo-history.part.$ti"
+  done
+  rm -f repo-impact.combined.txt
 
   # These grep/log dumps are the lowest-value corpus sections (and on small PRs
   # can dwarf the actual change), so keep their caps tight.
@@ -70,15 +116,13 @@ if gate_feature_for_forks "$EVIDENCE_ENABLE_FOR_FORKS" \
     evidence-providers.json '{"configured": false, "has_blocker": false, "providers": [], "skipped": true, "skip_reason": "fork-pr"}'; then
   : # fork PR without evidence_enable_for_forks — skip artifacts already written
 else
-  if ! python3 "$SCRIPT_DIR/run_evidence_providers.py"; then
-    error "Evidence provider execution failed"
-    cat > evidence-providers.md <<'EOF'
-Evidence providers failed to run in this review.
-EOF
-    cat > evidence-providers.json <<'EOF'
-{"configured": false, "has_blocker": false, "providers": [], "error": "execution failed"}
-EOF
-  fi
+  # Advisory phase parallelized in #371: writes only evidence-providers.{md,json}
+  # (consumed later at build_review_corpus). Launched in the background here and
+  # harvested in corpus.sh. EVIDENCE_PID being set is the signal to harvest;
+  # failure handling is deferred to harvest_advisory_phases, preserving the old
+  # fallback exactly.
+  python3 "$SCRIPT_DIR/run_evidence_providers.py" >evidence-providers.phase.log 2>&1 &
+  EVIDENCE_PID=$!
 fi
 section_timer_end
 

--- a/scripts/sections/common.sh
+++ b/scripts/sections/common.sh
@@ -36,6 +36,53 @@ section_timer_end() {
   log "PERF: section=$name elapsed=${elapsed}s"
 }
 
+# Harvest the advisory background phases (#371) launched in enrichment.sh and
+# classification.sh: linked-source enrichment, image-digest provenance, and the
+# evidence providers. None consumes another's output — each only writes files
+# read together later at build_review_corpus — so they run concurrently and are
+# reaped here before the corpus is built. We PARALLELIZE THE FETCH, never the
+# render order, so the corpus stays byte-deterministic. Each phase is advisory:
+# `wait` returns the job's exit status (guarded with `|| status=$?` so a nonzero
+# code cannot trip `set -e`), and on failure we apply the SAME fallback the old
+# sequential guards did. Per-phase logs are echoed in a FIXED order so
+# interleaved output stays attributable.
+harvest_advisory_phases() {
+  local status
+
+  status=0
+  wait "$ENRICHMENT_PID" || status=$?
+  cat enrichment.phase.log 2>/dev/null || true
+  if [ "$status" -ne 0 ]; then
+    log "WARNING: enrichment.py failed, producing empty linked-sources.md"
+    : > linked-sources.md
+  fi
+
+  status=0
+  wait "$IMAGE_DIGEST_PID" || status=$?
+  cat image-digest.phase.log 2>/dev/null || true
+  if [ "$status" -ne 0 ]; then
+    error "Image digest analysis failed"
+    echo "Image digest provenance analysis failed for this run." > image-digest-context.md
+  fi
+
+  # EVIDENCE_PID is unset when the evidence phase was skipped by the fork gate
+  # (its skip artifacts are already written) — nothing to harvest in that case.
+  if [ -n "${EVIDENCE_PID:-}" ]; then
+    status=0
+    wait "$EVIDENCE_PID" || status=$?
+    cat evidence-providers.phase.log 2>/dev/null || true
+    if [ "$status" -ne 0 ]; then
+      error "Evidence provider execution failed"
+      cat > evidence-providers.md <<'EOF'
+Evidence providers failed to run in this review.
+EOF
+      cat > evidence-providers.json <<'EOF'
+{"configured": false, "has_blocker": false, "providers": [], "error": "execution failed"}
+EOF
+    fi
+  fi
+}
+
 # Fork gate for a per-feature capability that runs untrusted PR content (#370).
 # When the PR is a fork and the feature is not explicitly enabled for forks,
 # write the paired skip artifacts (.md + .json) and return 0 (gated → skip).

--- a/scripts/sections/corpus.sh
+++ b/scripts/sections/corpus.sh
@@ -3,6 +3,12 @@
 # Verbatim in-order slice of the former monolith (#307); relies on globals/helpers
 # set up by the orchestrator. Not executable on its own.
 
+# Reap the advisory background phases (enrichment, image digests, evidence)
+# before their output files are read into the corpus below (#371).
+section_timer_start "advisory-phases"
+harvest_advisory_phases
+section_timer_end
+
 log "Building review corpus..."
 : > standards-context.md
 if [ -f "$STANDARDS_FILE" ]; then

--- a/scripts/sections/enrichment.sh
+++ b/scripts/sections/enrichment.sh
@@ -6,9 +6,13 @@
 section_timer_start "enrichment"
 log "Gathering linked sources..."
 
-python3 "$SCRIPT_DIR/run_enrichment.py" || {
-  log "WARNING: enrichment.py failed, producing empty linked-sources.md"
-  : > linked-sources.md
-}
+# Advisory phase parallelized in #371: this only writes the linked-sources.md
+# file (consumed later at build_review_corpus), so we launch it in the
+# background here and harvest it in corpus.sh before the corpus is built. Its
+# stdout/stderr is buffered to a per-phase log so interleaved output with the
+# other background phases stays attributable. Failure handling is deferred to
+# harvest_advisory_phases, preserving the old fallback exactly.
+python3 "$SCRIPT_DIR/run_enrichment.py" >enrichment.phase.log 2>&1 &
+ENRICHMENT_PID=$!
 
 section_timer_end

--- a/tests/test_advisory_parallel.sh
+++ b/tests/test_advisory_parallel.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Wiring assertions for #371: the independent advisory context-gathering phases
+# (linked-source enrichment, image-digest provenance, evidence providers) must
+# run as background jobs and be harvested before the corpus is built, and the
+# classification repo-impact scan must use a single combined git grep instead of
+# one pass per term. These are static grep checks (same idiom as
+# test_review_routing.sh) — the sections rely on orchestrator globals and are
+# not executable standalone.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+PASS=0
+FAIL=0
+# shellcheck source=_lib/assert.sh
+source "$SCRIPT_DIR/_lib/assert.sh"
+
+ENRICHMENT="$(cat "$ROOT_DIR/scripts/sections/enrichment.sh")"
+CLASSIFICATION="$(cat "$ROOT_DIR/scripts/sections/classification.sh")"
+COMMON="$(cat "$ROOT_DIR/scripts/sections/common.sh")"
+CORPUS="$(cat "$ROOT_DIR/scripts/sections/corpus.sh")"
+
+echo "=== Test: advisory phases launched in the background ==="
+check_contains "enrichment.py runs as a background job" \
+  "$ENRICHMENT" 'run_enrichment.py" >enrichment.phase.log 2>&1 &'
+check_contains "enrichment records its pid" "$ENRICHMENT" 'ENRICHMENT_PID=$!'
+check_contains "image digest runs as a background job" \
+  "$CLASSIFICATION" 'image_digest_analysis.py" >image-digest.phase.log 2>&1 &'
+check_contains "image digest records its pid" "$CLASSIFICATION" 'IMAGE_DIGEST_PID=$!'
+check_contains "evidence providers run as a background job" \
+  "$CLASSIFICATION" 'run_evidence_providers.py" >evidence-providers.phase.log 2>&1 &'
+check_contains "evidence records its pid" "$CLASSIFICATION" 'EVIDENCE_PID=$!'
+
+echo ""
+echo "=== Test: advisory phases harvested before the corpus is built ==="
+check_contains "harvest waits on the enrichment pid" "$COMMON" 'wait "$ENRICHMENT_PID"'
+check_contains "harvest waits on the image-digest pid" "$COMMON" 'wait "$IMAGE_DIGEST_PID"'
+check_contains "harvest waits on the evidence pid" "$COMMON" 'wait "$EVIDENCE_PID"'
+# Advisory failure must degrade, never abort: waits are guarded with || status=$?.
+check_contains "harvest guards wait status against set -e" "$COMMON" '|| status=$?'
+# Fallbacks preserved verbatim from the old sequential guards.
+check_contains "harvest keeps the enrichment fallback" \
+  "$COMMON" 'WARNING: enrichment.py failed, producing empty linked-sources.md'
+check_contains "harvest keeps the image-digest fallback" \
+  "$COMMON" 'Image digest provenance analysis failed for this run.'
+check_contains "harvest keeps the evidence fallback" \
+  "$COMMON" 'Evidence providers failed to run in this review.'
+check "corpus harvests exactly once before building" \
+  "$(grep -c 'harvest_advisory_phases' "$ROOT_DIR/scripts/sections/corpus.sh")" "1"
+
+echo ""
+echo "=== Test: repo-impact uses ONE combined git grep, not per-term ==="
+# Exactly one git grep command (the combined -E alternation); the old
+# per-term `git grep -n -- "$term"` must be gone.
+check "single combined git grep command in classification" \
+  "$(grep -c 'git grep -nEI -e' "$ROOT_DIR/scripts/sections/classification.sh")" "1"
+check_contains "combined grep uses an escaped -E alternation" \
+  "$CLASSIFICATION" 'git grep -nEI -e "$alt"'
+check_not_contains "no per-term git grep remains" \
+  "$CLASSIFICATION" 'git grep -n -- "$term"'
+check_contains "history scans run concurrently and are reaped" \
+  "$CLASSIFICATION" 'wait "$pid"'
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ]

--- a/tests/test_enrichment.py
+++ b/tests/test_enrichment.py
@@ -689,3 +689,104 @@ class TestReleasesCache:
         # share one cached fetch of the releases list.
         releases_calls = [e for e in endpoints if "releases?per_page=30" in e]
         assert len(releases_calls) == 1
+
+
+class TestLinkedSourcesFanout:
+    """Phase 2-4 gh_api_call fan-out (#371): concurrent fetch, ordered render."""
+
+    URLS = [
+        "https://github.com/o1/r1/releases/tag/v1.0",
+        "https://github.com/o2/r2/releases/tag/v2.0",
+    ]
+
+    @staticmethod
+    def _data_for(endpoint: str):
+        """Pure function of endpoint so results are stable across timings."""
+        if endpoint.endswith("/releases/tags/v1.0"):
+            return {"tag_name": "v1.0", "name": "R1"}
+        if endpoint.endswith("/releases/tags/v2.0"):
+            return {"tag_name": "v2.0", "name": "R2"}
+        if "o1/r1/releases?per_page=30" in endpoint:
+            return [{"tag_name": "v1.0", "name": "R1"}]
+        if "o2/r2/releases?per_page=30" in endpoint:
+            return [{"tag_name": "v2.0", "name": "R2"}]
+        return None
+
+    def _render(self, monkeypatch, gh_stub):
+        from pr_reviewer import linked_sources
+
+        monkeypatch.setattr(linked_sources, "gh_api_call", gh_stub)
+        monkeypatch.setattr(linked_sources, "fetch_url", lambda url, timeout=25: None)
+        budget = linked_sources.BudgetTracker(max_seconds=60)
+        return linked_sources.render_linked_sources(
+            self.URLS, {"github.com"}, None, "", [], None, budget,
+        )
+
+    def test_output_identical_when_calls_complete_out_of_order(self, monkeypatch):
+        """Determinism: parallelism changes only WHEN a call runs, not output."""
+        import time
+
+        def instant(endpoint, token=None):
+            return self._data_for(endpoint)
+
+        def out_of_order(endpoint, token=None):
+            # Make the first source's calls finish LAST so completion order is
+            # the reverse of source order; the render must be unaffected.
+            if "o1/r1" in endpoint:
+                time.sleep(0.05)
+            return self._data_for(endpoint)
+
+        instant_md = self._render(monkeypatch, instant)
+        shuffled_md = self._render(monkeypatch, out_of_order)
+
+        assert shuffled_md == instant_md
+        # Sections stay in source order regardless of fetch completion order.
+        assert shuffled_md.index("## Source 1") < shuffled_md.index("## Source 2")
+        assert "R1" in shuffled_md and "R2" in shuffled_md
+
+    def test_fan_out_dedups_endpoints(self, monkeypatch):
+        """Each unique endpoint is fetched once even across prewarm + render."""
+        calls = []
+
+        def counting(endpoint, token=None):
+            calls.append(endpoint)
+            return self._data_for(endpoint)
+
+        self._render(monkeypatch, counting)
+
+        # Two repos × {release-tag lookup, releases list} = 4 unique calls, each once.
+        assert sorted(calls) == sorted(set(calls))
+        assert len(calls) == 4
+
+    def test_budget_drop_stops_remaining_sources(self, monkeypatch):
+        """Once the budget is exhausted the render drops remaining sources,
+        and the budget is only ever consulted on the main thread."""
+        from pr_reviewer import linked_sources
+
+        class FakeBudget:
+            def __init__(self, allowed):
+                self.allowed = allowed
+                self.calls = 0
+
+            def ok(self):
+                self.calls += 1
+                return self.calls <= self.allowed
+
+        # Non-allowlisted, non-github URLs: no fetch, no fan-out, exactly one
+        # budget.ok() per source at the loop top — so the drop point is precise.
+        urls = [f"https://skip{i}.example.com/x" for i in range(4)]
+        monkeypatch.setattr(linked_sources, "fetch_url", lambda url, timeout=25: None)
+
+        budget = FakeBudget(allowed=2)
+        md = linked_sources.render_linked_sources(
+            urls, set(), None, "", [], None, budget,
+        )
+
+        # Skip-only sections are collapsed into the trailing summary (#372), so
+        # the budget drop shows up as which HOSTS made it into that line: the
+        # two rendered before exhaustion, and none after.
+        assert "skip0.example.com" in md
+        assert "skip1.example.com" in md
+        assert "skip2.example.com" not in md
+        assert "skip3.example.com" not in md
+        assert "(2 sources skipped" in md


### PR DESCRIPTION
Closes #371. Fetching is parallelized; render order stays byte-deterministic throughout.

## Summary
- **Advisory phases overlap on the wall clock**: linked-source enrichment, image-digest provenance, and evidence providers now launch as background jobs and are reaped by `harvest_advisory_phases` (common.sh) at the top of corpus.sh, before anything reads their files. `wait` statuses are guarded against `set -e`; each phase's original failure fallback (same files, same log lines) is applied at harvest. Per-phase output is buffered to log files and echoed in fixed order. All three consumers run post-harvest (verified: nothing between launch and harvest reads the outputs).
- **Enrichment `gh` fan-out**: a thread-safe endpoint-keyed memo (subsuming the #366 per-repo releases cache) is prewarmed concurrently (≤8 workers) with the independent Phase 2–4 endpoints in source order; the render loop is unchanged except calls go through the cache. `gh_api_call` is fail-soft, so prewarm can never raise. Budget is consulted only on the main thread. Fewer sources get silently budget-dropped on link-heavy Renovate PRs — the completeness half of the issue.
- **Repo-impact scans**: up to 28 sequential `git grep`/`git log` passes collapse into one combined `git grep -nEI` alternation (re-attributed per term via awk on content only, 60-hit cap preserved) plus concurrent per-term history scans assembled in fixed term order. Terms now match literally (`.` escaped) and binary-file matches are dropped — both strict noise reductions, called out in comments.

## Verification
- Full pytest (1192) + all `tests/test_*.sh` green.
- New tests: byte-identical output under out-of-order completion, endpoint dedup, main-thread budget behavior (pytest); background-launch/harvest wiring (shell).
- Live-executed `harvest_advisory_phases` under `set -euo pipefail` with failing jobs: fallbacks written, gate-skipped evidence branch handled, no `set -e` trips.

## Notes
- Touches the same `linked_sources.py` render loop as #395 — whichever merges second will need a small rebase; ping me and I'll resolve it.