### PR TITLE
fix(review): prevent stale and unpublishable AI verdicts

### DIFF
--- a/.github/workflows/ai-pr-review.yaml
+++ b/.github/workflows/ai-pr-review.yaml
@@ -42,22 +42,23 @@ jobs:
         uses: misospace/pr-reviewer-action@258ac494ff48261cba9a62dce384b35ed73404ba # v2.1.7
         with:
           github_token: ${{ steps.app-token.outputs.token }}
-          ai_primary_retries: "3"
-          ai_primary_retry_delay_sec: "15"
+          ai_primary_retries: "2"
+          ai_primary_retry_delay_sec: "5"
+          ai_connect_timeout_sec: "10"
           ai_base_url: ${{ vars.LITELLM_URL }}
-          ai_api_format: ${{ vars.PRIMARY_FORMAT }}
-          ai_model: ${{ vars.PRIMARY_MODEL }}
+          ai_api_format: openai
+          ai_model: qwen3.6-27b
           ai_api_key: ${{ secrets.LITELLM_API_KEY }}
           ai_response_format: json_object
           ai_fallback_base_url: ${{ vars.LITELLM_URL }}
-          ai_fallback_api_format: ${{ vars.FALLBACK_FORMAT }}
-          ai_fallback_model: ${{ vars.FALLBACK_MODEL }}
+          ai_fallback_api_format: openai
+          ai_fallback_model: gpt-5.6-sol
           ai_fallback_api_key: ${{ secrets.LITELLM_API_KEY }}
           ai_max_tokens: "32768"
           review_routing_mode: auto
           ai_smart_base_url: ${{ vars.LITELLM_URL }}
-          ai_smart_api_format: ${{ vars.SMART_FORMAT }}
-          ai_smart_model: ${{ vars.SMART_MODEL }}
+          ai_smart_api_format: openai
+          ai_smart_model: gpt-5.6-sol
           ai_smart_api_key: ${{ secrets.LITELLM_API_KEY }}
           context_limit_mode: normal
           ci_status_check: "true"
@@ -73,8 +74,11 @@ jobs:
           tool_allowed_gh_api_repos: misospace/pr-reviewer-action
           tool_request_timeout_sec: "15"
           tool_enable_for_forks: "false"
+          linear_enable_for_forks: "false"
+          evidence_enable_for_forks: "false"
           on_model_failure: notice
           inline_findings: "true"
           verdict_policy: findings_severity_gated
           publish_mode: review_verdict
           allow_approve: "true"
+          approve_forks: "false"

