### PR TITLE
fix: omit Linked Issue Context / Evidence Providers headers when empty

### DIFF
--- a/scripts/run_evidence_providers.py
+++ b/scripts/run_evidence_providers.py
@@ -263,7 +263,14 @@ def write_outputs(summary: dict, markdown: str) -> None:
         json.dumps(summary, indent=2, ensure_ascii=False) + "\n",
         encoding="utf-8",
     )
-    Path("evidence-providers.md").write_text(markdown.rstrip() + "\n", encoding="utf-8")
+    # Empty markdown (the "not configured" case) writes a truly empty file so
+    # corpus.sh's `[ -s evidence-providers.md ]` gate can omit the section
+    # header entirely, instead of the model reacting to a header with nothing
+    # under it (#399/#409). Real diagnostics (config errors, provider output)
+    # still get a trailing newline as before.
+    Path("evidence-providers.md").write_text(
+        markdown.rstrip() + "\n" if markdown.strip() else "", encoding="utf-8"
+    )
 
 
 def main() -> int:
@@ -279,7 +286,10 @@ def main() -> int:
     }
 
     if not config_path_raw:
-        write_outputs(summary, "No evidence providers configured.")
+        # Leave the markdown empty (not "not configured") — this is the normal,
+        # expected state for consumers with no evidence providers set up, not
+        # a diagnostic worth a corpus section. See #399/#409.
+        write_outputs(summary, "")
         return 0
 
     config_path = Path(config_path_raw)

--- a/scripts/sections/corpus.sh
+++ b/scripts/sections/corpus.sh
@@ -107,9 +107,14 @@ print(render_evidence_memory_section(load_evidence_memory()), end='')
 " 2>/dev/null || true
       fi
     else
-      echo "# Linked Issue Context"
-      cat linked-issues.md
-      echo
+      # context.sh leaves linked-issues.md empty when there's no linked issue
+      # (#399/#400) so the model sees no section boundary to react to. Gate
+      # the header the same way, matching the CI Check Results pattern below.
+      if [ -s linked-issues.md ]; then
+        echo "# Linked Issue Context"
+        cat linked-issues.md
+        echo
+      fi
       echo "# PR Files (truncated)"
       echo '```json'
       cat pr-files.truncated.json
@@ -137,9 +142,13 @@ print(render_evidence_memory_section(load_evidence_memory()), end='')
     fi
     cat tool-harness.md
     echo
-    echo "# Evidence Providers"
-    cat evidence-providers.md
-    echo
+    # run_evidence_providers.py leaves evidence-providers.md empty when no
+    # providers are configured, same treatment as linked-issues.md above.
+    if [ -s evidence-providers.md ]; then
+      echo "# Evidence Providers"
+      cat evidence-providers.md
+      echo
+    fi
     # CI ran to completion in its own sandbox before this review; surface the
     # per-check outcomes so the model cites real test/lint results instead of
     # reporting them as "not verifiable". Only present when ci_status_check=true

--- a/tests/test_evidence_providers.py
+++ b/tests/test_evidence_providers.py
@@ -478,6 +478,48 @@ class TestMarkdownOutput:
         assert "super_secret_value_xyz123" not in content
         assert "[REDACTED]" in content
 
+    def test_not_configured_writes_empty_markdown(self, tmp_path: Path):
+        """No EVIDENCE_PROVIDERS_FILE set: evidence-providers.md must be truly
+        empty (0 bytes) so corpus.sh's `[ -s evidence-providers.md ]` gate
+        omits the "# Evidence Providers" header entirely, rather than the
+        model reacting to a "not configured" placeholder (#399/#409)."""
+        env = os.environ.copy()
+        env.pop("EVIDENCE_PROVIDERS_FILE", None)
+        result = subprocess.run(
+            [sys.executable, str(EVIDENCE_SCRIPT)],
+            cwd=str(tmp_path),
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        md_file = tmp_path / "evidence-providers.md"
+        assert md_file.exists()
+        assert md_file.read_text(encoding="utf-8") == ""
+        data = _load_json_output(tmp_path)
+        assert data["configured"] is False
+
+    def test_config_not_found_still_reports_error(self, tmp_path: Path):
+        """A misconfigured (nonexistent) path is a real error, unlike the
+        "not configured at all" case above — it must stay visible in the
+        corpus, not be silenced by the same empty-markdown treatment."""
+        env = os.environ.copy()
+        env["EVIDENCE_PROVIDERS_FILE"] = str(tmp_path / "does-not-exist.json")
+        result = subprocess.run(
+            [sys.executable, str(EVIDENCE_SCRIPT)],
+            cwd=str(tmp_path),
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        md_file = tmp_path / "evidence-providers.md"
+        content = md_file.read_text(encoding="utf-8")
+        assert content.strip() != ""
+        assert "not found" in content.lower()
+
 
 # ── Integration tests: command format (argv vs shell string) ───────
 


### PR DESCRIPTION
Closes #409, completes #399.

## What

`corpus.sh` unconditionally printed both the `# Linked Issue Context` and
`# Evidence Providers` headers regardless of whether the underlying file
had any content. #400 fixed `context.sh` to leave `linked-issues.md`
empty when there's no linked issue, but the header above it in
`corpus.sh` stayed unconditional — so the model still saw a section
boundary with nothing under it, and (per #399's original report) reliably
filled it in anyway rather than omitting the section.

`run_evidence_providers.py` had the identical bug in a second code path
#400 never touched: the "not configured" branch wrote a literal
`"No evidence providers configured."` sentence into `evidence-providers.md`,
which `corpus.sh` then unconditionally headered.

## Fix

- `corpus.sh`: gate both headers on `[ -s <file> ]`, the same pattern
  already used for the CI Check Results section a few lines below.
- `run_evidence_providers.py`: only the "not configured" branch (no
  `EVIDENCE_PROVIDERS_FILE` set at all) now writes an empty markdown file.
  The "config not found" and "invalid JSON" branches are left untouched —
  those are real misconfigurations worth surfacing, not "nothing to
  report", so they should stay visible under the (now correctly gated)
  header.

## Testing

- Added `test_not_configured_writes_empty_markdown` and
  `test_config_not_found_still_reports_error` to
  `tests/test_evidence_providers.py`, both passing.
- Full suite: `pytest tests/` — 1212 passed. The 2 failures in
  `TestMarkdownCaps` are pre-existing on unmodified `main` in my sandbox
  (a local `python3 -c` subprocess-interception quirk unrelated to this
  change — verified by stashing and re-running against the base commit).
- `tests/test_advisory_parallel.sh` — 18 passed, 0 failed.
- `bash -n scripts/sections/corpus.sh` — clean.

## Evidence

Real review output before this fix, on a routine dependency-bump PR with
no linked issue and no evidence providers configured:

> ### Linked Issue Fit
> No linked issues were provided for this PR. As a routine dependency update, no specific issue acceptance criteria need to be verified.
>
> ### Evidence Provider Findings
> No evidence provider findings were generated.

Both sections should be entirely absent per `default_system_prompt.txt`'s
own stated conditional ("a Linked Issue Fit section **when issue context
is available**", "an Evidence Provider Findings section **when provider
output exists**").