### PR TITLE
Fix over-escalation: trust concise fast reviews + route on filename/linked signals only

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,10 +247,10 @@ Only three inputs are required: `github_token`, `ai_base_url`, and `ai_model`. E
 | `ai_smart_base_url` | Base URL for the smart model; defaults to `ai_base_url` | No | `""` |
 | `ai_smart_api_format` | API format for the smart model; defaults to `ai_api_format` | No | `""` |
 | `ai_smart_api_key` | API key for the smart model; defaults to `ai_api_key` | No | `""` |
-| `escalate_on_risk_flags` | Comma-separated `pr_kind`/`risk_flag` names that route to the smart model in `auto` mode | No | security/priority/auth/route/file-serving/path/secret/db list |
+| `escalate_on_risk_flags` | Comma-separated `pr_kind`/`risk_flag` names that route to the smart model in `auto` mode. Matched against `route_signals` (linked-issue flags + file-based signals backed by an actual changed filename), so a PR whose diff merely mentions a pattern does not route | No | security/priority/auth/route/file-serving/path/secret/db list |
 | `escalate_on_incomplete_required_checks` | Escalate primary-route reviews with unaddressed required checks to the smart model (`auto` mode) | No | `true` |
 | `escalate_on_fast_request_changes` | Escalate primary-route reviews whose verdict is `request_changes` (`auto` mode) | No | `true` |
-| `escalate_on_fast_low_confidence` | Escalate low-confidence primary-route reviews (short relative to the diff, or populated Unknowns section) (`auto` mode) | No | `true` |
+| `escalate_on_fast_low_confidence` | Escalate low-confidence primary-route reviews: a stub review (below ~80 chars) or a populated Unknowns section. A concise confident review is not escalated, regardless of diff size (`auto` mode) | No | `true` |
 | `escalate_on_tool_or_evidence_blockers` | Escalate when evidence blockers exist or every executed tool request failed (`auto` mode) | No | `true` |
 | `escalate_on_tool_planning_failure` | Escalate when the tool-harness planning call failed (`auto` mode). Off by default: a planning failure degrades the review to no-tools, it does not signal risk | No | `false` |
 | `escalate_on_dirty_baseline` | Escalate incremental reviews whose baseline review found issues (`auto` mode) | No | `true` |
@@ -864,7 +864,7 @@ With `review_routing_mode: auto`, the deterministic classification decides which
 
 Routing rules:
 
-- A PR whose `pr_kind` **or** any `risk_flags` entry matches `escalate_on_risk_flags` routes to the **smart** model; everything else routes to the **fast** model.
+- A PR whose `route_signals` match `escalate_on_risk_flags` routes to the **smart** model; everything else routes to the **fast** model. `route_signals` are the PR's `pr_kind` plus its `risk_flags`, **excluding content-only pattern matches** — a flag or kind that fired only because the diff text mentioned a pattern (e.g. `os.path`, `token`) does not route unless an actual changed *filename* (or a linked issue) backs it. This keeps benign PRs on the fast model.
 - The fast config defaults to the primary `ai_*` inputs; the smart config's endpoint/format/key default to those same primary inputs, but the smart **model** is opt-in via `ai_smart_model` and is never the fallback model. If a risky PR is detected but no smart model is configured, the review stays on the fast model (logged, never fails).
 - `off` (the default) preserves the existing primary/fallback behavior exactly (`review_route` output reports `legacy`).
 - The retry and failure-fallback machinery is unchanged — routing only picks which model it talks to.
@@ -876,7 +876,7 @@ In `auto` mode, a fast review can also be **escalated after the fact**: the acti
 
 - `escalate_on_fast_request_changes` — the fast model wants changes; let the smart model confirm or overturn before a human is summoned.
 - `escalate_on_incomplete_required_checks` — the fast review never discussed one of the classifier's required checks.
