### PR TITLE
fix(impact): avoid awk broken pipe

### DIFF
--- a/scripts/sections/classification.sh
+++ b/scripts/sections/classification.sh
@@ -79,8 +79,16 @@ if [ "${#impact_terms[@]}" -gt 0 ]; then
       echo
       echo "### git grep hits"
       echo '```text'
-      awk -v pat="$esc" '{ c=$0; sub(/^[^:]*:[0-9]+:/, "", c); if (c ~ pat) print }' \
-        repo-impact.combined.txt | head -n 60 || true
+      awk -v pat="$esc" '
+        {
+          c=$0
+          sub(/^[^:]*:[0-9]+:/, "", c)
+          if (c ~ pat) {
+            print
+            if (++matches == 60) exit
+          }
+        }
+      ' repo-impact.combined.txt
       echo '```'
       echo
     } >> repo-impact.md

--- a/tests/test_advisory_parallel.sh
+++ b/tests/test_advisory_parallel.sh
@@ -64,5 +64,34 @@ check_contains "history scans run concurrently and are reaped" \
   "$CLASSIFICATION" 'wait "$pid"'
 
 echo ""
+echo "=== Test: repo-impact caps matches without a downstream pipe ==="
+check_not_contains "repo-impact does not pipe awk into head" \
+  "$CLASSIFICATION" 'repo-impact.combined.txt | head -n 60'
+check_contains "repo-impact caps matches inside awk" \
+  "$CLASSIFICATION" 'if (++matches == 60) exit'
+
+impact_fixture="$(mktemp)"
+impact_stdout="$(mktemp)"
+impact_stderr="$(mktemp)"
+trap 'rm -f "$impact_fixture" "$impact_stdout" "$impact_stderr"' EXIT
+for i in $(seq 1 75); do
+  printf 'file.txt:%s:target match %s\n' "$i" "$i" >> "$impact_fixture"
+done
+awk -v pat='target' '
+  {
+    c=$0
+    sub(/^[^:]*:[0-9]+:/, "", c)
+    if (c ~ pat) {
+      print
+      if (++matches == 60) exit
+    }
+  }
+' "$impact_fixture" > "$impact_stdout" 2> "$impact_stderr"
+check "awk emits exactly 60 matches from an over-limit fixture" \
+  "$(wc -l < "$impact_stdout" | tr -d ' ')" "60"
+check "awk emits no broken-pipe diagnostics" \
+  "$(wc -c < "$impact_stderr" | tr -d ' ')" "0"
+
+echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Move the 60-hit cap into `awk` so `head` no longer closes the pipe early and produces GNU awk broken-pipe diagnostics. This also removes the broad `|| true`, allowing genuine awk/read failures to surface.

Adds an over-limit regression fixture that verifies exactly 60 matches and empty stderr.

Closes #408.

Validation: `tests/test_advisory_parallel.sh`; `pytest tests/ -q` (1214 passed); shell syntax and diff checks.