### PR TITLE
perf(planner): share section piece files with the corpus so verdict dedup drops them

### DIFF
--- a/scripts/run_tool_harness.py
+++ b/scripts/run_tool_harness.py
@@ -156,43 +156,76 @@ def build_planning_context(max_bytes, corpus_path=None):
     and the head of the diff. Falls back to the corpus head when the piece
     files are unavailable (e.g. standalone invocation).
 
+    Shared-piece preference (#398): each high-signal section has a shared piece
+    file written ONCE by build_review_corpus (scripts/sections/corpus.sh) that
+    holds the EXACT bytes the corpus emits for that section. When a shared piece
+    exists and fits WHOLE within the remaining budget, we embed it verbatim
+    (rstripped) — title, fences and all — so the verdict-turn dedup
+    (dedupe_verdict_corpus) can drop the byte-identical corpus copy. Full-fit
+    only: a partial/clipped embed would never match the corpus section verbatim
+    and would defeat the byte-exact dedup, so we fall back to the older
+    self-built excerpt (different title/cap/fence) instead — the excerpt then
+    just fails to dedup and the corpus section is (correctly, conservatively)
+    kept in full. A fixed 2200-byte reserve (the guaranteed 2000-byte diff head
+    + margin) is withheld from every shared-fit check so a large piece can't
+    starve the diff.
+
     Returns (text, truncated).
     """
+    # (planner_title, shared_piece_path, excerpt_source_path, excerpt_cap, fence)
     pieces = [
-        ("PR Classification", "classification.json", 4000, "json"),
-        ("Changed Files", "pr-files.truncated.json", 6000, "json"),
-        ("Version Hints from Diff", "version-hints.truncated.txt", 2500, "text"),
-        ("Repository Standards and Conventions", "standards-context.capped.md", 6000, None),
+        ("PR Classification", "section-pr-classification.md", "classification.json", 4000, "json"),
+        ("Changed Files", "section-pr-files.md", "pr-files.truncated.json", 6000, "json"),
+        ("Version Hints from Diff", "section-version-hints.md", "version-hints.truncated.txt", 2500, "text"),
+        ("Repository Standards and Conventions", "section-standards.md", "standards-context.capped.md", 6000, None),
     ]
 
     sections = []
     any_clipped = False
 
-    def add_section(title, path, cap, fence):
-        nonlocal any_clipped
+    def _read_stripped(path):
         p = Path(path)
         if not p.exists():
-            return
+            return None
         body = p.read_text(encoding="utf-8", errors="replace").strip()
-        if not body:
-            return
+        return body or None
+
+    def _excerpt(title, path, cap, fence):
+        nonlocal any_clipped
+        body = _read_stripped(path)
+        if body is None:
+            return None
         raw = body.encode("utf-8")
         if len(raw) > cap:
             body = raw[:cap].decode("utf-8", errors="ignore") + "\n[truncated]"
             any_clipped = True
         if fence:
-            sections.append(f"# {title}\n```{fence}\n{body}\n```")
-        else:
-            sections.append(f"# {title}\n{body}")
+            return f"# {title}\n```{fence}\n{body}\n```"
+        return f"# {title}\n{body}"
 
-    for title, path, cap, fence in pieces:
-        add_section(title, path, cap, fence)
+    for title, shared_path, excerpt_path, cap, fence in pieces:
+        used = sum(len(s.encode("utf-8")) for s in sections)
+        # Reserve 2200 = the 2000-byte guaranteed diff head + 200 margin.
+        avail = max_bytes - used - 2200
+        section = None
+        shared = _read_stripped(shared_path)
+        # Embed the shared piece verbatim only when the WHOLE thing (plus the
+        # "\n\n" join separator) fits — byte-exact dedup needs every byte.
+        if shared is not None and len(shared.encode("utf-8")) + 2 <= avail:
+            section = shared
+        if section is None:
+            section = _excerpt(title, excerpt_path, cap, fence)
+        if section is not None:
+            sections.append(section)
 
     if sections:
-        # Whatever budget remains goes to the head of the diff.
+        # Whatever budget remains goes to the head of the diff. The diff head is
+        # never a shared piece — a prefix overlap can't be deduped byte-exactly.
         used = sum(len(s.encode("utf-8")) for s in sections)
         diff_cap = max(2000, max_bytes - used - 200)
-        add_section("PR Diff (head)", "pr.diff.truncated", diff_cap, "diff")
+        diff_section = _excerpt("PR Diff (head)", "pr.diff.truncated", diff_cap, "diff")
+        if diff_section is not None:
+            sections.append(diff_section)
         text, clipped = mask_and_truncate("\n\n".join(sections), max_bytes)
         return text, clipped or any_clipped
 
@@ -633,10 +666,11 @@ def run_native_loop(
                 else ""
             )
             if verdict_corpus:
-                # #372: the loop's first user message (corpus_text — the
-                # planning context) already carries several corpus sections
-                # verbatim. Drop only those byte-duplicates so the verdict turn
-                # doesn't re-send ~50KB the model already has. Dedup is
+                # #372/#398: the loop's first user message (corpus_text — the
+                # planning context) embeds several corpus sections verbatim via
+                # the shared piece files (build_planning_context), so their bytes
+                # match exactly. Drop only those byte-duplicates so the verdict
+                # turn doesn't re-send ~50KB the model already has. Dedup is
                 # section-exact and conservative (partial/truncated overlaps are
                 # kept in full), so the #362 contract invariant "the full corpus
                 # reaches the model" still holds — the dropped bytes live in

--- a/scripts/sections/corpus.sh
+++ b/scripts/sections/corpus.sh
@@ -63,15 +63,28 @@ build_review_corpus() {
     echo
 
 
-    echo "# PR Classification"
-    if [ -f classification.json ]; then
-      jq -c '{pr_kind, risk_flags, risk_flags_with_files, changed_files_summary: (.changed_files_summary | .[0:20]), linked_issue_labels, must_check}' classification.json | head -c 8000
-    else
-      echo "(Classification data unavailable for this review)"
-    fi
+    # Shared section pieces (#398): build each section body ONCE into a file so
+    # the planner (build_planning_context) can embed the SAME bytes and the
+    # verdict-turn dedup (dedupe_verdict_corpus) can drop the corpus copy. The
+    # blank separator lives OUTSIDE the piece file, so a piece's rstripped text
+    # equals the section text the dedup matcher sees. review-corpus.md must stay
+    # byte-identical — the `cat piece; echo` below reproduces the former inline
+    # emit exactly (echo header + body, then a blank line).
+    {
+      echo "# PR Classification"
+      if [ -f classification.json ]; then
+        jq -c '{pr_kind, risk_flags, risk_flags_with_files, changed_files_summary: (.changed_files_summary | .[0:20]), linked_issue_labels, must_check}' classification.json | head -c 8000
+      else
+        echo "(Classification data unavailable for this review)"
+      fi
+    } > section-pr-classification.md
+    cat section-pr-classification.md
     echo
 
     if [[ "$corpus_type" == "incremental" ]]; then
+      # Full-scope-only pieces must not linger into an incremental build (#398).
+      # A fresh workspace makes this mostly moot, but be explicit.
+      rm -f section-pr-files.md section-version-hints.md
       local head_sha
       head_sha="$(jq -r '.headRefOid' pr.json 2>/dev/null || echo 'unknown')"
       echo "# Incremental Review Delta"
@@ -110,15 +123,21 @@ print(render_evidence_memory_section(load_evidence_memory()), end='')
       echo "# Linked Issue Context"
       cat linked-issues.md
       echo
-      echo "# PR Files (truncated)"
-      echo '```json'
-      cat pr-files.truncated.json
-      echo '```'
+      {
+        echo "# PR Files (truncated)"
+        echo '```json'
+        cat pr-files.truncated.json
+        echo '```'
+      } > section-pr-files.md
+      cat section-pr-files.md
       echo
-      echo "# Version Hints from Diff"
-      echo '```text'
-      cat version-hints.truncated.txt 2>/dev/null || echo "(none)"
-      echo '```'
+      {
+        echo "# Version Hints from Diff"
+        echo '```text'
+        cat version-hints.truncated.txt 2>/dev/null || echo "(none)"
+        echo '```'
+      } > section-version-hints.md
+      cat section-version-hints.md
       echo
       echo "# PR Diff (truncated)"
       echo '```diff'
@@ -178,10 +197,17 @@ print(render_evidence_memory_section(load_evidence_memory()), end='')
     '```
 …[review corpus truncated to fit the model context budget]'
 
-  # Prepend the (capped) standards section, then append the truncated body
+  # Standards shared piece (#398): built here, after truncate_clean produced the
+  # capped file, so the planner embeds the SAME bytes. Separator (echo) stays
+  # OUTSIDE the piece so its rstripped text matches the corpus section.
   {
     echo "# Repository Standards and Conventions ($STANDARDS_FILE)"
     cat standards-context.capped.md
+  } > section-standards.md
+
+  # Prepend the (capped) standards section, then append the truncated body
+  {
+    cat section-standards.md
     echo
     cat review-corpus.body.truncated.md
   } > review-corpus.md

--- a/tests/test_corpus_shared_pieces.sh
+++ b/tests/test_corpus_shared_pieces.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# #398: build_review_corpus writes shared section piece files so the planner
+# (build_planning_context) can embed the SAME bytes and the verdict-turn dedup
+# drops the corpus copy. The HARD constraint is that review-corpus.md stays
+# byte-identical — the piece files only capture, at their original stream
+# position, the exact bytes the corpus already emitted. This test extracts
+# build_review_corpus + truncate_clean, runs a full-scope build over minimal
+# fixtures, and asserts: (a) each piece's bytes appear verbatim in the corpus,
+# (b) the classification/version-hints pieces render to the pinned exact bytes,
+# (c) each piece's rstripped text is a matchable unit inside the corpus (the
+# "separator lives outside the piece" invariant the dedup relies on).
+
+# Bash >= 4 required (see test_corpus_standards_survival.sh for why).
+if [ -z "${BASH_VERSINFO:-}" ] || [ "${BASH_VERSINFO[0]}" -lt 4 ]; then
+  echo "SKIP: bash >= 4 required (found ${BASH_VERSION:-unknown}); on macOS run with PATH=\"/opt/homebrew/bin:\$PATH\"" >&2
+  exit 0
+fi
+
+for dep in python3 jq; do
+  if ! command -v "$dep" &>/dev/null; then
+    echo "SKIP: $dep is not available — cannot run test_corpus_shared_pieces.sh" >&2
+    exit 0
+  fi
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+PASS=0
+FAIL=0
+# shellcheck source=_lib/assert.sh
+source "$SCRIPT_DIR/_lib/assert.sh"
+
+# Extract build_review_corpus (corpus.sh) and truncate_clean (config.sh) so we
+# can drive the corpus build in isolation — the section modules rely on
+# orchestrator globals and are not sourceable standalone.
+FUNCS="$(mktemp)"
+python3 - "$ROOT_DIR/scripts/sections/corpus.sh" "$ROOT_DIR/scripts/sections/config.sh" "$FUNCS" <<'PY'
+import re, sys
+corpus_src = open(sys.argv[1]).read()
+config_src = open(sys.argv[2]).read()
+out = []
+m = re.search(r"^build_review_corpus\(\) \{\n(.*?)\n\}", corpus_src, re.S | re.M)
+if not m:
+    sys.exit("could not extract build_review_corpus")
+out.append("build_review_corpus() {\n%s\n}\n" % m.group(1))
+m = re.search(r"^truncate_clean\(\) \{\n(.*?)\n\}", config_src, re.S | re.M)
+if not m:
+    sys.exit("could not extract truncate_clean")
+out.append("truncate_clean() {\n%s\n}\n" % m.group(1))
+open(sys.argv[3], "w").write("\n".join(out))
+PY
+
+log() { :; }  # silence log() calls
+# shellcheck source=/dev/null
+source "$FUNCS"
+
+TMP="$(mktemp -d)"
+trap 'rm -f "$FUNCS"; rm -rf "$TMP"' EXIT
+cd "$TMP"
+
+# ── Fixtures (minimal, small enough that nothing truncates) ──────────────
+MAX_CORPUS=220000
+MAX_DIFF=100000
+STANDARDS_FILE="AGENTS.md"
+CI_CHECKS_FILE=""
+
+printf 'manifest body\n' > manifest-context.md
+cat > pr.json <<'EOF'
+{"number":7,"title":"bump","author":{"login":"octo"},"baseRefName":"main","headRefName":"feat","headRefOid":"abc123","changedFiles":1,"additions":2,"deletions":1,"url":"https://example/pr/7","body":"hello"}
+EOF
+cat > classification.json <<'EOF'
+{"pr_kind":"dependency-update","risk_flags":["auth"],"risk_flags_with_files":[],"changed_files_summary":["a.py"],"linked_issue_labels":["bug"],"must_check":["x"]}
+EOF
+printf 'linked issue body\n' > linked-issues.md
+printf '[{"filename":"a.py","status":"modified"}]\n' > pr-files.truncated.json
+printf '+  image: v1.2.3\n' > version-hints.truncated.txt
+printf 'diff --git a/a.py b/a.py\n+added line\n' > pr.diff.truncated
+printf 'harness findings body\n' > tool-harness.md
+printf 'evidence providers body\n' > evidence-providers.md
+printf 'image digest body\n' > image-digest-context.md
+printf 'linked sources body\n' > linked-sources.md
+printf 'repo impact body\n' > repo-impact.truncated.md
+printf 'repo history body\n' > repo-history.truncated.md
+{
+  echo "# Repository Standards and Conventions"
+  echo "Derived from AGENTS.md for this repository."
+  echo
+  echo "Always verify upstream release notes."
+} > standards-context.md
+
+build_review_corpus "full"
+
+# ── (b) Pinned exact bytes for the classification + version-hints pieces ──
+# jq -c preserves the object-literal key order; the blank separator lives
+# OUTSIDE the piece, so the piece ends with the section's own final newline.
+cat > expected-classification.md <<'EOF'
+# PR Classification
+{"pr_kind":"dependency-update","risk_flags":["auth"],"risk_flags_with_files":[],"changed_files_summary":["a.py"],"linked_issue_labels":["bug"],"must_check":["x"]}
+EOF
+cat > expected-version-hints.md <<'EOF'
+# Version Hints from Diff
+```text
++  image: v1.2.3
+```
+EOF
+
+if cmp -s section-pr-classification.md expected-classification.md; then
+  echo "  PASS: classification piece renders to the pinned exact bytes"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: classification piece differs from pinned bytes"
+  diff expected-classification.md section-pr-classification.md || true
+  FAIL=$((FAIL + 1))
+fi
+
+if cmp -s section-version-hints.md expected-version-hints.md; then
+  echo "  PASS: version-hints piece renders to the pinned exact bytes"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: version-hints piece differs from pinned bytes"
+  diff expected-version-hints.md section-version-hints.md || true
+  FAIL=$((FAIL + 1))
+fi
+
+# ── (a) + (c) Each piece's bytes appear verbatim in the corpus, and each
+# piece's rstripped text is a matchable unit inside it (dedup invariant). ──
+PYRC=0
+PYTHONPATH="$ROOT_DIR" python3 - <<'PY' || PYRC=$?
+import sys
+from pathlib import Path
+
+corpus = Path("review-corpus.md").read_text(encoding="utf-8")
+pieces = [
+    "section-pr-classification.md",
+    "section-pr-files.md",
+    "section-version-hints.md",
+    "section-standards.md",
+]
+failures = []
+for name in pieces:
+    piece = Path(name).read_text(encoding="utf-8")
+    # (a) exact bytes present verbatim
+    if piece not in corpus:
+        failures.append(f"{name}: bytes not found verbatim in review-corpus.md")
+    # (c) rstripped piece is a matchable unit (separator outside the piece)
+    if piece.rstrip() not in corpus:
+        failures.append(f"{name}: rstripped text not a substring of the corpus")
+
+# Sanity: the dedup matcher, given a piece as the "planning context", must
+# resolve that section to the placeholder (proves the piece is exactly one
+# level-1 section as the corpus emits it).
+from pr_reviewer.conversation import dedupe_verdict_corpus, VERDICT_DEDUP_NOTICE
+cls_piece = Path("section-pr-classification.md").read_text(encoding="utf-8").rstrip()
+deduped = dedupe_verdict_corpus(corpus, cls_piece)
+if VERDICT_DEDUP_NOTICE not in deduped:
+    failures.append("dedupe did not drop the classification section given its piece")
+
+if failures:
+    print("PYFAIL")
+    for f in failures:
+        print("  - " + f)
+    sys.exit(1)
+print("PYOK")
+PY
+if [ "$PYRC" -eq 0 ]; then
+  echo "  PASS: pieces appear verbatim + rstripped are matchable units + dedup drops them"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: byte-verbatim / dedup checks failed (see above)"
+  FAIL=$((FAIL + 1))
+fi
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ]

--- a/tests/test_tool_planning_context.py
+++ b/tests/test_tool_planning_context.py
@@ -13,6 +13,14 @@ import pytest
 
 from run_tool_harness import build_planning_context
 
+_ROOT = Path(__file__).resolve().parent.parent
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+from pr_reviewer.conversation import (  # noqa: E402
+    VERDICT_DEDUP_NOTICE,
+    dedupe_verdict_corpus,
+)
+
 
 def _write_pieces(tmp_path, diff_lines=20):
     (tmp_path / "classification.json").write_text(
@@ -91,6 +99,87 @@ class TestBuildPlanningContext:
         text, truncated = build_planning_context(50000)
         assert truncated is True
         assert "[truncated]" in text
+
+
+class TestSharedPieceEmbedding:
+    """#398: shared piece files let the planner embed the EXACT corpus section
+    bytes so the verdict-turn dedup (dedupe_verdict_corpus) can drop the copy."""
+
+    # The bytes build_review_corpus writes for the classification section (header
+    # + newline + jq projection), with the blank separator living OUTSIDE the
+    # piece — i.e. exactly what dedupe_verdict_corpus sees after rstrip.
+    CLASSIFICATION_PIECE = (
+        "# PR Classification\n"
+        '{"pr_kind":"dependency-update","risk_flags":[],"must_check":[]}'
+    )
+
+    def test_shared_piece_embedded_verbatim_and_dedups(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "section-pr-classification.md").write_text(
+            self.CLASSIFICATION_PIECE + "\n"
+        )
+        text, _ = build_planning_context(50000)
+        # Embedded verbatim: the corpus title (not the excerpt title) and the
+        # unfenced projection appear exactly as the corpus emitted them.
+        assert self.CLASSIFICATION_PIECE in text
+        # End-to-end: a corpus carrying that section verbatim gets it dropped.
+        corpus = (
+            self.CLASSIFICATION_PIECE + "\n\n"
+            "# PR Diff (truncated)\n```diff\n+kept\n```\n"
+        )
+        deduped = dedupe_verdict_corpus(corpus, text)
+        assert VERDICT_DEDUP_NOTICE in deduped
+        assert "## PR Classification" in deduped
+        # The projection body is gone from the verdict corpus (lives in message 1).
+        assert '"pr_kind":"dependency-update"' not in deduped
+        # A section NOT in the planning context is kept in full.
+        assert "+kept" in deduped
+
+    def test_oversized_shared_piece_falls_back_to_excerpt(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        # Shared piece far larger than the budget → cannot embed whole.
+        big = "x" * 60000
+        (tmp_path / "section-pr-files.md").write_text(
+            "# PR Files (truncated)\n```json\n" + big + "\n```\n"
+        )
+        # Excerpt source (small) is present for the fallback.
+        (tmp_path / "pr-files.truncated.json").write_text(
+            '[{"filename": "a.py", "status": "modified"}]'
+        )
+        text, _ = build_planning_context(50000)
+        # Excerpt used: the OLD title, not the corpus title.
+        assert "# Changed Files" in text
+        assert "# PR Files (truncated)" not in text
+        # Dedup conservatively keeps the corpus section (title/content differ).
+        corpus = "# PR Files (truncated)\n```json\n[{\"filename\": \"a.py\"}]\n```\n"
+        deduped = dedupe_verdict_corpus(corpus, text)
+        assert VERDICT_DEDUP_NOTICE not in deduped
+        assert "# PR Files (truncated)" in deduped
+
+    def test_missing_shared_piece_uses_excerpt(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        # No section-*.md files; only the old excerpt sources exist.
+        (tmp_path / "pr-files.truncated.json").write_text(
+            '[{"filename": "a.py", "status": "modified"}]'
+        )
+        text, _ = build_planning_context(50000)
+        assert "# Changed Files" in text
+        assert "# PR Files (truncated)" not in text
+
+    def test_diff_head_appended_last_after_shared_pieces(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "section-pr-classification.md").write_text(
+            self.CLASSIFICATION_PIECE + "\n"
+        )
+        big_diff = "\n".join(f"+line {i}" for i in range(10000))
+        (tmp_path / "pr.diff.truncated").write_text(
+            "diff --git a/x b/x\n" + big_diff + "\n"
+        )
+        text, truncated = build_planning_context(20000)
+        # Diff head comes last and is clipped to the remaining budget.
+        assert text.index("# PR Classification") < text.index("# PR Diff (head)")
+        assert truncated is True
+        assert len(text.encode("utf-8")) <= 20100
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #398. **Draft until the N=3 live eval against home-ops#7462 passes** (model-input change).

## Summary
- `build_review_corpus` writes four shared piece files (classification, PR files, version hints, standards) containing the exact bytes it already emits for those sections, then assembles the corpus from them. **Corpus output is byte-identical** — verified empirically by extracting old (main) and new `build_review_corpus`, running both over identical fixtures (multibyte content, both scopes), and `cmp`-ing: full and incremental match byte-for-byte.
- `build_planning_context` embeds a shared piece verbatim when the whole piece fits its budget (2200-byte reserve keeps the guaranteed diff head), else falls back to exactly today's excerpts (different titles/caps, so dedup conservatively keeps the corpus copy). The diff head is never shared — prefix overlap isn't byte-dedupable.
- Net effect in native_loop: the #395 dedup now drops classification + version hints + standards from the uncached verdict turn; their bytes move into message 1, which the loop's prompt cache covers across rounds.

## Verification
- 1210 pytest + all `tests/test_*.sh` green.
- New: `test_corpus_shared_pieces.sh` (pins piece bytes exactly, asserts verbatim presence in the corpus, exercises dedup on the real pieces); 4 planner tests (fit→embed+dedup, oversize→excerpt fallback, missing piece→fallback, diff-head cap).
- Pending: N=3/arm live eval on home-ops#7462 (verdicts, findings, tool traces, prompt tokens) — results will be posted here before undrafting.