### PR TITLE
docs(forgejo): note create_native_review is Forgejo-mode only

### DIFF
--- a/pr_reviewer/forgejo_backend.py
+++ b/pr_reviewer/forgejo_backend.py
@@ -843,6 +843,12 @@ def create_native_review(
     event: str,
     body: str,
 ) -> dict[str, Any] | None:
+    """Submit a body-only review. Forgejo mode only.
+
+    The event is pre-mapped to Forgejo's ReviewStateType tokens (e.g.
+    ``APPROVED``), which GitHub's review API rejects — GitHub-mode callers
+    go through ``gh pr review`` in ``scripts/platform_api.sh`` instead.
+    """
     return create_pr_review_from_payload(
         repo_full_name,
         pr_number,

--- a/tests/test_forgejo_backend.py
+++ b/tests/test_forgejo_backend.py
@@ -732,6 +732,22 @@ class TestNativeReviews(unittest.TestCase):
         self.assertEqual(result["state"], "APPROVED")
 
     @_PATCH_FORGEJO
+    def test_create_native_review_maps_request_changes_state(self, mock_curl):
+        seen = {}
+
+        def _run(method: str, url: str, **kwargs: Any) -> tuple[int, str]:
+            seen.update(method=method, url=url, data=kwargs.get("data"))
+            return 201, json.dumps(dict(REVIEW, id=58, state="REQUEST_CHANGES"))
+
+        mock_curl.side_effect = _run
+
+        with _forgejo_env_patch():
+            result = fb.create_native_review("misospace/pr-reviewer-action", 42, "CHANGES_REQUESTED", "needs work")
+
+        self.assertIsNotNone(result)
+        self.assertEqual(seen["data"], {"body": "needs work", "event": "REQUEST_CHANGES"})
+
+    @_PATCH_FORGEJO
     def test_dismiss_review_uses_forgejo_dismissal_endpoint(self, mock_curl):
         seen = {}
 


### PR DESCRIPTION
## Summary

Follow-up to #435:

- Docstring on `create_native_review` warning that it pre-maps events to Forgejo `ReviewStateType` tokens (e.g. `APPROVED`), which GitHub's review API rejects — GitHub-mode callers use `gh pr review` via `scripts/platform_api.sh` instead. Closes the latent trap where the shared `create_pr_review_from_payload` is dual-mode but this wrapper isn't.
- Regression test for the `REQUEST_CHANGES`/`CHANGES_REQUESTED` mapping, symmetric with the `APPROVED` test.

## Validation

- `python -m pytest tests/test_forgejo_backend.py -q` — 78 passed
- `python3 -m py_compile pr_reviewer/forgejo_backend.py`