### PR TITLE
fix(forgejo): submit approvals with native state

### DIFF
--- a/pr_reviewer/forgejo_backend.py
+++ b/pr_reviewer/forgejo_backend.py
@@ -739,7 +739,10 @@ def _forgejo_review_to_github(review: dict[str, Any]) -> dict[str, Any]:
 def _forgejo_review_event(event: str) -> str:
     event = (event or "COMMENT").upper()
     if event in {"APPROVE", "APPROVED"}:
-        return "APPROVE"
+        # GitHub submits reviews with `APPROVE`; Forgejo's ReviewStateType uses
+        # `APPROVED`. Forgejo accepts the former without an error but creates a
+        # PENDING draft whose body the timeline hides as "No description".
+        return "APPROVED"
     if event in {"REQUEST_CHANGES", "CHANGES_REQUESTED"}:
         return "REQUEST_CHANGES"
     return "COMMENT"

--- a/tests/test_forgejo_backend.py
+++ b/tests/test_forgejo_backend.py
@@ -712,12 +712,15 @@ class TestNativeReviews(unittest.TestCase):
         self.assertEqual(data["comments"], [{"path": "test.txt", "new_position": 2, "body": "anchored"}])
 
     @_PATCH_FORGEJO
-    def test_create_native_review_posts_approve_event(self, mock_curl):
+    def test_create_native_review_uses_forgejo_approved_state(self, mock_curl):
         seen = {}
 
         def _run(method: str, url: str, **kwargs: Any) -> tuple[int, str]:
             seen.update(method=method, url=url, data=kwargs.get("data"))
-            return 201, json.dumps(dict(REVIEW, id=57, state="APPROVE"))
+            # Forgejo silently creates a PENDING draft for GitHub's `APPROVE`
+            # token. Its ReviewStateType requires `APPROVED` to submit it.
+            state = "APPROVED" if kwargs["data"]["event"] == "APPROVED" else "PENDING"
+            return 201, json.dumps(dict(REVIEW, id=57, state=state))
 
         mock_curl.side_effect = _run
 
@@ -725,7 +728,8 @@ class TestNativeReviews(unittest.TestCase):
             result = fb.create_native_review("misospace/pr-reviewer-action", 42, "APPROVE", "looks good")
 
         self.assertIsNotNone(result)
-        self.assertEqual(seen["data"], {"body": "looks good", "event": "APPROVE"})
+        self.assertEqual(seen["data"], {"body": "looks good", "event": "APPROVED"})
+        self.assertEqual(result["state"], "APPROVED")
 
     @_PATCH_FORGEJO
     def test_dismiss_review_uses_forgejo_dismissal_endpoint(self, mock_curl):


### PR DESCRIPTION
## Summary

Map GitHub review event `APPROVE` to Forgejo ReviewStateType `APPROVED`. Forgejo silently accepts `APPROVE` by creating a PENDING draft, leaving the review body hidden as “No description provided.”

## Validation

- `python -m pytest tests/test_forgejo_backend.py -q` — 77 passed
- `git diff --check`
- `python3 -m py_compile pr_reviewer/forgejo_backend.py`

The regression test models Forgejo returning `PENDING` for the GitHub token and asserts the native `APPROVED` token is sent.