-- `escalate_on_fast_low_confidence` — the review is very short or carries a populated "Unknowns or Needs Verification" section. The length floor is diff-aware: a diff of ≤10 changed lines only needs an 80-char review (a correct review of a one-line renovate bump is short — escalating it wastes a smart-model run on exactly the PRs least worth one), while larger diffs keep the 200-char floor.
+- `escalate_on_fast_low_confidence` — the review is a **stub** (below ~80 chars, e.g. "LGTM.") or carries a populated "Unknowns or Needs Verification" section. A concise but real review is trusted **regardless of diff size**: the review length is no longer scaled with the diff. Escalating short-but-correct reviews of small/medium PRs was the main source of over-escalation (a confident review that simply wasn't verbose kept triggering a redundant smart-model run). Genuinely under-reviewed risky PRs are still caught by `request_changes`, the Unknowns section, blockers, and risk-flag routing.
 - `escalate_on_tool_or_evidence_blockers` — evidence providers reported a blocker, or tool requests executed and every one failed.
 - `escalate_on_tool_planning_failure` (default **false**) — the harness planning call failed before any tools ran. Off by default because a planning failure means the review proceeded with less evidence (the same situation as `tool_mode: off`), not that the PR is risky; the failure is still recorded in the step summary.
 - `escalate_on_dirty_baseline` — this is an incremental review and the previous review found issues; judging whether the delta resolves them is run on the smart model.

--- a/action.yml
+++ b/action.yml
@@ -175,7 +175,9 @@ inputs:
   escalate_on_risk_flags:
     description: >-
       Comma-separated pr_kind / risk_flag names that route directly to the smart model
-      when review_routing_mode=auto.
+      when review_routing_mode=auto. Matched against route_signals — linked-issue flags
+      and file-based signals backed by an actual changed filename — so a benign PR whose
+      diff merely mentions a pattern (e.g. os.path) does not route.
     required: false
     default: "linked_security_issue,linked_priority_p0,linked_priority_p1,auth_changes,public_route_changes,file_serving_changes,path_handling_changes,secret_handling_changes,db_or_migration_changes"
   escalate_on_incomplete_required_checks:
@@ -187,7 +189,7 @@ inputs:
     required: false
     default: "true"
   escalate_on_fast_low_confidence:
-    description: Escalate when the primary-route review is low-confidence (very short, or carries a populated Unknowns/Needs Verification section). review_routing_mode=auto only.
+    description: Escalate when the primary-route review is low-confidence — a stub review (below ~80 chars) or one carrying a populated Unknowns/Needs Verification section. A concise, confident review is NOT escalated regardless of diff size. review_routing_mode=auto only.
     required: false
     default: "true"
   escalate_on_tool_or_evidence_blockers:

--- a/pr_reviewer/classifier.py
+++ b/pr_reviewer/classifier.py
@@ -176,6 +176,11 @@ class PRClassification:
     pr_kind: str = "app_code"
     risk_flags: list[str] = field(default_factory=list)
     risk_flags_with_files: dict[str, list[str]] = field(default_factory=dict)
+    # Subset of (pr_kind + risk_flags) safe to drive smart-model routing:
+    # linked-issue flags and any file-based signal backed by an actual changed
+    # filename. Content-only pattern matches (e.g. a diff that merely mentions
+    # os.path or `token`) are excluded — they over-route benign PRs (#159 fix).
+    route_signals: list[str] = field(default_factory=list)
     changed_files_summary: list[str] = field(default_factory=list)
     linked_issue_labels: list[str] = field(default_factory=list)
     must_check: list[str] = field(default_factory=list)
@@ -437,6 +442,48 @@ FLAG_CHECKS: dict[str, list[str]] = {
 }
 
 
+# Kinds whose classification can come from diff CONTENT, not just filenames
+# (they use _filename_or_diff_matches). A content-only match of these must not
+# drive smart-model routing — only an actual changed filename should.
+_CONTENT_CAPABLE_KINDS: dict[str, list[re.Pattern]] = {
+    "file_serving_changes": FILE_SERVING_PATTERNS,
+    "path_handling_changes": PATH_HANDLING_PATTERNS,
+}
+
+
+def _route_signals(
+    pr_kind: str,
+    filenames: list[str],
+    risk_flags: list[str],
+    risk_flags_with_files: dict[str, list[str]],
+) -> list[str]:
+    """Signals eligible to route a PR straight to the smart model.
+
+    Excludes content-only matches (which over-route benign PRs): keeps
+    linked-issue flags, file-based flags backed by a real changed filename, and
+    the pr_kind unless it is a content-only file_serving/path_handling match.
+    """
+    signals: list[str] = []
+    # Linked-issue flags are explicit human signals — always route.
+    for flag in risk_flags:
+        if flag.startswith("linked_") and flag not in signals:
+            signals.append(flag)
+    # File-based risk flags only when an actual changed filename matched;
+    # content-only matches carry an empty file list.
+    for flag, files in risk_flags_with_files.items():
+        if files and flag not in signals:
+            signals.append(flag)
+    # pr_kind routes unless it is the catch-all default or a content-only
+    # file_serving/path_handling kind.
+    if pr_kind and pr_kind != DEFAULT_PR_KIND and pr_kind not in signals:
+        patterns = _CONTENT_CAPABLE_KINDS.get(pr_kind)
+        if patterns is None:
+            signals.append(pr_kind)
+        elif any(any(p.search(fn) for p in patterns) for fn in filenames):
+            signals.append(pr_kind)
+    return signals
+
+
 def _build_must_check(pr_kind: str, risk_flags: list[str]) -> list[str]:
     """Generate explicit must-check items based on classification.
 
@@ -489,6 +536,9 @@ def classify_pr(
     # Build changed files summary (just filenames, truncated)
     file_names = [f.get("filename", "") for f in pr_files]
     changed_files_summary = file_names[:max_summary_files]
+    route_signals = _route_signals(
+        pr_kind, file_names, risk_flags, risk_flags_with_files
+    )
 
     # Collect linked issue labels
     linked_issue_labels: list[str] = []
@@ -502,6 +552,7 @@ def classify_pr(
         pr_kind=pr_kind,
         risk_flags=risk_flags,
         risk_flags_with_files=risk_flags_with_files,
+        route_signals=route_signals,
         changed_files_summary=changed_files_summary,
         linked_issue_labels=linked_issue_labels,
         must_check=must_check,

--- a/pr_reviewer/escalation.py
+++ b/pr_reviewer/escalation.py
@@ -15,16 +15,15 @@ from pathlib import Path
 
 from pr_reviewer.completeness import validate_review
 
-# Reviews shorter than this are treated as low-confidence regardless of
-# content — a fast model that produced two sentences did not review anything.
-LOW_CONFIDENCE_MIN_CHARS = 200
-
-# For trivial diffs the expected review is legitimately short: a correct
-# review of a one-line renovate bump should not escalate as "low confidence"
-# (#215). At or below this many changed lines, the minimum drops to a floor
-# that still catches bare "LGTM"-style non-reviews.
-TRIVIAL_DIFF_MAX_CHANGED_LINES = 10
-TRIVIAL_DIFF_MIN_CHARS = 80
+# A review shorter than this is a stub / non-review (e.g. "LGTM.") and is
+# treated as low-confidence regardless of verdict or diff size. Above it, a
+# concise-but-real review is trusted: escalating a confident short approval
+# just to have the smart model re-approve wasted a run on exactly the PRs
+# least in need of one (#215 and the over-escalation follow-up). The review's
+# length is NOT otherwise scaled with diff size — the real "needs a closer
+# look" signals are request_changes, a populated Unknowns section, blockers,
+# and risk-flag routing, each of which has its own trigger.
+STUB_REVIEW_MIN_CHARS = 80
 
 # Header of the section the default prompt asks for "when evidence is
 # incomplete" — its presence with real content is the model saying it is
@@ -44,36 +43,38 @@ def _load(path: str) -> dict:
         return {}
 
 
-def count_changed_lines(diff_path: str = "pr.diff") -> int | None:
-    """Count added/removed lines in a unified diff, or None when unreadable.
+def _has_populated_unknowns(text: str) -> bool:
+    """Whether the review has a non-empty Unknowns/Needs-Verification section.
 
-    None (rather than 0) on a missing/unreadable diff so callers fail closed
-    to the standard low-confidence threshold instead of the trivial one.
+    That section, when the model actually fills it in, is the model stating it
+    could not verify something — the genuine "escalate me" signal.
     """
-    try:
-        text = Path(diff_path).read_text(encoding="utf-8", errors="replace")
-    except OSError:
-        return None
-    count = 0
-    for line in text.splitlines():
-        if line.startswith("+") and not line.startswith("+++"):
-            count += 1
-        elif line.startswith("-") and not line.startswith("---"):
-            count += 1
-    return count
+    match = _UNKNOWNS_HEADER_RE.search(text)
+    if not match:
+        return False
+    rest = text[match.end():].strip()
+    section = re.split(r"(?m)^#{1,6}\s", rest, maxsplit=1)[0].strip()
+    return bool(section) and not _EMPTY_SECTION_RE.match(section) and len(section) > 40
 
 
-def is_low_confidence(review_markdown: str, min_chars: int = LOW_CONFIDENCE_MIN_CHARS) -> bool:
+def is_low_confidence(review_markdown: str, min_chars: int = STUB_REVIEW_MIN_CHARS) -> bool:
+    """Whether the fast review warrants the smart model on confidence grounds.
+
+    Two signals only:
+      * a populated Unknowns / Needs-Verification section — the model saying it
+        is unsure; and
+      * a stub review shorter than *min_chars* — too short to have reviewed
+        anything (e.g. "LGTM.").
+
+    A confident, concise review above the stub floor is NOT low-confidence,
+    whatever the diff size. This deliberately drops the former length scaling
+    with diff size, which escalated most small/medium PRs whose correct reviews
+    were simply brief.
+    """
     text = (review_markdown or "").strip()
     if len(text) < min_chars:
         return True
-    match = _UNKNOWNS_HEADER_RE.search(text)
-    if match:
-        rest = text[match.end():].strip()
-        section = re.split(r"(?m)^#{1,6}\s", rest, maxsplit=1)[0].strip()
-        if section and not _EMPTY_SECTION_RE.match(section) and len(section) > 40:
-            return True
-    return False
+    return _has_populated_unknowns(text)
 
 
 def _has_blocker_signals(evidence: dict, harness: dict) -> bool:
@@ -108,7 +109,6 @@ def should_escalate(
     classification_path: str = "classification.json",
     evidence_path: str = "evidence-providers.json",
     tool_harness_path: str = "tool-harness.json",
-    diff_path: str = "pr.diff",
 ) -> tuple[bool, list[str]]:
     """Return (escalate, reasons) for the fast review in *output_path*.
 
@@ -130,17 +130,12 @@ def should_escalate(
         if must_check and not validate_review(must_check, review)["validated"]:
             reasons.append("incomplete_required_checks")
 
-    if on_low_confidence:
-        # The minimum review length scales with the diff: a 2-line image bump
-        # warrants a short review, and escalating it wastes a smart-model run
-        # on exactly the PRs least worth one (#215). Unknowns-section
-        # detection inside is_low_confidence applies at any length.
-        min_chars = LOW_CONFIDENCE_MIN_CHARS
-        changed = count_changed_lines(diff_path)
-        if changed is not None and changed <= TRIVIAL_DIFF_MAX_CHANGED_LINES:
-            min_chars = TRIVIAL_DIFF_MIN_CHARS
-        if is_low_confidence(review, min_chars):
-            reasons.append("fast_low_confidence")
+    if on_low_confidence and is_low_confidence(review):
+        # Only a stub review or a populated Unknowns section counts — a concise
+        # confident review is trusted regardless of diff size (see
+        # is_low_confidence). This is the primary fix for over-escalation:
+        # previously any review under ~200 chars on an >10-line diff escalated.
+        reasons.append("fast_low_confidence")
 
     harness = _load(tool_harness_path)
     if on_blockers and _has_blocker_signals(_load(evidence_path), harness):

--- a/scripts/sections/classification.sh
+++ b/scripts/sections/classification.sh
@@ -142,8 +142,9 @@ section_timer_end
 
 # ── Model routing (#159) ─────────────────────────────────────────────
 # With review_routing_mode=auto, most PRs run on the PRIMARY model and PRs whose
-# pr_kind or risk_flags match ESCALATE_ON_RISK_FLAGS go to the smart model when
-# one is configured. Routing only rebinds which model the existing retry/fallback
+# route_signals (pr_kind + risk_flags, excluding content-only pattern matches)
+# match ESCALATE_ON_RISK_FLAGS go to the smart model when one is configured.
+# Routing only rebinds which model the existing retry/fallback
 # machinery talks to — that machinery is unchanged. (The primary model is fully
 # capable; the route is not a "fast/dumb" lane, and it gets the full tool budget.)
 resolve_review_route() {
@@ -153,12 +154,17 @@ resolve_review_route() {
     return
   fi
 
-  local kind flags candidates matched="" raw_flag flag
-  kind="$(jq -r '.pr_kind // ""' classification.json 2>/dev/null || echo "")"
-  flags="$(jq -r '(.risk_flags // []) | join(",")' classification.json 2>/dev/null || echo "")"
-  # Match against the union of pr_kind and risk_flags: the default escalation
-  # list mixes kind names (auth_changes, ...) and flag names (linked_*).
-  candidates=",${kind},${flags},"
+  local signals candidates matched="" raw_flag flag
+  # Match against route_signals: pr_kind + risk_flags, but EXCLUDING content-only
+  # pattern matches — a diff that merely mentions os.path or `token` no longer
+  # routes a benign PR to the smart model. Falls back to the old pr_kind+flags
+  # union for classification JSON written before route_signals existed.
+  signals="$(jq -r '
+      (if has("route_signals") then (.route_signals // [])
+       else ((.risk_flags // []) + [(.pr_kind // "")]) end)
+      | map(select(. != "")) | join(",")
+    ' classification.json 2>/dev/null || echo "")"
+  candidates=",${signals},"
 
   IFS=',' read -ra _esc_flags <<< "$ESCALATE_ON_RISK_FLAGS"
   for raw_flag in "${_esc_flags[@]}"; do

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -529,3 +529,31 @@ class TestEdgeCases:
         result = classify_pr([], linked_issues=issues)
         # Labels should be deduplicated
         assert result.linked_issue_labels.count("priority/p1") <= 1
+
+
+class TestRouteSignals:
+    """route_signals drives smart routing and must exclude content-only matches
+    (the over-escalation fix)."""
+
+    def test_content_only_path_match_not_in_route_signals(self):
+        # A diff that merely mentions os.path in an ordinary file must not route.
+        result = classify_pr([_make_file("app.py")], diff_text="x = os.path.join(a, b)")
+        assert "path_handling_changes" in result.risk_flags       # still flagged for checks
+        assert result.route_signals == []                          # but not for routing
+
+    def test_real_auth_filename_in_route_signals(self):
+        result = classify_pr([_make_file("auth.py")], diff_text="")
+        assert "auth_changes" in result.route_signals
+
+    def test_filename_backed_file_serving_in_route_signals(self):
+        result = classify_pr([_make_file("static/handler.py")], diff_text="")
+        assert "file_serving_changes" in result.route_signals
+
+    def test_linked_security_issue_in_route_signals(self):
+        issues = [{"labels": [{"name": "security"}]}]
+        result = classify_pr([_make_file("app.py")], diff_text="", linked_issues=issues)
+        assert result.route_signals == ["linked_security_issue"]
+
+    def test_app_code_default_not_in_route_signals(self):
+        result = classify_pr([_make_file("app.py")], diff_text="print('hi')")
+        assert result.route_signals == []

--- a/tests/test_escalation.py
+++ b/tests/test_escalation.py
@@ -13,7 +13,6 @@ sys.path.insert(0, str(_REPO_ROOT))
 import pytest
 
 from pr_reviewer.escalation import (
-    count_changed_lines,
     is_low_confidence,
     should_escalate,
 )
@@ -213,22 +212,10 @@ SHORT_BUMP_REVIEW = (
 )
 
 
-class TestCountChangedLines:
-    def test_counts_only_change_lines(self, tmp_path):
-        path = tmp_path / "pr.diff"
-        path.write_text(TRIVIAL_DIFF)
-        assert count_changed_lines(str(path)) == 2
+class TestConciseReviewLowConfidence:
+    """A concise, confident review is trusted at any diff size; only stubs and
+    populated Unknowns sections escalate (over-escalation fix)."""
 
-    def test_missing_diff_is_none(self, tmp_path):
-        assert count_changed_lines(str(tmp_path / "absent.diff")) is None
-
-    def test_empty_diff_is_zero(self, tmp_path):
-        path = tmp_path / "pr.diff"
-        path.write_text("")
-        assert count_changed_lines(str(path)) == 0
-
-
-class TestTrivialDiffLowConfidence:
     def test_short_review_of_trivial_diff_does_not_escalate(self, tmp_path, monkeypatch):
         monkeypatch.chdir(tmp_path)
         _write_fast_output(tmp_path, review=SHORT_BUMP_REVIEW)
@@ -237,7 +224,7 @@ class TestTrivialDiffLowConfidence:
         escalate, reasons = should_escalate()
         assert escalate is False and reasons == []
 
-    def test_bare_lgtm_still_escalates_on_trivial_diff(self, tmp_path, monkeypatch):
+    def test_bare_lgtm_still_escalates(self, tmp_path, monkeypatch):
         monkeypatch.chdir(tmp_path)
         _write_fast_output(tmp_path, review="LGTM.")
         _write_classification(tmp_path)
@@ -245,21 +232,36 @@ class TestTrivialDiffLowConfidence:
         escalate, reasons = should_escalate()
         assert "fast_low_confidence" in reasons
 
-    def test_short_review_of_large_diff_still_escalates(self, tmp_path, monkeypatch):
+    def test_concise_approve_of_large_diff_does_not_escalate(self, tmp_path, monkeypatch):
+        # The core over-escalation fix: a confident, concise approval no longer
+        # escalates just because the diff is large. (Was: escalated on length.)
         monkeypatch.chdir(tmp_path)
         _write_fast_output(tmp_path, review=SHORT_BUMP_REVIEW)
         _write_classification(tmp_path)
         big = TRIVIAL_DIFF + "".join(f"+added line {i}\n" for i in range(40))
         (tmp_path / "pr.diff").write_text(big)
         escalate, reasons = should_escalate()
+        assert "fast_low_confidence" not in reasons
+
+    def test_stub_review_of_large_diff_still_escalates(self, tmp_path, monkeypatch):
+        # A genuine non-review (below the stub floor) still escalates regardless
+        # of diff size.
+        monkeypatch.chdir(tmp_path)
+        _write_fast_output(tmp_path, review="LGTM.")
+        _write_classification(tmp_path)
+        big = TRIVIAL_DIFF + "".join(f"+added line {i}\n" for i in range(40))
+        (tmp_path / "pr.diff").write_text(big)
+        escalate, reasons = should_escalate()
         assert "fast_low_confidence" in reasons
 
-    def test_missing_diff_fails_closed_to_standard_threshold(self, tmp_path, monkeypatch):
+    def test_missing_diff_concise_approve_does_not_escalate(self, tmp_path, monkeypatch):
+        # No diff file present: a concise confident approve is still trusted
+        # (the stub floor no longer depends on diff size).
         monkeypatch.chdir(tmp_path)
         _write_fast_output(tmp_path, review=SHORT_BUMP_REVIEW)
         _write_classification(tmp_path)
         escalate, reasons = should_escalate()
-        assert "fast_low_confidence" in reasons
+        assert "fast_low_confidence" not in reasons
 
     def test_unknowns_section_escalates_even_on_trivial_diff(self, tmp_path, monkeypatch):
         monkeypatch.chdir(tmp_path)

--- a/tests/test_review_routing.sh
+++ b/tests/test_review_routing.sh
@@ -76,6 +76,29 @@ check "app_code with path_handling_changes flag routes smart" \
   "$(route_for auto app_code "other_flag,path_handling_changes" 1)" "smart"
 
 echo ""
+echo "=== Test: route_signals excludes content-only matches (over-escalation fix) ==="
+route_for_signals() {
+  # $1 = pr_kind, $2 = risk_flags csv, $3 = route_signals csv, $4 = smart resolved
+  local rf sig
+  rf="$(printf '%s' "$2" | python3 -c 'import json,sys; s=sys.stdin.read().strip(); print(json.dumps(s.split(",") if s else []))')"
+  sig="$(printf '%s' "$3" | python3 -c 'import json,sys; s=sys.stdin.read().strip(); print(json.dumps(s.split(",") if s else []))')"
+  printf '{"pr_kind": "%s", "risk_flags": %s, "route_signals": %s}' "$1" "$rf" "$sig" > classification.json
+  REVIEW_ROUTING_MODE=auto SMART_MODEL_RESOLVED="$4" ESCALATE_ON_RISK_FLAGS="$DEFAULT_FLAGS" \
+    resolve_review_route
+  echo "$REVIEW_ROUTE"
+}
+# risk_flags carries path_handling_changes (content-only), but route_signals is
+# empty → must stay primary even though the flag is in the escalation list.
+check "content-only risk flag does NOT route smart" \
+  "$(route_for_signals path_handling_changes "path_handling_changes" "" 1)" "primary"
+# A filename-backed signal in route_signals still routes smart.
+check "filename-backed signal routes smart" \
+  "$(route_for_signals auth_changes "auth_changes" "auth_changes" 1)" "smart"
+# Linked-issue signal routes smart.
+check "linked signal routes smart" \
+  "$(route_for_signals app_code "linked_security_issue" "linked_security_issue" 1)" "smart"
+
+echo ""
 echo "=== Test: risky PR without smart config stays primary ==="
 check "risky PR without smart model stays primary" "$(route_for auto auth_changes "" "")" "primary"
 


### PR DESCRIPTION
## Problem
Fast→smart routing was buying nothing: across recent PRs in dispatch, **26 of 27 reviews reached the smart model** (fast-only = 1). This is constant across repos on the action, so it's fixed upstream — no per-repo config changes.

Example: [dispatch#583](https://github.com/misospace/dispatch/pull/583), a 16-line docs change (`SECURITY-ACCEPTED-RISKS.md`, +15/−1), escalated on `fast_low_confidence`; the smart model then just approved.

## Two independent causes

**1. `fast_low_confidence` fired on normal-length reviews.** `is_low_confidence` treated any review under 200 chars as low-confidence, relaxing to 80 only for diffs ≤10 changed lines. Fast models write correct, concise reviews that routinely land under 200 chars → constant escalation (17 of 27 sampled PRs, including a +3/−0 PR). Fix: low-confidence now means **only** a stub review (below ~80 chars, e.g. "LGTM.") or a **populated Unknowns/Needs-Verification section**. A concise, confident review is trusted regardless of diff size. Removed the diff-scaled length floor and the now-unused `count_changed_lines`.

**2. `escalate_on_risk_flags` matched content-only pattern hits.** Risk flags/kinds are detected from diff **content** as well as filenames, so any PR whose diff mentioned `os.path`, `token`, `base64.decode`, etc. routed straight to smart (9 of 27). Fix: routing now matches a new `classification.route_signals` field — linked-issue flags + file-based signals backed by an **actual changed filename** + non-content-only kinds. `resolve_review_route` falls back to the old `pr_kind`+`risk_flags` union for markers written before this field existed.

The genuine "needs a closer look" signals are unchanged: `request_changes`, Unknowns section, tool/evidence blockers, dirty baseline, and filename/linked-issue risk routing. So `auth.py`, `secrets.yaml`, DB migrations, and linked security issues still route to smart; a diff that merely *mentions* a path helper does not.

## Tests
- Escalation: rewrote the low-confidence cases to the new intent (concise approve on a large diff no longer escalates; a stub still does); Unknowns/request_changes/blocker triggers unchanged.
- Classifier: added `route_signals` tests (content-only match excluded; real filename / linked issue included).
- Routing: added a case asserting a content-only risk flag stays `primary` while filename/linked signals route `smart`.
- Full suite green: 1206 pytest + all 26 bash suites.

## Effect
On the sampled PRs, the docs/config/small-diff PRs that were escalating on length now stay on the fast model; only genuinely risky (by filename/linked issue) or genuinely-incomplete reviews reach smart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)