### PR TITLE
Set both GH_TOKEN and GITHUB_TOKEN in gh_api_call subprocess env

### DIFF
--- a/pr_reviewer/http_client.py
+++ b/pr_reviewer/http_client.py
@@ -36,6 +36,7 @@ def gh_api_call(endpoint: str, token: str | None = None) -> dict | list | None:
         env = os.environ.copy()
         if token:
             env["GH_TOKEN"] = token
+            env["GITHUB_TOKEN"] = token
         result = subprocess.run(
             cmd, capture_output=True, text=True, timeout=30, env=env
         )

--- a/tests/test_enrichment.py
+++ b/tests/test_enrichment.py
@@ -653,6 +653,25 @@ class TestGhApiCall:
         monkeypatch.setattr(http_client.subprocess, "run", _boom)
         assert http_client.gh_api_call("repos/o/r") is None
 
+    def test_sets_both_gh_token_and_github_token(self, monkeypatch):
+        from pr_reviewer import http_client
+
+        captured_env = None
+
+        class _R:
+            returncode = 0
+            stdout = "{}"
+
+        def _run(*a, **k):
+            nonlocal captured_env
+            captured_env = k.get("env", {})
+            return _R()
+
+        monkeypatch.setattr(http_client.subprocess, "run", _run)
+        http_client.gh_api_call("repos/o/r", token="secret-token")
+        assert captured_env["GH_TOKEN"] == "secret-token"
+        assert captured_env["GITHUB_TOKEN"] == "secret-token"
+
 
 class TestReleasesCache:
     """render_linked_sources fetches a repo's releases list at most once."""


### PR DESCRIPTION
## What

Adds `env["GITHUB_TOKEN"] = token` alongside the existing `env["GH_TOKEN"] = token` inside `pr_reviewer/http_client.py::gh_api_call`, and adds a unit test in `tests/test_enrichment.py` asserting both env vars are set when a token is passed.

## Why

The `gh` CLI reads…

Fixes #439

_Opened by foreman on review GO (workload wl-misospace-pr-reviewer-action-439)._