--- a/README.md
+++ b/README.md
@@ -747,7 +747,7 @@ jobs:
 ```
 
 > [!NOTE]
-> This workflow requires the **Allow GitHub Actions to create and approve pull requests** setting to be enabled for your repository or organization. Without it, native approvals will fail with a 403 error even though `pull-requests: write` is granted.
+> This workflow requires the **Allow GitHub Actions to create and approve pull requests** setting to be enabled for your repository or organization. Without it, the action publishes the clean result as an advisory `COMMENT`; it never converts a failed approval into `REQUEST_CHANGES`.
 
 This configuration allows the AI to submit native approvals when its verdict is `approve`. Fork PRs are still blocked from approval unless `approve_forks` is also set to `"true"`.
 
@@ -763,7 +763,7 @@ Even when your workflow grants `pull-requests: write`, native PR review verdicts
 
 3. **Fork PRs without `approve_forks: true`** — Approvals from fork PRs are blocked by default unless `approve_forks` is explicitly set to `"true"`.
 
-When approval is blocked, the action always submits a `request_changes` verdict with an explanation in the review body rather than failing silently.
+When a clean verdict cannot be approved because of these guardrails, the action submits a non-blocking `COMMENT` review with an explanation. A real model `request_changes` verdict remains a native blocking review.
 
 ### 💬 Non-blocking review comments
 

--- a/action.yml
+++ b/action.yml
@@ -648,6 +648,7 @@ runs:
         FORGEJO_TOKEN: ${{ inputs.forgejo_token || inputs.github_token }}
         REPO: ${{ inputs.repo || github.repository }}
         PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
+        EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha || '' }}
         COMMENT_MARKER: ${{ inputs.comment_marker }}
         PUBLISH_MODE: ${{ inputs.publish_mode }}
         REVIEW_SCOPE: ${{ inputs.review_scope }}
@@ -734,8 +735,36 @@ runs:
         CI_CHECKS_FILE: ${{ runner.temp }}/ci-checks-context.md
       run: bash "${{ github.action_path }}/scripts/wait_for_ci.sh"
 
-    - name: Run AI review
+    - name: Verify pull request head is still current
+      id: head_check
       if: steps.precheck.outputs.should_review == 'true'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github_token }}
+        PLATFORM: ${{ steps.precheck.outputs.resolved_platform }}
+        FORGEJO_API_URL: ${{ steps.precheck.outputs.effective_forgejo_api_url }}
+        FORGEJO_TOKEN: ${{ inputs.forgejo_token || inputs.github_token }}
+        REPO: ${{ inputs.repo || github.repository }}
+        PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
+        EXPECTED_HEAD_SHA: ${{ steps.precheck.outputs.head_sha }}
+        GITHUB_ACTION_PATH: ${{ github.action_path }}
+      run: |
+        set -euo pipefail
+        set +e
+        bash "${GITHUB_ACTION_PATH}/scripts/verify_pr_head.sh"
+        VERIFY_RC=$?
+        set -e
+        case "$VERIFY_RC" in
+          0) echo "current=true" >> "$GITHUB_OUTPUT" ;;
+          3)
+            echo "current=false" >> "$GITHUB_OUTPUT"
+            echo "::notice title=AI review skipped::A newer pull request head superseded this run before model invocation."
+            ;;
+          *) exit "$VERIFY_RC" ;;
+        esac
+
+    - name: Run AI review
+      if: steps.precheck.outputs.should_review == 'true' && steps.head_check.outputs.current == 'true'
       id: review
       shell: bash
       env:
@@ -845,7 +874,7 @@ runs:
       # block makes a duplicate-key manifest error structurally impossible.
       # All per-mode inline `${{ }}` expressions are hoisted into env so the
       # run body is pure bash dispatching on $PUBLISH_MODE.
-      if: steps.precheck.outputs.should_review == 'true' && (inputs.publish_mode == 'review_comment' || inputs.publish_mode == 'review_verdict' || (inputs.publish_mode == 'comment' && inputs.publish_review_comment == 'true'))
+      if: steps.precheck.outputs.should_review == 'true' && steps.head_check.outputs.current == 'true' && (inputs.publish_mode == 'review_comment' || inputs.publish_mode == 'review_verdict' || (inputs.publish_mode == 'comment' && inputs.publish_review_comment == 'true'))
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.github_token }}
@@ -882,6 +911,22 @@ runs:
       run: |
         set -euo pipefail
         source "${GITHUB_ACTION_PATH}/scripts/publish_helpers.sh"
+
+        # The model can run for minutes. Re-check at the publication boundary so
+        # no comment, request-changes review, or approval can target a newer head.
+        export EXPECTED_HEAD_SHA="$HEAD_SHA"
+        set +e
+        bash "${GITHUB_ACTION_PATH}/scripts/verify_pr_head.sh"
+        VERIFY_RC=$?
+        set -e
+        case "$VERIFY_RC" in
+          0) ;;
+          3)
+            echo "::notice title=AI review not published::A newer pull request head superseded the commit reviewed by this run."
+            exit 0
+            ;;
+          *) exit "$VERIFY_RC" ;;
+        esac
 
         case "$PUBLISH_MODE" in
           comment)
@@ -1091,8 +1136,8 @@ runs:
             submit_native_review() {
               local event="$1" body_file="$2"
               if [ -n "$COMMENTS_JSON" ] && [ "$COMMENTS_JSON" != "[]" ]; then
-                jq -n --rawfile body "$body_file" --arg event "$event" --argjson comments "$COMMENTS_JSON" \
-                  '{body: $body, event: $event, comments: $comments}' > review-request.json
+                jq -n --rawfile body "$body_file" --arg event "$event" --arg commit_id "$HEAD_SHA" --argjson comments "$COMMENTS_JSON" \
+                  '{body: $body, event: $event, commit_id: $commit_id, comments: $comments}' > review-request.json
                 if platform_review_create_json "$REPO" "$PR_NUMBER" review-request.json >/dev/null 2>&1; then
                   echo "Submitted native review ($event) with $(printf '%s' "$COMMENTS_JSON" | jq 'length') inline comment(s)"
                   return 0
@@ -1100,42 +1145,48 @@ runs:
                 echo "WARN: inline-comment review submission failed; falling back to plain review" >&2
               fi
               case "$event" in
-                APPROVE) platform_review_native "$REPO" "$PR_NUMBER" APPROVE "$body_file" ;;
-                *) platform_review_native "$REPO" "$PR_NUMBER" REQUEST_CHANGES "$body_file" ;;
+                APPROVE|REQUEST_CHANGES|COMMENT)
+                  jq -n --rawfile body "$body_file" --arg event "$event" --arg commit_id "$HEAD_SHA" \
+                    '{body: $body, event: $event, commit_id: $commit_id}' > review-request.json
+                  platform_review_create_json "$REPO" "$PR_NUMBER" review-request.json ;;
+                *)
+                  echo "Unsupported native review event: $event" >&2
+                  return 2 ;;
               esac
             }
 
             if [ "$CAN_APPROVE" = true ]; then
               echo "Submitting native approval for #$PR_NUMBER"
               if ! submit_native_review APPROVE "$BODY_FILE" 2>&1; then
-                echo "ERROR: Native approval failed for #$PR_NUMBER." >&2
-                echo "This may be caused by the 'Allow GitHub Actions to create and approve pull requests' setting being disabled." >&2
-                echo "Enable this setting at: Repository Settings → Actions → General → Allow GitHub Actions to create and approve pull requests" >&2
-                echo "Or at the organization level: Organization Settings → Actions → Organization permissions → Allow GitHub Actions to create and approve pull requests" >&2
-                exit 1
+                echo "WARN: Native approval failed for #$PR_NUMBER; publishing the clean verdict as an advisory COMMENT instead." >&2
+                {
+                  echo ""
+                  echo "> **Approval withheld**: the platform rejected native approval. This clean review is advisory and does not satisfy an approval requirement."
+                } >> "$BODY_FILE"
+                submit_native_review COMMENT "$BODY_FILE"
               fi
             else
-              # Block approval: submit request_changes with explanation
-              echo "Blocking native approval for #$PR_NUMBER (allow_approve=${ALLOW_APPROVE_BOOL}, approve_forks=${APPROVE_FORKS_BOOL}, is_fork=${IS_FORK_PR})"
-
               if [ "$VERDICT" = "request_changes" ]; then
+                echo "Submitting blocking findings for #$PR_NUMBER"
                 submit_native_review REQUEST_CHANGES "$BODY_FILE"
               else
-                # The review approved but a guardrail blocked native approval —
-                # explain the actual reason.
+                # A clean verdict withheld by policy remains advisory. Turning it
+                # into REQUEST_CHANGES would invent a blocker the model did not
+                # find, especially for forks where approvals are intentionally off.
+                echo "Withholding native approval for #$PR_NUMBER (allow_approve=${ALLOW_APPROVE_BOOL}, approve_forks=${APPROVE_FORKS_BOOL}, is_fork=${IS_FORK_PR})"
                 if [ "$EFFECTIVE_SCOPE" = "incremental" ] && [ "$BASELINE_CLEAN" != "true" ]; then
                   {
                     echo ""
-                    echo "> **Approval withheld**: the previous review of this PR found blocking issues. This review's verdict is approve, but native approval is withheld until a review against a clean baseline confirms the PR as a whole."
+                    echo "> **Approval withheld**: the previous review of this PR found blocking issues. This clean incremental review is advisory until a full review against a clean baseline confirms the PR as a whole."
                   } >> "$BODY_FILE"
                 else
                   {
                     echo ""
-                    echo "> **Approval blocked by policy**: native approvals require \`allow_approve: true\` (and \`approve_forks: true\` for cross-repository PRs)."
+                    echo "> **Approval blocked by policy**: this clean review is advisory. Native approvals require \`allow_approve: true\` and, for cross-repository PRs, \`approve_forks: true\`."
                   } >> "$BODY_FILE"
                 fi
 
-                submit_native_review REQUEST_CHANGES "$BODY_FILE"
+                submit_native_review COMMENT "$BODY_FILE"
               fi
             fi
             ;;

--- a/pr_reviewer/forgejo_backend.py
+++ b/pr_reviewer/forgejo_backend.py
@@ -27,8 +27,16 @@ import os
 import re
 import subprocess
 import sys
+from pathlib import Path
 from typing import Any
 from urllib.parse import quote
+
+# Reuse the action's shared credential redactor for all remote diagnostics.
+_SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+from redact import mask_secrets  # noqa: E402
 
 # Top-level import is safe: platform.py imports forgejo_backend only lazily
 # (inside _gh_api_forgejo), so there is no import cycle in this direction.
@@ -194,6 +202,83 @@ def _json_decode(text: str) -> Any:
         return json.loads(text)
     except (json.JSONDecodeError, ValueError):
         return None
+
+
+def _report_http_error(operation: str, status_code: int, body_text: str) -> None:
+    """Emit a useful error without echoing arbitrary response fields or secrets."""
+    data = _json_decode(body_text)
+    message = data.get("message") if isinstance(data, dict) else None
+    if isinstance(message, str):
+        message = mask_secrets(re.sub(r"[\x00-\x1f\x7f]", " ", message).strip())[:300]
+    detail = f": {message}" if message else ""
+    print(f"Forgejo {operation} failed (HTTP {status_code}){detail}", file=sys.stderr)
+
+
+# ---------------------------------------------------------------------------
+# Repository access preflight
+# ---------------------------------------------------------------------------
+
+def probe_review_publication_access(
+    repo_full_name: str,
+    pr_number: int,
+    head_sha: str,
+) -> bool:
+    """Prove the token can publish reviews without leaving a visible review.
+
+    Forgejo PAT scopes are independent of repository membership. A transient
+    pending review exercises the same repository-write API as final native
+    publication, is bound to the current head, and is immediately deleted.
+    """
+    owner, repo = _parse_repo(repo_full_name)
+    if not _is_forgejo_mode() or not head_sha:
+        return False
+
+    review_url = f"{FORGEJO_API_URL}/api/v1/repos/{owner}/{repo}/pulls/{pr_number}/reviews"
+    status_code, body_text = _curl(
+        "POST",
+        review_url,
+        data={
+            "event": "PENDING",
+            "body": "AI review publication capability preflight; safe to delete.",
+            "commit_id": head_sha,
+        },
+    )
+    data = _json_decode(body_text)
+    review_id = data.get("id") if status_code in (200, 201) and isinstance(data, dict) else None
+    if not isinstance(review_id, int) or review_id <= 0:
+        _report_http_error("publication capability preflight", status_code, body_text)
+        return False
+
+    delete_status, delete_body = _curl("DELETE", f"{review_url}/{review_id}")
+    if delete_status != 204:
+        _report_http_error("publication capability preflight cleanup", delete_status, delete_body)
+        return False
+    return True
+
+
+def get_authenticated_repo_permission(repo_full_name: str) -> str | None:
+    """Return the active Forgejo token's repository permission."""
+    owner, repo = _parse_repo(repo_full_name)
+    if not _is_forgejo_mode():
+        return None
+
+    status_code, body_text = _curl("GET", f"{FORGEJO_API_URL}/api/v1/user")
+    user = _json_decode(body_text)
+    login = user.get("login") if status_code == 200 and isinstance(user, dict) else None
+    if not isinstance(login, str) or not login:
+        _report_http_error("review access preflight", status_code, body_text)
+        return None
+
+    status_code, body_text = _curl(
+        "GET",
+        f"{FORGEJO_API_URL}/api/v1/repos/{owner}/{repo}/collaborators/{quote(login, safe='')}/permission",
+    )
+    data = _json_decode(body_text)
+    permission = data.get("permission") if status_code == 200 and isinstance(data, dict) else None
+    if permission not in {"read", "write", "admin"}:
+        _report_http_error("review access preflight", status_code, body_text)
+        return None
+    return str(permission)
 
 
 # ---------------------------------------------------------------------------
@@ -789,6 +874,9 @@ def create_pr_review_from_payload(
             "body": str(payload.get("body") or ""),
             "event": _forgejo_review_event(str(payload.get("event") or "COMMENT")),
         }
+        commit_id = payload.get("commit_id")
+        if isinstance(commit_id, str) and commit_id:
+            request["commit_id"] = commit_id
         comments = _normalise_review_comment_positions(repo_full_name, pr_number, payload.get("comments"))
         if comments:
             request["comments"] = comments
@@ -798,6 +886,7 @@ def create_pr_review_from_payload(
             data=request,
         )
         if status_code not in (200, 201):
+            _report_http_error("review publication", status_code, body_text)
             return None
         data = _json_decode(body_text)
         return data if isinstance(data, dict) else {"id": 0, "body": request["body"]}
@@ -969,6 +1058,14 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Forgejo backend CLI")
     sub = parser.add_subparsers(dest="command")
 
+    p_permission = sub.add_parser("repo-permission")
+    p_permission.add_argument("repo")
+
+    p_probe = sub.add_parser("probe-review-publication")
+    p_probe.add_argument("repo")
+    p_probe.add_argument("pr_number", type=int)
+    p_probe.add_argument("head_sha")
+
     p_meta = sub.add_parser("get-pr-metadata")
     p_meta.add_argument("repo")
     p_meta.add_argument("pr_number", type=int)
@@ -1040,7 +1137,16 @@ def main() -> None:
 
     args = parser.parse_args()
 
-    if args.command == "get-pr-metadata":
+    if args.command == "repo-permission":
+        result = get_authenticated_repo_permission(args.repo)
+        print(result or "none")
+        if result is None:
+            sys.exit(1)
+    elif args.command == "probe-review-publication":
+        if not probe_review_publication_access(args.repo, args.pr_number, args.head_sha):
+            sys.exit(1)
+        print("ok")
+    elif args.command == "get-pr-metadata":
         result = get_pr_metadata(args.repo, args.pr_number)
         print(json.dumps(result, indent=2) if result else "null")
     elif args.command == "get-pr-diff":

--- a/scripts/check_review_needed.sh
+++ b/scripts/check_review_needed.sh
@@ -526,13 +526,59 @@ fi
 # Get the current PR object once. This is the single PR-object fetch point for
 # the whole action: the head/base SHAs drive scope resolution here, and the
 # object is saved to pr-object.json so run_review.sh (and the publish steps,
-# via the is_fork_pr output) do not have to fetch it again.
+# via the is_fork_pr output) do not have to fetch it again. An inaccessible PR
+# is a configuration/access error: continuing would spend model tokens on data
+# that cannot be safely classified or published.
 if ! platform_pr_get "$REPO" "$PR_NUMBER" > pr-object.json 2>/dev/null; then
-  echo '{}' > pr-object.json
+  echo "ERROR: Could not fetch pull request $REPO#$PR_NUMBER; verify the review token has repository read access." >&2
+  exit 1
 fi
 CURRENT_HEAD_SHA="$(jq -r '.head.sha // ""' pr-object.json 2>/dev/null || echo "")"
 CURRENT_BASE_SHA="$(jq -r '.base.sha // ""' pr-object.json 2>/dev/null || echo "")"
+if [[ -z "$CURRENT_HEAD_SHA" || -z "$CURRENT_BASE_SHA" ]] || ! jq -e '.head.repo.full_name and .base.repo.full_name' pr-object.json >/dev/null 2>&1; then
+  echo "ERROR: Could not fetch a complete pull request object for $REPO#$PR_NUMBER; verify repository access before reviewing." >&2
+  exit 1
+fi
+
+# Forgejo exposes the authenticated user's effective repository permission.
+# Require write access before model invocation because every supported publish
+# mode needs to create or update PR content. GitHub App/GITHUB_TOKEN permissions
+# are unit-scoped and cannot be inferred from GitHub's coarse repo permission;
+# approval rejection there is handled by the advisory-COMMENT fallback.
+if [[ "$RESOLVED_PLATFORM" == "forgejo" ]]; then
+  REPO_PERMISSION="$(platform_authenticated_repo_permission "$REPO" 2>/dev/null || true)"
+  if [[ "$REPO_PERMISSION" != "write" && "$REPO_PERMISSION" != "admin" ]]; then
+    echo "ERROR: Review token lacks Forgejo write permission for $REPO; refusing to invoke a model that cannot publish its result." >&2
+    exit 1
+  fi
+  if ! platform_probe_review_publication "$REPO" "$PR_NUMBER" "$CURRENT_HEAD_SHA"; then
+    echo "ERROR: Forgejo token could not create and clean up a pending review for $REPO; verify its repository-write scope before invoking the model." >&2
+    exit 1
+  fi
+fi
+
 IS_FORK_PR="$(derive_is_fork_pr pr-object.json)"
+
+# A queued synchronize run can start after a newer push. The event head is the
+# immutable work item this run was created for; do not spend on it once Forgejo
+# or GitHub reports a different current head.
+if [[ -n "${EVENT_HEAD_SHA:-}" && "$EVENT_HEAD_SHA" != "$CURRENT_HEAD_SHA" ]]; then
+  echo "Skipping superseded review event: event head $EVENT_HEAD_SHA is no longer current." >&2
+  {
+    echo "effective_review_scope=full"
+    echo "previous_head_sha="
+    echo "baseline_clean=false"
+    echo "head_sha=$CURRENT_HEAD_SHA"
+    echo "base_sha=$CURRENT_BASE_SHA"
+    echo "is_fork_pr=$IS_FORK_PR"
+    echo "diff_fingerprint=$broad_fingerprint"
+    echo "should_review=false"
+    echo "skip_reason=superseded-head"
+    echo "resolved_platform=$RESOLVED_PLATFORM"
+    echo "effective_forgejo_api_url=$EFFECTIVE_FORGEJO_API_URL"
+  } >> "$OUTPUT_FILE"
+  exit 0
+fi
 
 # Resolve effective review scope
 resolve_review_scope "$REVIEW_SCOPE" "$LAST_HEAD_SHA" "$LAST_BASE_SHA" \

--- a/scripts/platform_api.sh
+++ b/scripts/platform_api.sh
@@ -120,6 +120,26 @@ _forgejo_jq() {
 
 # ── Core PR I/O ─────────────────────────────────────────────────────────
 
+platform_authenticated_repo_permission() {
+  # $1=repo → read|write|admin. Forgejo-only: GitHub token permissions are
+  # unit-scoped and cannot be inferred safely from the coarse repo permission.
+  if _platform_is_forgejo; then
+    _forgejo_py repo-permission "$1"
+  else
+    echo "unknown"
+  fi
+}
+
+platform_probe_review_publication() {
+  # $1=repo $2=pr_number $3=head_sha. Forgejo-only transient pending-review
+  # probe that verifies the PAT's repository-write scope and then deletes it.
+  if _platform_is_forgejo; then
+    _forgejo_py probe-review-publication "$1" "$2" "$3" >/dev/null
+  else
+    return 0
+  fi
+}
+
 platform_pr_get() {
   # $1=repo $2=pr_number [extra gh api flags, e.g. --jq] → PR object
   # (GitHub REST shape, or the --jq projection) on stdout
@@ -221,13 +241,15 @@ platform_review_create_json() {
 }
 
 platform_review_native() {
-  # $1=repo $2=pr_number $3=APPROVE|REQUEST_CHANGES $4=body_file
+  # $1=repo $2=pr_number $3=APPROVE|REQUEST_CHANGES|COMMENT $4=body_file
   if _platform_is_forgejo; then
     _forgejo_py create-native-review "$1" "$2" "$3" "$4"
   else
     case "$3" in
-      APPROVE) gh pr review "$2" --repo "$1" --approve --body-file "$4" ;;
-      *)       gh pr review "$2" --repo "$1" --request-changes --body-file "$4" ;;
+      APPROVE)         gh pr review "$2" --repo "$1" --approve --body-file "$4" ;;
+      REQUEST_CHANGES) gh pr review "$2" --repo "$1" --request-changes --body-file "$4" ;;
+      COMMENT)         gh pr review "$2" --repo "$1" --comment --body-file "$4" ;;
+      *) echo "Unsupported native review event: $3" >&2; return 2 ;;
     esac
   fi
 }

--- a/scripts/verify_pr_head.sh
+++ b/scripts/verify_pr_head.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Fail closed when the pull request head no longer matches the reviewed commit.
+# Exit 0=current, 2=unavailable/error, 3=superseded.
+set -euo pipefail
+
+: "${GITHUB_ACTION_PATH:?GITHUB_ACTION_PATH is required}"
+: "${REPO:?REPO is required}"
+: "${PR_NUMBER:?PR_NUMBER is required}"
+: "${EXPECTED_HEAD_SHA:?EXPECTED_HEAD_SHA is required}"
+
+# shellcheck source=platform_api.sh
+source "${GITHUB_ACTION_PATH}/scripts/platform_api.sh"
+
+CURRENT_HEAD_SHA="$(platform_pr_head_sha "$REPO" "$PR_NUMBER" 2>/dev/null || true)"
+if [[ -z "$CURRENT_HEAD_SHA" ]]; then
+  echo "ERROR: Could not re-fetch the current pull request head; refusing to publish a potentially stale review." >&2
+  exit 2
+fi
+if [[ "$CURRENT_HEAD_SHA" != "$EXPECTED_HEAD_SHA" ]]; then
+  echo "A newer pull request head superseded reviewed commit $EXPECTED_HEAD_SHA; no review will be published." >&2
+  exit 3
+fi

--- a/tests/smoke_test.sh
+++ b/tests/smoke_test.sh
@@ -504,13 +504,13 @@ fi
 if [ "$CAN_APPROVE" = true ]; then
   COMMAND_BLOCKED="gh pr review 123 --repo owner/repo --approve --body-file $TMPDIR/review-verdict-body.md"
 else
-  COMMAND_BLOCKED="gh pr review 123 --repo owner/repo --request-changes --body-file $TMPDIR/review-verdict-body.md"
+  COMMAND_BLOCKED="gh pr review 123 --repo owner/repo --comment --body-file $TMPDIR/review-verdict-body.md"
 fi
 
-if echo "$COMMAND_BLOCKED" | grep -q '\-\-request-changes'; then
-  check "approve blocked when allow_approve=false uses --request-changes" "PASS" "PASS"
+if echo "$COMMAND_BLOCKED" | grep -q '\-\-comment'; then
+  check "approve blocked when allow_approve=false uses advisory comment" "PASS" "PASS"
 else
-  check "approve blocked when allow_approve=false uses --request-changes" "FAIL" "PASS"
+  check "approve blocked when allow_approve=false uses advisory comment" "FAIL" "PASS"
 fi
 
 echo ""
@@ -533,13 +533,13 @@ fi
 if [ "$CAN_APPROVE" = true ]; then
   COMMAND_FORK_BLOCKED="gh pr review 123 --repo owner/repo --approve --body-file $TMPDIR/review-verdict-body.md"
 else
-  COMMAND_FORK_BLOCKED="gh pr review 123 --repo owner/repo --request-changes --body-file $TMPDIR/review-verdict-body.md"
+  COMMAND_FORK_BLOCKED="gh pr review 123 --repo owner/repo --comment --body-file $TMPDIR/review-verdict-body.md"
 fi
 
-if echo "$COMMAND_FORK_BLOCKED" | grep -q '\-\-request-changes'; then
-  check "fork approval blocked when approve_forks=false uses --request-changes" "PASS" "PASS"
+if echo "$COMMAND_FORK_BLOCKED" | grep -q '\-\-comment'; then
+  check "fork approval blocked when approve_forks=false uses advisory comment" "PASS" "PASS"
 else
-  check "fork approval blocked when approve_forks=false uses --request-changes" "FAIL" "PASS"
+  check "fork approval blocked when approve_forks=false uses advisory comment" "FAIL" "PASS"
 fi
 
 echo ""

--- a/tests/test_approval_guardrails.sh
+++ b/tests/test_approval_guardrails.sh
@@ -98,19 +98,22 @@ check_exists "action.yml has the publish dispatcher step" \
 check_exists "action.yml dispatches the review_verdict publish mode" \
   "$(grep -c '^          review_verdict)' "$ACTION_YML" || echo 0)"
 
-# The native-review invocations route through the platform seam (#221):
-# action.yml calls platform_review_native, whose github backend holds the
-# actual `gh pr review --approve/--request-changes` command lines.
-PLATFORM_SEAM="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/scripts/platform_api.sh"
+# Native reviews use the JSON publication seam so every event can be bound to
+# the reviewed commit SHA on both GitHub and Forgejo.
+check_exists "action.yml routes approve through the native review helper" \
+  "$(grep -c 'submit_native_review APPROVE' "$ACTION_YML" || echo 0)"
 
-check_exists "action.yml routes approve through the seam" \
-  "$(grep -c 'platform_review_native "\$REPO" "\$PR_NUMBER" APPROVE' "$ACTION_YML" || echo 0)"
+check_exists "native review payload is commit-bound" \
+  "$(grep -c "commit_id: \\\$commit_id" "$ACTION_YML" || echo 0)"
 
-check_exists "seam github backend has gh pr review approve" \
-  "$(grep -c 'gh pr review.*--approve' "$PLATFORM_SEAM" || echo 0)"
+check_exists "native reviews use the JSON publication seam" \
+  "$(grep -c 'platform_review_create_json.*review-request.json' "$ACTION_YML" || echo 0)"
 
-check_exists "seam github backend has gh pr review request-changes" \
-  "$(grep -c 'gh pr review.*--request-changes' "$PLATFORM_SEAM" || echo 0)"
+check_exists "publication boundary rechecks the PR head" \
+  "$(grep -c 'scripts/verify_pr_head.sh' "$ACTION_YML" || echo 0)"
+
+check_exists "policy-withheld clean verdict publishes COMMENT" \
+  "$(grep -c 'submit_native_review COMMENT' "$ACTION_YML" || echo 0)"
 
 echo ""
 echo "=== README.md documentation validation ==="

--- a/tests/test_check_review_needed.sh
+++ b/tests/test_check_review_needed.sh
@@ -31,6 +31,8 @@ TMPDIR="$(mktemp -d)"
 trap 'rm -rf "$TMPDIR"' EXIT
 
 mkdir -p "$TMPDIR/bin"
+REAL_PYTHON3="$(command -v python3)"
+export REAL_PYTHON3
 
 FIXED_DIFF='diff --git a/x b/x
 index 123..456 644
@@ -61,6 +63,28 @@ esac
 exit 0
 SHELLEOF
 chmod +x "$TMPDIR/bin/gh"
+
+cat > "$TMPDIR/bin/python3" <<'SHELLEOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-m" && "${2:-}" == "pr_reviewer.forgejo_backend" ]]; then
+  case "${3:-}" in
+    list-comments|list-pr-reviews) printf '[]\n' ;;
+    get-pr-diff) cat /tmp/testfp_diff ;;
+    get-pr-metadata) cat /tmp/testfp_pr_object.json ;;
+    repo-permission)
+      printf '%s\n' "${TEST_FORGEJO_PERMISSION:-none}"
+      [[ "${TEST_FORGEJO_PERMISSION:-none}" != "none" ]]
+      ;;
+    probe-review-publication)
+      [[ "${TEST_FORGEJO_PROBE:-fail}" == "pass" ]]
+      ;;
+    *) echo "unexpected Forgejo test command: ${3:-}" >&2; exit 1 ;;
+  esac
+  exit $?
+fi
+exec "$REAL_PYTHON3" "$@"
+SHELLEOF
+chmod +x "$TMPDIR/bin/python3"
 
 cat > /tmp/testfp_pr_object.json <<'JSONEOF'
 {
@@ -122,6 +146,7 @@ run_precheck() {
     REREVIEW_LABEL="${REREVIEW_LABEL:-ai-review}" \
     GITHUB_EVENT_NAME="${GITHUB_EVENT_NAME:-}" \
     GITHUB_EVENT_PATH="${GITHUB_EVENT_PATH:-}" \
+    EVENT_HEAD_SHA="${EVENT_HEAD_SHA:-}" \
     COMMENT_MARKER="${COMMENT_MARKER:-<!-- ai-pr-reviewer -->}" \
     PUBLISH_MODE="${PUBLISH_MODE:-comment}" \
     bash "$PRECHECK_SCRIPT"
@@ -383,9 +408,9 @@ set_empty_comments
 RESULT="$(run_precheck)"
 check "fork PR forwards is_fork_pr=true" "$(echo "$RESULT" | grep '^is_fork_pr=' | head -1 | cut -d= -f2)" "true"
 
-# ── Test 16: missing head.repo → fail closed (treated as fork) ───────
+# ── Test 16: incomplete fork metadata is an access error ─────────────
 echo ""
-echo "=== Test 16: missing head.repo metadata → is_fork_pr=true (fail closed) ==="
+echo "=== Test 16: missing head.repo metadata fails before model use ==="
 cat > /tmp/testfp_pr_object.json <<'JSONEOF'
 {
   "number": 42,
@@ -394,18 +419,25 @@ cat > /tmp/testfp_pr_object.json <<'JSONEOF'
 }
 JSONEOF
 set_empty_comments
-RESULT="$(run_precheck)"
-check "missing head.repo fails closed to is_fork_pr=true" "$(echo "$RESULT" | grep '^is_fork_pr=' | head -1 | cut -d= -f2)" "true"
+if run_precheck >/tmp/testfp_incomplete_precheck.out 2>&1; then
+  check "missing head.repo fails precheck" "success" "failure"
+else
+  check "missing head.repo fails precheck" "failure" "failure"
+fi
 
-# ── Test 17: degraded/empty PR object → fail closed ──────────────────
+# ── Test 17: degraded/empty PR object fails before model use ─────────
 echo ""
-echo "=== Test 17: empty PR object (degraded fetch) → is_fork_pr=true (fail closed) ==="
+echo "=== Test 17: empty PR object is an access/configuration error ==="
 cat > /tmp/testfp_pr_object.json <<'JSONEOF'
 {}
 JSONEOF
 set_empty_comments
-RESULT="$(run_precheck)"
-check "empty PR object fails closed to is_fork_pr=true" "$(echo "$RESULT" | grep '^is_fork_pr=' | head -1 | cut -d= -f2)" "true"
+if run_precheck >/tmp/testfp_failed_precheck.out 2>&1; then
+  check "empty PR object fails precheck" "success" "failure"
+else
+  check "empty PR object fails precheck" "failure" "failure"
+  check_contains "failure explains PR access" "$(cat /tmp/testfp_failed_precheck.out)" "Could not fetch a complete pull request object"
+fi
 
 # Restore the default same-repo PR object for any later additions.
 cat > /tmp/testfp_pr_object.json <<'JSONEOF'
@@ -440,6 +472,40 @@ RESULT="$(PLATFORM=auto FORGEJO_API_URL="https://forge.example.com" GITHUB_EVENT
 check "unrelated-label path still emits should_review=false" "$(echo "$RESULT" | grep '^should_review=' | head -1 | cut -d= -f2)" "false"
 check "auto+FORGEJO_API_URL resolves to forgejo" "$(echo "$RESULT" | grep '^resolved_platform=' | head -1 | cut -d= -f2)" "forgejo"
 check "effective_forgejo_api_url forwarded when forgejo" "$(echo "$RESULT" | grep '^effective_forgejo_api_url=' | head -1 | cut -d= -f2-)" "https://forge.example.com"
+
+# Test 20: an event for an old head is skipped before the model step.
+echo ""
+echo "=== Test 20: superseded event head is a no-op ==="
+set_empty_comments
+EVENT_HEAD_SHA="cccc111122223333cccc111122223333cccc1111" RESULT="$(run_precheck)"
+check "superseded head skips review" "$(echo "$RESULT" | grep '^should_review=' | head -1 | cut -d= -f2)" "false"
+check "superseded head has explicit reason" "$(echo "$RESULT" | grep '^skip_reason=' | head -1 | cut -d= -f2)" "superseded-head"
+
+# Tests 21-23: exercise the full Forgejo precheck path. Repository membership
+# and PAT scope are separate: both must pass before model invocation.
+echo ""
+echo "=== Test 21: Forgejo read-only membership fails precheck ==="
+set_empty_comments
+if PLATFORM=forgejo FORGEJO_API_URL="https://forge.example.com" TEST_FORGEJO_PERMISSION=read TEST_FORGEJO_PROBE=pass run_precheck >/tmp/testfp_forgejo_read.out 2>&1; then
+  check "read-only Forgejo membership is rejected" "success" "failure"
+else
+  check "read-only Forgejo membership is rejected" "failure" "failure"
+fi
+
+echo ""
+echo "=== Test 22: Forgejo PAT without publication scope fails precheck ==="
+if PLATFORM=forgejo FORGEJO_API_URL="https://forge.example.com" TEST_FORGEJO_PERMISSION=write TEST_FORGEJO_PROBE=fail run_precheck >/tmp/testfp_forgejo_scope.out 2>&1; then
+  check "write member with insufficient PAT scope is rejected" "success" "failure"
+else
+  check "write member with insufficient PAT scope is rejected" "failure" "failure"
+  check_contains "scope failure is actionable" "$(cat /tmp/testfp_forgejo_scope.out)" "repository-write scope"
+fi
+
+echo ""
+echo "=== Test 23: Forgejo write membership and publication scope pass ==="
+unset EVENT_HEAD_SHA
+RESULT="$(PLATFORM=forgejo FORGEJO_API_URL="https://forge.example.com" TEST_FORGEJO_PERMISSION=write TEST_FORGEJO_PROBE=pass run_precheck)"
+check "Forgejo capability-verified token reviews" "$(echo "$RESULT" | grep '^should_review=' | head -1 | cut -d= -f2)" "true"
 
 echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="

--- a/tests/test_forgejo_backend.py
+++ b/tests/test_forgejo_backend.py
@@ -8,10 +8,12 @@ of the existing fake-gh test suites.
 
 from __future__ import annotations
 
+import io
 import json
 import os
 import sys
 import unittest
+from contextlib import redirect_stderr
 from pathlib import Path
 from typing import Any
 from unittest.mock import Mock, patch
@@ -202,6 +204,73 @@ def _forgejo_env_patch() -> Any:
 # ---------------------------------------------------------------------------
 # Test cases
 # ---------------------------------------------------------------------------
+
+class TestAuthenticatedRepoPermission(unittest.TestCase):
+    @_PATCH_FORGEJO
+    def test_returns_effective_write_permission(self, mock_curl):
+        mock_curl.side_effect = [
+            (200, json.dumps({"login": "review-bot"})),
+            (200, json.dumps({"permission": "write"})),
+        ]
+
+        with _forgejo_env_patch():
+            result = fb.get_authenticated_repo_permission("misospace/pr-reviewer-action")
+
+        self.assertEqual(result, "write")
+        self.assertTrue(mock_curl.call_args_list[1].args[1].endswith("/collaborators/review-bot/permission"))
+
+    @_PATCH_FORGEJO
+    def test_missing_permission_fails_closed_without_printing_response_fields(self, mock_curl):
+        mock_curl.side_effect = [
+            (200, json.dumps({"login": "review-bot"})),
+            (403, json.dumps({"message": "permission denied", "token": "must-not-print"})),
+        ]
+
+        stderr = io.StringIO()
+        with _forgejo_env_patch(), redirect_stderr(stderr):
+            result = fb.get_authenticated_repo_permission("misospace/pr-reviewer-action")
+
+        self.assertIsNone(result)
+        self.assertIn("HTTP 403", stderr.getvalue())
+        self.assertNotIn("must-not-print", stderr.getvalue())
+
+
+class TestReviewPublicationProbe(unittest.TestCase):
+    @_PATCH_FORGEJO
+    def test_pending_review_probe_is_commit_bound_and_deleted(self, mock_curl):
+        calls = []
+
+        def _run(method: str, url: str, **kwargs: Any) -> tuple[int, str]:
+            calls.append((method, url, kwargs))
+            if method == "POST":
+                return 201, json.dumps({"id": 91})
+            if method == "DELETE":
+                return 204, ""
+            self.fail(f"unexpected request: {method} {url}")
+
+        mock_curl.side_effect = _run
+        with _forgejo_env_patch():
+            result = fb.probe_review_publication_access(
+                "misospace/pr-reviewer-action", 42, "abc123def456"
+            )
+
+        self.assertTrue(result)
+        self.assertEqual(calls[0][2]["data"]["event"], "PENDING")
+        self.assertEqual(calls[0][2]["data"]["commit_id"], "abc123def456")
+        self.assertEqual(calls[1][0], "DELETE")
+        self.assertTrue(calls[1][1].endswith("/pulls/42/reviews/91"))
+
+    @_PATCH_FORGEJO
+    def test_probe_fails_when_token_cannot_create_review(self, mock_curl):
+        mock_curl.return_value = (403, json.dumps({"message": "scope denied"}))
+
+        with _forgejo_env_patch(), redirect_stderr(io.StringIO()):
+            result = fb.probe_review_publication_access(
+                "misospace/pr-reviewer-action", 42, "abc123def456"
+            )
+
+        self.assertFalse(result)
+
 
 class TestGetPrMetadata(unittest.TestCase):
     """Test get_pr_metadata with Forgejo fixtures."""
@@ -698,6 +767,7 @@ class TestNativeReviews(unittest.TestCase):
         payload = {
             "body": "review body",
             "event": "REQUEST_CHANGES",
+            "commit_id": "abc123def456",
             "comments": [{"path": "test.txt", "line": 1, "side": "RIGHT", "body": "anchored"}],
         }
 
@@ -709,6 +779,7 @@ class TestNativeReviews(unittest.TestCase):
         data = review_call[2]["data"]
         self.assertEqual(review_call[1], f"{FORGEJO_BASE}/api/v1/repos/misospace/pr-reviewer-action/pulls/42/reviews")
         self.assertEqual(data["event"], "REQUEST_CHANGES")
+        self.assertEqual(data["commit_id"], "abc123def456")
         self.assertEqual(data["comments"], [{"path": "test.txt", "new_position": 2, "body": "anchored"}])
 
     @_PATCH_FORGEJO
@@ -746,6 +817,44 @@ class TestNativeReviews(unittest.TestCase):
 
         self.assertIsNotNone(result)
         self.assertEqual(seen["data"], {"body": "needs work", "event": "REQUEST_CHANGES"})
+
+    @_PATCH_FORGEJO
+    def test_create_native_review_preserves_comment_event(self, mock_curl):
+        seen = {}
+
+        def _run(method: str, url: str, **kwargs: Any) -> tuple[int, str]:
+            seen.update(method=method, url=url, data=kwargs.get("data"))
+            return 201, json.dumps(dict(REVIEW, id=58, state="COMMENT"))
+
+        mock_curl.side_effect = _run
+
+        with _forgejo_env_patch():
+            result = fb.create_native_review("misospace/pr-reviewer-action", 42, "COMMENT", "advisory")
+
+        self.assertIsNotNone(result)
+        self.assertEqual(seen["data"], {"body": "advisory", "event": "COMMENT"})
+
+    @_PATCH_FORGEJO
+    def test_create_native_review_reports_sanitized_http_error(self, mock_curl):
+        mock_curl.return_value = (
+            403,
+            json.dumps(
+                {
+                    "message": "review permission denied; token=must-not-print-secret",
+                    "token": "also-must-not-print",
+                }
+            ),
+        )
+
+        stderr = io.StringIO()
+        with _forgejo_env_patch(), redirect_stderr(stderr):
+            result = fb.create_native_review("misospace/pr-reviewer-action", 42, "COMMENT", "advisory")
+
+        self.assertIsNone(result)
+        self.assertIn("HTTP 403", stderr.getvalue())
+        self.assertIn("review permission denied", stderr.getvalue())
+        self.assertIn("[REDACTED]", stderr.getvalue())
+        self.assertNotIn("must-not-print", stderr.getvalue())
 
     @_PATCH_FORGEJO
     def test_dismiss_review_uses_forgejo_dismissal_endpoint(self, mock_curl):

--- a/tests/test_platform_api.sh
+++ b/tests/test_platform_api.sh
@@ -55,6 +55,12 @@ check "invalid platform errors" "$(echo "$RESULT" | grep -c "unsupported PLATFOR
 
 echo ""
 echo "=== github backend: exact gh argv ==="
+check "platform_authenticated_repo_permission is unknown on github" \
+  "$(run_seam github "" 'platform_authenticated_repo_permission o/r')" \
+  "unknown"
+check "platform_probe_review_publication is a no-op on github" \
+  "$(run_seam github "" 'platform_probe_review_publication o/r 7 abc; echo ok')" \
+  "ok"
 check "platform_pr_get" \
   "$(run_seam github "" 'platform_pr_get o/r 7')" \
   "gh api repos/o/r/pulls/7"
@@ -100,6 +106,9 @@ check "platform_review_native approve" \
 check "platform_review_native request changes" \
   "$(run_seam github "" 'platform_review_native o/r 7 REQUEST_CHANGES body.md')" \
   "gh pr review 7 --repo o/r --request-changes --body-file body.md"
+check "platform_review_native comment" \
+  "$(run_seam github "" 'platform_review_native o/r 7 COMMENT body.md')" \
+  "gh pr review 7 --repo o/r --comment --body-file body.md"
 check "platform_review_dismiss" \
   "$(run_seam github "" 'platform_review_dismiss o/r 7 55 superseded')" \
   "gh api repos/o/r/pulls/7/reviews/55/dismissals --method PUT -f message=superseded --jq .id"
@@ -163,6 +172,12 @@ check "forgejo without FORGEJO_API_URL fails loudly" \
 RESULT="$(run_seam forgejo "" 'platform_graphql -f query=Q')"
 check "unimplemented forgejo op names itself" \
   "$(echo "$RESULT" | grep -c "not yet implemented")" "1"
+RESULT="$(run_seam forgejo "" '_forgejo_py(){ echo "forgejo $*"; }; platform_authenticated_repo_permission o/r' "https://forgejo.example.com")"
+check "forgejo permission preflight uses backend cli" "$RESULT" "forgejo repo-permission o/r"
+RESULT="$(run_seam forgejo "" '_forgejo_py(){ echo "forgejo $*"; }; platform_probe_review_publication o/r 7 abc' "https://forgejo.example.com")"
+check "forgejo publication probe uses backend cli" "$RESULT" ""
+RESULT="$(run_seam forgejo "" '_forgejo_py(){ echo "forgejo $*" >&2; }; platform_probe_review_publication o/r 7 abc' "https://forgejo.example.com" 2>&1)"
+check_contains "forgejo publication probe forwards the reviewed head" "$RESULT" "forgejo probe-review-publication o/r 7 abc"
 RESULT="$(run_seam forgejo "" '_forgejo_py(){ echo "forgejo $*"; }; platform_compare o/r aaa...bbb' "https://forgejo.example.com")"
 check "forgejo compare uses backend cli" "$RESULT" "forgejo compare o/r aaa...bbb"
 # --jq passthrough: the forgejo path applies a trailing --jq to the backend's

--- a/tests/test_verify_pr_head.sh
+++ b/tests/test_verify_pr_head.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+VERIFY_SCRIPT="$ROOT_DIR/scripts/verify_pr_head.sh"
+
+PASS=0
+FAIL=0
+# shellcheck source=_lib/assert.sh
+source "$SCRIPT_DIR/_lib/assert.sh"
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+mkdir -p "$TMPDIR/bin"
+cat > "$TMPDIR/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$*" == "api repos/o/r/pulls/7 --jq .head.sha" ]]; then
+  printf '%s\n' "${TEST_CURRENT_HEAD:-}"
+  exit 0
+fi
+exit 1
+EOF
+chmod +x "$TMPDIR/bin/gh"
+
+run_verify() {
+  PATH="$TMPDIR/bin:$PATH" \
+    PLATFORM=github \
+    REPO=o/r \
+    PR_NUMBER=7 \
+    EXPECTED_HEAD_SHA=abc123 \
+    GITHUB_ACTION_PATH="$ROOT_DIR" \
+    bash "$VERIFY_SCRIPT"
+}
+
+echo "=== current PR head ==="
+TEST_CURRENT_HEAD=abc123 run_verify >/dev/null
+check "current head succeeds" "$?" "0"
+
+echo "=== superseded PR head ==="
+set +e
+TEST_CURRENT_HEAD=def456 run_verify >/dev/null 2>&1
+RC=$?
+set -e
+check "superseded head has distinct no-publication status" "$RC" "3"
+
+echo "=== unavailable PR head ==="
+set +e
+TEST_CURRENT_HEAD= run_verify >/dev/null 2>&1
+RC=$?
+set -e
+check "unavailable head fails closed" "$RC" "2"
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary

- fail before model invocation when Forgejo PR read/publication access is unavailable
- skip superseded PR heads before model use and recheck immediately before publishing
- bind GitHub and Forgejo native reviews to the reviewed commit SHA
- publish a non-blocking advisory `COMMENT` when a clean verdict cannot safely approve
- fall back to an advisory comment if native approval fails
- redact Forgejo publication diagnostics
- standardize the self-review workflow on the released v2.1.7 baseline and low-retry/fork-safe settings

## Why

A private Forgejo consumer spent on model reviews and only then failed publication because its reviewer token lacked repository access. Separately, a push during model execution could allow a verdict generated for an old head to be published against the newer PR, and clean fork reviews withheld from approval were represented as false `REQUEST_CHANGES` verdicts.

## Validation

- `uvx --from pytest pytest tests/ -q`: 1276 passed
- all 29 `tests/test_*.sh` suites passed
- `git diff --check`
- Python compile and shell syntax checks
- consumer/config-service compatibility was validated against the composite action metadata in a separate integration pass

## Rollout

After merge, release the next patch and update immutable consumer pins. Existing v2.1.7 consumers remain compatible.
