### PR TITLE
fix(forgejo): accept owner publication permission

### DIFF
--- a/pr_reviewer/forgejo_backend.py
+++ b/pr_reviewer/forgejo_backend.py
@@ -248,6 +248,10 @@ def get_authenticated_repo_permission(repo_full_name: str) -> str | None:
     )
     data = _json_decode(body_text)
     permission = data.get("permission") if status_code == 200 and isinstance(data, dict) else None
+    # Forgejo reports organization owners as "owner" rather than "admin".
+    # Normalize both to the action's coarse read/write/admin vocabulary.
+    if permission == "owner":
+        return "admin"
     if permission not in {"read", "write", "admin"}:
         _report_http_error("review access preflight", status_code, body_text)
         return None

--- a/pr_reviewer/forgejo_backend.py
+++ b/pr_reviewer/forgejo_backend.py
@@ -248,10 +248,10 @@ def get_authenticated_repo_permission(repo_full_name: str) -> str | None:
     )
     data = _json_decode(body_text)
     permission = data.get("permission") if status_code == 200 and isinstance(data, dict) else None
-    # Forgejo reports organization owners as "owner" rather than "admin".
-    # Normalize both to the action's coarse read/write/admin vocabulary.
+    # Forgejo reports repository/organization owners as "owner" rather than
+    # "admin". Normalize to the action's coarse read/write/admin vocabulary.
     if permission == "owner":
-        return "admin"
+        permission = "admin"
     if permission not in {"read", "write", "admin"}:
         _report_http_error("review access preflight", status_code, body_text)
         return None

--- a/tests/test_forgejo_backend.py
+++ b/tests/test_forgejo_backend.py
@@ -222,6 +222,18 @@ class TestAuthenticatedRepoPermission(unittest.TestCase):
         )
 
     @_PATCH_FORGEJO
+    def test_normalizes_owner_permission_to_admin(self, mock_curl):
+        mock_curl.side_effect = [
+            (200, json.dumps({"login": "repo-owner"})),
+            (200, json.dumps({"permission": "owner", "role_name": "owner"})),
+        ]
+
+        with _forgejo_env_patch():
+            result = fb.get_authenticated_repo_permission("misospace/pr-reviewer-action")
+
+        self.assertEqual(result, "admin")
+
+    @_PATCH_FORGEJO
     def test_permission_denied_fails_closed_with_sanitized_error(self, mock_curl):
         mock_curl.side_effect = [
             (200, json.dumps({"login": "review-bot"})),


### PR DESCRIPTION
## Summary

Normalize Forgejo's `owner` repository permission to `admin` during the publication-access preflight.

## Problem

Forgejo may return `"permission": "owner"` for organization owners. The preflight currently recognizes only `read`, `write`, and `admin`, so a fully authorized organization owner is treated as having unknown permissions and the review exits before model invocation.

## Changes

- Map Forgejo's `owner` permission to the action's existing `admin` permission level.
- Add regression coverage for the organization-owner response.
- Preserve fail-closed behavior for all other unknown permission values.

## Validation

- 1,281 tests passed across the full Python test suite.
- Verified against a live Forgejo organization-owner token: preflight and review publication completed successfully.
