### PR TITLE
Migrate check_review_needed.sh logic to Python

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,9 @@ jobs:
           python-version: '3.14'
 
       - name: Install test dependencies
-        run: pip install pytest pytest-cov yamllint
+        run: |
+          pip install pytest pytest-cov yamllint
+          sudo apt-get update -qq && sudo apt-get install -y -qq jq
 
       - name: Validate action metadata YAML
         run: ruby -e 'require "yaml"; YAML.load_file("action.yml")'


### PR DESCRIPTION
## What
Migrated the 554-line `scripts/check_review_needed.sh` to a Python module (`pr_reviewer/precheck.py`) and reduced the shell wrapper to a single `python3 -m pr_reviewer.precheck` invocation. Added 37 unit tests in `tests/test_precheck.py` covering all extracted function…

Fixes #429

_Opened by foreman on review GO (workload wl-misospace-pr-reviewer-action-429)._