### PR TITLE
fix(review): preserve forced verdict safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ Only three inputs are required: `github_token`, `ai_base_url`, and `ai_model`. E
 
 | Input | Description | Required | Default |
 |-------|-------------|----------|---------|
-| `verdict_policy` | How the final verdict is decided: `model` (the model's own verdict) or `findings_severity_gated` (derived from structured findings: `request_changes` iff any blocker finding; falls back to the model verdict when no findings). Enforcement settings still apply afterwards | No | `model` |
+| `verdict_policy` | How the final verdict is decided: `model` (the model's own verdict) or `findings_severity_gated` (one-way escalation: model request_changes is preserved; blocker findings can escalate approve to request_changes; non-blocker findings never weaken a rejection). Enforcement settings still apply afterwards | No | `model` |
 | `inline_findings` | Attach diff-anchorable structured findings as native line-anchored review comments in `review_comment`/`review_verdict` modes. Ignored for `comment` mode | No | `false` |
 | `inline_findings_max` | Maximum inline review comments per review when `inline_findings=true` | No | `20` |
 | `validate_required_checks` | Validate the final review against the classifier's `must_check` items: `auto` (when must_check is non-empty), `true`, or `false` | No | `auto` |
@@ -364,7 +364,7 @@ Only three inputs are required: `github_token`, `ai_base_url`, and `ai_model`. E
 | `forgejo_api_url` | Base URL for the Forgejo REST backend. Optional on Forgejo Actions runners when `github.server_url` is the Forgejo instance; set it when running from another host or when `GITHUB_SERVER_URL` is unavailable. | No | `""` |
 | `forgejo_token` | Optional Forgejo API token. Defaults to `github_token` when blank; set it when the token used for GitHub-compatible operations is not valid for the Forgejo REST API. | No | `""` |
 | `skip_if_diff_unchanged` | Skip the LLM review when the current PR patch matches the last managed review fingerprint | No | `true` |
-| `force_review` | Bypass the diff-unchanged guard and review even when the fingerprint matches. Set automatically by the `rereview_label`; also drivable from `workflow_dispatch`/`repository_dispatch`. When the last managed review was not clean, a forced re-review runs at **full** scope to re-establish a clean baseline (recovers a PR wedged in *Request changes*) | No | `false` |
+| `force_review` | Bypass the diff-unchanged guard and run a full PR review even when the fingerprint matches. Every forced review uses full scope to re-establish a clean baseline. Set automatically by the `rereview_label`; also drivable from `workflow_dispatch`/`repository_dispatch` when the consuming workflow explicitly maps its input or payload | No | `false` |
 | `rereview_label` | Label that, when added to a PR, forces a fresh review (add `labeled` to the workflow's `pull_request` types to enable). Self-authorizing — only write/triage can label. The label is removed after, so re-adding re-triggers | No | `ai-review` |
 | `ci_status_check` | Wait for all CI checks to reach a terminal state before starting the AI review. Default false — immediate review. | No | `false` |
 | `ci_timeout_sec` | Maximum seconds to wait for CI checks to complete when ci_status_check=true. | No | `300` |
@@ -504,13 +504,13 @@ on:
 >   cancel-in-progress: true
 > ```
 
-Nothing else changes. The action detects the label event itself: if the added label is the `rereview_label` (default `ai-review`) it forces a fresh review and then **removes the label** so adding it again re-triggers; any other label is ignored. There's no second workflow, no command parsing, and no checkout/authorization dance — labels are inherently maintainer-only (only users with write/triage permission can apply them), and the trigger rides `pull_request`, so there's no privileged-checkout exposure.
+Nothing else changes. The action detects the label event itself: if the added label is the `rereview_label` (default `ai-review`) it forces a full review and then **removes the label** so adding it again re-triggers; any other label is ignored. There's no second workflow, no command parsing, and no checkout/authorization dance — labels are inherently maintainer-only (only users with write/triage permission can apply them), and the trigger rides `pull_request`, so there's no privileged-checkout exposure.
 
 Rename the trigger label with the `rereview_label` input if `ai-review` collides with an existing label. This repository's own [`ai-pr-review.yaml`](.github/workflows/ai-pr-review.yaml) uses exactly this wiring.
 
-For non-interactive callers, `force_review: "true"` bypasses the guard directly — useful from a `workflow_dispatch` input or a `repository_dispatch` payload (both already require a write-scoped token to fire).
+For non-interactive callers, `force_review: "true"` bypasses the unchanged-diff guard and runs a full PR review. A `workflow_dispatch` or `repository_dispatch` event only does this when the consuming workflow explicitly maps its input or payload to the action's `force_review` input.
 
-**Recovering a "stuck" PR.** With `publish_mode: review_verdict`, an incremental review can only approve on top of a *trusted clean full baseline* (verdict safety). So once any full review records issues, later pushes — which are incremental — cannot approve until a clean full review re-establishes the baseline. A forced re-review (the `ai-review` label, `workflow_dispatch`, or `repository_dispatch`) now handles this automatically: when the last managed review was **not clean**, the forced re-review runs at **full** scope so it re-examines the whole PR and can clear the baseline. (A forced re-review on an already-clean baseline stays incremental — there's nothing to reset.) So a PR wedged in *Request changes* after its findings are fixed recovers with a single re-label.
+Every forced review re-establishes a full baseline by reviewing the complete PR diff at full scope. This is necessary for verdict safety: with `publish_mode: review_verdict`, an incremental review can approve only on top of a trusted clean full baseline, so any PR that needs to clear a previous request_changes requires a full review.
 
 ### 🧾 With evidence providers
 
@@ -802,7 +802,7 @@ The model may return an optional `findings` array alongside the verdict — conc
 
 Findings are normalized (severities mapped to `blocker`/`major`/`minor`/`info`, malformed entries dropped) and exposed as the `findings` output. **Absence is fine** — weaker local models that only produce `verdict`/`review_markdown` keep exactly the previous behavior.
 
-With `verdict_policy: findings_severity_gated`, the verdict is derived deterministically from the findings instead of trusting the model's headline call: `request_changes` iff any blocker-severity finding exists, otherwise `approve`. When no findings were produced, the model's verdict is used (the `verdict_source` output tells you which path applied). Enforcement settings (`evidence_blocker_enforcement`, tool-failure enforcement) still run afterwards and can force `request_changes`.
+With `verdict_policy: findings_severity_gated`, the policy applies one-way escalation: a model `request_changes` verdict is preserved, and `approve` is escalated to `request_changes` when any blocker-severity finding exists. Non-blocker findings never weaken a model rejection. When no findings were produced, the model's verdict stands (the `verdict_source` output tells you which path applied). Enforcement settings (`evidence_blocker_enforcement`, tool-failure enforcement) still run afterwards and can force `request_changes`.
 
 ```yaml
 - uses: misospace/pr-reviewer-action@v1

--- a/action.yml
+++ b/action.yml
@@ -96,10 +96,9 @@ inputs:
   verdict_policy:
     description: >-
       How the final verdict is decided. 'model' (default) uses the model's own verdict.
-      'findings_severity_gated' derives the verdict deterministically from the structured
-      findings array: request_changes iff any blocker-severity finding exists, otherwise
-      approve. When the model returns no findings, the policy falls back to the model
-      verdict (weak models degrade gracefully). Enforcement settings (evidence blockers,
+      'findings_severity_gated' preserves request_changes from the model and escalates
+      approve to request_changes when any blocker-severity finding exists. Non-blocker
+      findings never weaken a model rejection. Enforcement settings (evidence blockers,
       tool failure) still apply afterwards and can force request_changes.
     required: false
     default: "model"
@@ -510,7 +509,11 @@ inputs:
     required: false
     default: "true"
   force_review:
-    description: If true, bypass the diff-unchanged guard and always review, even when the fingerprint matches the last managed comment. Set automatically when the rereview_label is added; can also be driven from a workflow_dispatch or repository_dispatch. Default false.
+    description: >-
+      If true, bypass the diff-unchanged guard and run a full PR review, even
+      when the fingerprint matches the last managed review. Set automatically
+      when the rereview_label is added; callers can also pass it from a
+      workflow_dispatch or repository_dispatch. Default false.
     required: false
     default: "false"
   rereview_label:

--- a/pr_reviewer/enforcement.py
+++ b/pr_reviewer/enforcement.py
@@ -238,15 +238,17 @@ def apply_verdict_policy(
     policy: str = "model",
     output_path: str = "ai-output.json",
 ) -> str:
-    """Derive the verdict from structured findings when configured.
+    """Apply monotonic verdict escalation from structured findings.
 
     ``model`` (default) leaves the model's verdict untouched. With
-    ``findings_severity_gated`` the verdict is computed deterministically from
-    the findings array: ``request_changes`` iff any blocker-severity finding
-    exists, otherwise ``approve``. When the model produced no findings the
-    policy falls back to the model verdict, so weaker models degrade to
-    today's behaviour. Enforcement overlays (evidence blockers, tool-harness
-    failure) run after this and can still force ``request_changes``.
+    ``findings_severity_gated`` the policy only escalates an ``approve`` to
+    ``request_changes`` when blocker-severity findings exist. Non-blocker
+    findings never downgrade a model ``request_changes`` to ``approve``, and
+    non-blocker findings never change the verdict source from the model. When
+    the model produced no findings the policy falls back to the model verdict,
+    so weaker models degrade gracefully. Enforcement overlays (evidence
+    blockers, tool-harness failure) run after this and can still force
+    ``request_changes``.
 
     Returns the verdict source applied: ``"model"`` or ``"findings"``. The
     source is also recorded in the output JSON as ``verdict_source``.
@@ -255,27 +257,22 @@ def apply_verdict_policy(
     findings = data.get("findings")
     source = "model"
 
-    if (
-        policy == "findings_severity_gated"
-        and isinstance(findings, list)
-        and findings
-    ):
+    if policy == "findings_severity_gated" and isinstance(findings, list):
         blockers = [
-            f
-            for f in findings
-            if isinstance(f, dict) and f.get("severity") == "blocker"
+            finding
+            for finding in findings
+            if isinstance(finding, dict) and finding.get("severity") == "blocker"
         ]
-        derived = "request_changes" if blockers else "approve"
-        if derived != data.get("verdict"):
+        if blockers and data.get("verdict") != "request_changes":
             note = (
-                f"\n\n_Verdict derived from structured findings "
-                f"(verdict_policy=findings_severity_gated): "
+                "\n\n_Verdict escalated from structured findings "
+                "(verdict_policy=findings_severity_gated): "
                 f"{len(blockers)} blocker finding(s) out of {len(findings)}; "
                 f"model verdict was '{data.get('verdict')}'._"
             )
             data["review_markdown"] = str(data.get("review_markdown") or "") + note
-        data["verdict"] = derived
-        source = "findings"
+            data["verdict"] = "request_changes"
+            source = "findings"
 
     data["verdict_source"] = source
     Path(output_path).write_text(

--- a/scripts/check_review_needed.sh
+++ b/scripts/check_review_needed.sh
@@ -438,18 +438,11 @@ resolve_review_scope() {
   local current_base_sha="$5"
   local last_review_result="${6:-}"
 
-  # Recovery lever for a wedged PR: a forced re-review (ai-review label /
-  # workflow_dispatch / repository_dispatch) whose last managed review was NOT
-  # clean runs at FULL scope. The incremental-approval guardrail blocks every
-  # incremental approval until a trusted clean FULL baseline exists, and nothing
-  # else re-establishes one — so a PR that ever recorded issues (even a
-  # false-positive blocker, or one since fixed) could never return to approve via
-  # pushes/labels. force_review already bypasses the diff-unchanged guard; here it
-  # also resets scope so the re-review re-examines the whole PR and can vouch it
-  # clean. A forced re-review on an already-clean baseline keeps the user's scope
-  # (cheap incremental) — there is nothing to unwedge.
-  if [[ "${FORCE_REVIEW:-false}" == "true" && -n "$last_review_result" && "$last_review_result" != "clean" ]]; then
-    echo "Forced re-review with a non-clean baseline ($last_review_result): using full scope to reset the baseline" >&2
+  # An explicit re-review must re-evaluate the complete PR, regardless of the
+  # previous result. It also clears incremental baseline state via the shared
+  # full-scope reset helper.
+  if [[ "${FORCE_REVIEW:-false}" == "true" ]]; then
+    echo "Forced re-review: using full scope" >&2
     fallback_full_scope
     return
   fi

--- a/tests/test_enforcement.py
+++ b/tests/test_enforcement.py
@@ -426,14 +426,25 @@ class TestApplyVerdictPolicy:
         assert source == "findings"
         assert data["verdict"] == "request_changes"
         assert data["verdict_source"] == "findings"
-        assert "derived from structured findings" in data["review_markdown"]
+        assert "escalated from structured findings" in data["review_markdown"]
 
-    def test_gated_no_blockers_approves(self, tmp_path):
+    def test_gated_non_blockers_preserve_model_request_changes(self, tmp_path):
         out = self._write(tmp_path, "request_changes", [self._minor()])
         source = apply_verdict_policy("findings_severity_gated", str(out))
         data = json.loads(out.read_text())
-        assert source == "findings"
+        assert source == "model"
+        assert data["verdict"] == "request_changes"
+        assert data["verdict_source"] == "model"
+        assert "escalated from structured findings" not in data["review_markdown"]
+
+    def test_gated_non_blockers_preserve_model_approve(self, tmp_path):
+        out = self._write(tmp_path, "approve", [self._minor()])
+        source = apply_verdict_policy("findings_severity_gated", str(out))
+        data = json.loads(out.read_text())
+        assert source == "model"
         assert data["verdict"] == "approve"
+        assert data["verdict_source"] == "model"
+        assert "escalated from structured findings" not in data["review_markdown"]
 
     def test_gated_without_findings_falls_back_to_model(self, tmp_path):
         out = self._write(tmp_path, "request_changes", [])
@@ -451,10 +462,12 @@ class TestApplyVerdictPolicy:
 
     def test_unchanged_verdict_adds_no_note(self, tmp_path):
         out = self._write(tmp_path, "request_changes", [self._blocker()])
-        apply_verdict_policy("findings_severity_gated", str(out))
+        source = apply_verdict_policy("findings_severity_gated", str(out))
         data = json.loads(out.read_text())
+        assert source == "model"
+        assert data["verdict_source"] == "model"
         assert data["verdict"] == "request_changes"
-        assert "derived from structured findings" not in data["review_markdown"]
+        assert "escalated from structured findings" not in data["review_markdown"]
 
     def test_enforcement_still_overrides_gated_approve(self, tmp_path):
         out = self._write(tmp_path, "approve", [self._minor()])

--- a/tests/test_review_scope.sh
+++ b/tests/test_review_scope.sh
@@ -39,8 +39,8 @@ index 123..456 644
 +new'
 
 # Mock gh command
-PR_HEAD_SHA="def456ghi"
-PR_BASE_SHA="base789sha"
+PR_HEAD_SHA="def456abcdef1234567890abcdef1234567890ab"
+PR_BASE_SHA="ba5e789abcdef1234567890abcdef1234567890"
 
 cat > "$TMPDIR/bin/gh" <<SHELLEOF
 #!/usr/bin/env bash
@@ -78,7 +78,7 @@ case "\$1" in
     if echo "\$*" | grep -q 'comments'; then
       RESULT="\$(cat /tmp/testfp_comments.json)"
     elif echo "\$*" | grep -q 'pulls/42'; then
-      RESULT="\$(printf '{"head":{"repo":{"full_name":"test/repo"}},"base":{"repo":{"full_name":"test/repo"},"sha":"%s"}}' "\$PR_BASE_SHA")"
+      RESULT="\$(printf '{"head":{"sha":"%s","repo":{"full_name":"test/repo"}},"base":{"repo":{"full_name":"test/repo"},"sha":"%s"}}' "\$PR_HEAD_SHA" "\$PR_BASE_SHA")"
     elif echo "\$*" | grep -q 'compare/'; then
       RESULT='{"status":"ok"}'
     else
@@ -191,42 +191,48 @@ REVIEW_SCOPE=auto RESULT="$(run_precheck)"
 check "effective_scope=full with auto and no prior metadata" \
   "$(echo "$RESULT" | grep '^effective_review_scope=' | head -1 | cut -d= -f2)" "full"
 
-# ── Test 3: review_scope=auto, with prior metadata → full (safe fallback) ──
-# In a non-git-repo test environment, git merge-base --is-ancestor cannot
-# verify ancestry, so the implementation correctly falls back to full scope.
+# ── Test 3: review_scope=auto, with prior metadata → incremental ──
 echo ""
-echo "=== Test 3: review_scope=auto, with prior metadata → safe fallback ==="
-set_pr_data "def456ghi" "base789sha"
-set_comments_with_metadata "def456ghi" "base789sha" "full" "clean" ""
-REVIEW_SCOPE=auto RESULT="$(run_precheck)"
-check "effective_scope=full when git ancestry cannot be verified (safe fallback)" \
-  "$(echo "$RESULT" | grep '^effective_review_scope=' | head -1 | cut -d= -f2)" "full"
+echo "=== Test 3: review_scope=auto, with prior metadata → incremental ==="
+set_pr_data "$PR_HEAD_SHA" "$PR_BASE_SHA"
+set_comments_with_metadata "$PR_HEAD_SHA" "$PR_BASE_SHA" "full" "clean" ""
+FORCE_REVIEW=false REVIEW_SCOPE=auto RESULT="$(run_precheck)"
+check "non-forced auto review uses incremental scope with a safe baseline" \
+  "$(echo "$RESULT" | grep '^effective_review_scope=' | head -1 | cut -d= -f2)" "incremental"
+check "safe incremental review carries previous head" \
+  "$(echo "$RESULT" | grep '^previous_head_sha=' | head -1 | cut -d= -f2)" "$PR_HEAD_SHA"
+check "safe incremental review trusts clean baseline" \
+  "$(echo "$RESULT" | grep '^baseline_clean=' | head -1 | cut -d= -f2)" "true"
 
 # ── Test 4: baseline_clean defaults to false when scope is full ────────
 echo ""
 echo "=== Test 4: baseline_clean defaults to false on full fallback ==="
+set_empty_comments
+REVIEW_SCOPE=auto RESULT="$(run_precheck)"
 check "baseline_clean=false when falling back to full scope" \
   "$(echo "$RESULT" | grep '^baseline_clean=' | head -1 | cut -d= -f2)" "false"
 
 # ── Test 5: baseline_clean=false when prior result had issues ─────────
 echo ""
 echo "=== Test 5: baseline_clean=false when prior had issues ==="
-set_pr_data "def456ghi" "base789sha"
-set_comments_with_metadata "def456ghi" "base789sha" "incremental" "issues" "abc123def"
-echo "abc123def" >> "$SHA_TRACK_FILE"
+set_pr_data "$PR_HEAD_SHA" "$PR_BASE_SHA"
+set_comments_with_metadata "$PR_HEAD_SHA" "$PR_BASE_SHA" "incremental" "issues" ""
 REVIEW_SCOPE=auto RESULT="$(run_precheck)"
 check "baseline_clean=false when prior review had issues" \
   "$(echo "$RESULT" | grep '^baseline_clean=' | head -1 | cut -d= -f2)" "false"
 
-# ── Test 6: base SHA mismatch → fallback to full ─────────────────────
+# ── Test 6: base SHA mismatch → fallback to full ─────────────
 echo ""
 echo "=== Test 6: base SHA mismatch → fallback to full ==="
-set_pr_data "def456ghi" "different_base_sha"
-set_comments_with_metadata "def456ghi" "base789sha" "full" "clean" ""
-echo "different_base_sha" >> "$SHA_TRACK_FILE"
+MISMATCH_BASE_SHA="cccc789abcdef1234567890abcdef1234567890"
+ORIGINAL_BASE_SHA="$PR_BASE_SHA"
+set_pr_data "$PR_HEAD_SHA" "$MISMATCH_BASE_SHA"
+set_comments_with_metadata "$PR_HEAD_SHA" "$ORIGINAL_BASE_SHA" "full" "clean" ""
 REVIEW_SCOPE=auto RESULT="$(run_precheck)"
 check "effective_scope=full when base SHA changed" \
   "$(echo "$RESULT" | grep '^effective_review_scope=' | head -1 | cut -d= -f2)" "full"
+# Restore globals for subsequent tests
+PR_BASE_SHA="$ORIGINAL_BASE_SHA"
 
 # ── Test 7: review_scope=incremental, no prior metadata → full fallback ──
 echo ""
@@ -236,40 +242,42 @@ REVIEW_SCOPE=incremental RESULT="$(run_precheck)"
 check "effective_scope=full when incremental but no prior metadata" \
   "$(echo "$RESULT" | grep '^effective_review_scope=' | head -1 | cut -d= -f2)" "full"
 
-# ── Wedge recovery: a forced re-review on a DIRTY baseline escalates to full ──
-# so it can re-establish a clean baseline (incrementals can't clear one). The
-# mock-git env can't produce an incremental scope (ancestry can't be verified →
-# safe-fallback to full), so we assert on the recovery LOG LINE — which only
-# fires from the new forced-full branch — not on the scope alone.
-forced_full_logged() {
-  grep -q 'non-clean baseline' "$TMPDIR/precheck_stderr" && echo yes || echo no
-}
-
+# ── Test 7b: clean-baseline forced review → full scope ──
 echo ""
-echo "=== Test 7b: force_review + dirty baseline → forced full (wedge recovery) ==="
-set_pr_data "def456ghi" "base789sha"
-set_comments_with_metadata "def456ghi" "base789sha" "incremental" "issues" "abc123def"
-echo "abc123def" >> "$SHA_TRACK_FILE"
+echo "=== Test 7b: force_review + clean baseline → forced full ==="
+set_pr_data "$PR_HEAD_SHA" "$PR_BASE_SHA"
+set_comments_with_metadata "$PR_HEAD_SHA" "$PR_BASE_SHA" "full" "clean" ""
 FORCE_REVIEW=true REVIEW_SCOPE=auto RESULT="$(run_precheck)"
-check "dirty-baseline forced re-review resolves to full scope" \
+check "clean-baseline forced review uses full scope" \
   "$(echo "$RESULT" | grep '^effective_review_scope=' | head -1 | cut -d= -f2)" "full"
-check "dirty-baseline forced re-review takes the recovery branch" "$(forced_full_logged)" "yes"
+check "clean-baseline forced review clears previous head" \
+  "$(echo "$RESULT" | grep '^previous_head_sha=' | head -1 | cut -d= -f2)" ""
+check "clean-baseline forced review resets baseline trust" \
+  "$(echo "$RESULT" | grep '^baseline_clean=' | head -1 | cut -d= -f2)" "false"
 
+# ── Test 7c: dirty-baseline forced review → full scope ──
 echo ""
-echo "=== Test 7c: force_review + CLEAN baseline → recovery branch NOT taken ==="
-set_pr_data "def456ghi" "base789sha"
-set_comments_with_metadata "def456ghi" "base789sha" "incremental" "clean" "abc123def"
-echo "abc123def" >> "$SHA_TRACK_FILE"
+echo "=== Test 7c: force_review + dirty baseline → forced full ==="
+set_pr_data "$PR_HEAD_SHA" "$PR_BASE_SHA"
+set_comments_with_metadata "$PR_HEAD_SHA" "$PR_BASE_SHA" "incremental" "issues" ""
 FORCE_REVIEW=true REVIEW_SCOPE=auto RESULT="$(run_precheck)"
-check "clean-baseline forced re-review does NOT take the recovery branch" "$(forced_full_logged)" "no"
+check "dirty-baseline forced review uses full scope" \
+  "$(echo "$RESULT" | grep '^effective_review_scope=' | head -1 | cut -d= -f2)" "full"
+check "dirty-baseline forced review clears previous head" \
+  "$(echo "$RESULT" | grep '^previous_head_sha=' | head -1 | cut -d= -f2)" ""
+check "dirty-baseline forced review resets baseline trust" \
+  "$(echo "$RESULT" | grep '^baseline_clean=' | head -1 | cut -d= -f2)" "false"
 
+# ── Test 7d: dirty baseline, no force → remains incremental (force-gated) ──
 echo ""
-echo "=== Test 7d: DIRTY baseline, no force → recovery branch NOT taken (force-gated) ==="
-set_pr_data "def456ghi" "base789sha"
-set_comments_with_metadata "def456ghi" "base789sha" "incremental" "issues" "abc123def"
-echo "abc123def" >> "$SHA_TRACK_FILE"
+echo "=== Test 7d: non-forced dirty-baseline review remains incremental ==="
+set_pr_data "$PR_HEAD_SHA" "$PR_BASE_SHA"
+set_comments_with_metadata "$PR_HEAD_SHA" "$PR_BASE_SHA" "incremental" "issues" ""
 FORCE_REVIEW=false REVIEW_SCOPE=auto RESULT="$(run_precheck)"
-check "non-forced dirty-baseline re-review does NOT take the recovery branch" "$(forced_full_logged)" "no"
+check "non-forced dirty-baseline review remains incremental" \
+  "$(echo "$RESULT" | grep '^effective_review_scope=' | head -1 | cut -d= -f2)" "incremental"
+check "non-forced dirty baseline remains untrusted" \
+  "$(echo "$RESULT" | grep '^baseline_clean=' | head -1 | cut -d= -f2)" "false"
 
 # ── Test 8: action.yml has review_scope input ────────────────────────
 echo ""


### PR DESCRIPTION
Forced re-reviews now always examine the full PR, and findings severity gating can only make a model verdict stricter. This prevents a model `request_changes` verdict from being published as approval and ensures the `ai-review` label establishes a fresh full-review baseline.

Regression coverage exercises clean and dirty forced baselines, genuine safe incremental reviews, and monotonic verdict/source behavior.

Verification:
- `PATH="/opt/homebrew/bin:$PATH" bash tests/test_review_scope.sh` (21 passed)
- `PATH="/opt/homebrew/bin:$PATH" bash tests/test_check_review_needed.sh` (38 passed)
- `python3 -m pytest tests/test_enforcement.py -v` (38 passed)
- `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false python3 -m pytest tests/ -q --tb=short` (1231 passed)