### PR TITLE
fix(security): reject artifact symlinks

### DIFF
--- a/scripts/artifact_paths.sh
+++ b/scripts/artifact_paths.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+# Generated files are written in the reviewed checkout. Refuse PR-controlled
+# symlinks at those paths before the first redirect can follow one outside the
+# workspace (notably on persistent self-hosted runners).
+assert_safe_artifact_paths() {
+  local path
+  local -a artifact_paths=(
+    pr.diff pr-object.json pr.json pr-body.txt changed-files.json
+    previous-review-meta.json previous-findings.json previous-evidence.json
+    incremental.diff linked-issues.md urls.all.txt urls.txt
+    version-hints.txt version-hints.truncated.txt ghcr-images.txt compare-shas.txt
+    linked-sources.md manifest-context.md image-digest-context.md
+    repo-impact.md repo-impact.truncated.md repo-history.md repo-history.truncated.md
+    evidence-providers.md evidence-providers.json classification.json
+    standards-context.md tool-harness.md tool-harness.json
+    review-corpus.md review-corpus.truncated.md review-corpus.fallback.truncated.md
+    ai-request.json ai-response.json ai-output.json ai-output.primary.json
+    ai-request.fallback.json ai-response.fallback.json
+    verdict.txt analysis_engine.txt review-markdown.raw.md
+    review-comment-markdown.raw.md review-comment.md review-comment-body.md
+    review-body.md inline-comments.json
+  )
+
+  for path in "${artifact_paths[@]}"; do
+    if [[ -L "$path" ]]; then
+      echo "Refusing to write review artifact through symlink: $path" >&2
+      return 1
+    fi
+  done
+}

--- a/scripts/check_review_needed.sh
+++ b/scripts/check_review_needed.sh
@@ -14,11 +14,18 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 export PYTHONPATH="${SCRIPT_DIR}/..${PYTHONPATH:+:${PYTHONPATH}}"
 # shellcheck source=scripts/platform_api.sh
 source "${SCRIPT_DIR}/platform_api.sh"
+# shellcheck source=scripts/artifact_paths.sh
+source "${SCRIPT_DIR}/artifact_paths.sh"
 
 if [[ -z "$REPO" || -z "$PR_NUMBER" ]]; then
   echo "Missing REPO or PR_NUMBER for review precheck" >&2
   exit 1
 fi
+
+# This is the first action step that writes generated files into the reviewed
+# checkout. Guard every later artifact path before any redirect can follow a
+# PR-controlled symlink.
+assert_safe_artifact_paths
 
 # ── Platform resolution, once (#367) ──────────────────────────────────
 # Resolve the host platform a single time here — using the shared

--- a/tests/test_artifact_paths.sh
+++ b/tests/test_artifact_paths.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=scripts/artifact_paths.sh
+source "$ROOT_DIR/scripts/artifact_paths.sh"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+cd "$TMP"
+
+outside="$TMP/outside.txt"
+printf 'unchanged\n' > "$outside"
+ln -s "$outside" pr.json
+
+if assert_safe_artifact_paths 2>error.txt; then
+  echo "FAIL: artifact symlink was accepted" >&2
+  exit 1
+fi
+
+grep -q 'Refusing to write review artifact through symlink: pr.json' error.txt
+[[ "$(cat "$outside")" == "unchanged" ]]
+
+rm pr.json
+ln -s "$outside" legitimate-repo-link
+assert_safe_artifact_paths
+
+grep -q 'assert_safe_artifact_paths' "$ROOT_DIR/scripts/check_review_needed.sh"
+echo "PASS: generated artifact symlinks are rejected before precheck writes"


### PR DESCRIPTION
Closes #406.

Rejects PR-controlled symlinks at every known generated artifact path before the precheck performs its first write. This prevents shell redirects and Python writes from following a malicious artifact symlink outside the checkout while leaving unrelated repository symlinks alone.

Validated with the new adversarial shell test, the existing precheck suite (38 checks), and `pytest tests/ -q` (1,212 passed).
