### PR TITLE
fix(tools): honor "*" wildcard in web_fetch host allowlist

### DIFF
--- a/pr_reviewer/tool_executors.py
+++ b/pr_reviewer/tool_executors.py
@@ -59,7 +59,12 @@ def normalize_host(host):
 def allowlisted_host(host, allowlist):
     candidate = normalize_host(host)
     for item in allowlist:
-        if candidate == item:
+        norm = normalize_host(item)
+        # "'*'" is an allow-all wildcard, consistent with the gh_api repo
+        # allowlist in platform.py — so operators can set
+        # allowed_source_hosts: "*" and actually permit any host (previously
+        # the exact-match loop silently matched nothing, blocking every fetch).
+        if norm == "*" or candidate == norm:
             return True
     return False
 

--- a/tests/test_native_loop_exfil_redteam.py
+++ b/tests/test_native_loop_exfil_redteam.py
@@ -148,6 +148,25 @@ def test_web_fetch_blocks_unallowlisted_host(tmp_path, url):
     assert "not allowlisted" in str(res["result"]).lower()
 
 
+def test_allowlisted_host_wildcard_allows_any():
+    """Wildcard '*' should allow any host, mirroring gh_api's repo wildcard.
+
+    Regression guard: ``allowlisted_host`` previously did exact-match only, so
+    an operator setting ``allowed_source_hosts: "*"`` silently blocked every
+    fetch (the "*" matched no real host).
+    """
+    from pr_reviewer.tool_executors import allowlisted_host
+
+    assert allowlisted_host("registry.npmjs.org", ["*"]) is True
+    assert allowlisted_host("evil.example.com", ["*"]) is True
+    # Non-wildcard exact behaviour is unchanged.
+    assert allowlisted_host("github.com", ["github.com"]) is True
+    assert allowlisted_host("evil.example.com", ["github.com"]) is False
+    # Entries are normalised, so stray case/whitespace no longer causes a
+    # silent denial.
+    assert allowlisted_host("github.com", ["  GitHub.COM  "]) is True
+
+
 # 5. A hostile web_search query cannot smuggle in a different host: the query is
 #    URL-encoded into the operator-configured search_url, which stays fixed.
 def test_web_search_query_cannot_change_host(tmp_path, monkeypatch):


### PR DESCRIPTION
## Problem

`allowed_source_hosts: "*"` silently blocked **every** `web_fetch`. `allowlisted_host()` did exact string match, so `"*"` matched no real host — an operator setting "allow all" got "allow nothing". Observed downstream in [joryirving/dotfiles#55](https://github.com/joryirving/dotfiles/pull/55): the reviewer could not fetch `registry.npmjs.org` to scan an npm plugin bump, despite `allowed_source_hosts: "*"`.

## Root cause

The `gh_api` repo allowlist (`platform.py`) already treats `"*"` as allow-all, and `run_tool_harness.py` adds `"*"` for gh_api. The `web_fetch` host check was the odd one out — same codebase, same `"*"` convention, just missing from this path.

## Fix

`allowlisted_host()` now honors `"*"` (parity with gh_api) and normalises each allowlist entry, so stray case/whitespace no longer causes a silent denial.

```python
def allowlisted_host(host, allowlist):
    candidate = normalize_host(host)
    for item in allowlist:
        norm = normalize_host(item)
        if norm == "*" or candidate == norm:
            return True
    return False
```

## Tests

- New `test_allowlisted_host_wildcard_allows_any` (deterministic, no network): wildcard allows any host, exact-match is unchanged, entry normalisation works.
- Existing `test_web_fetch_blocks_unallowlisted_host` / `test_web_fetch_error_non_allowlisted_host` still pass (their allowlists have no `"*"`).

Full suite: **1232 passed**.