### PR TITLE
ci: dogfood the action via self-repository $/ syntax

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,9 @@
+# actionlint (pinned in ci.yaml) does not yet understand GitHub's
+# self-repository `uses: $/` syntax (2026-07-30 changelog): it parses the spec
+# as {owner}/{repo}@{ref} and reports a missing ref. Scope the ignore to the
+# dogfood workflow only, and delete this block once actionlint learns the
+# syntax.
+paths:
+  .github/workflows/ai-pr-review.yaml:
+    ignore:
+      - 'specifying action "\$/[^"]*" in invalid format because ref is missing'

--- a/.github/workflows/ai-pr-review.yaml
+++ b/.github/workflows/ai-pr-review.yaml
@@ -39,7 +39,14 @@ jobs:
       - name: Review PR with reusable AI reviewer
         if: github.event_name == 'pull_request'
         id: review
-        uses: misospace/pr-reviewer-action@258ac494ff48261cba9a62dce384b35ed73404ba # v2.1.7
+        # Dogfood: `$/` resolves to this repository at the running commit, so
+        # every PR is reviewed by its own in-flight action code instead of the
+        # last release — a PR that breaks the manifest or publish path now
+        # fails its own review before it can ship. Also ends the renovate
+        # self-pin churn. Fork PRs are unchanged: they get no secrets and the
+        # job fails at the app-token step. Requires runner >= 2.336.0
+        # (github.com hosted runners qualify; not available on GHES).
+        uses: $/
         with:
           github_token: ${{ steps.app-token.outputs.token }}
           ai_primary_retries: "3"


### PR DESCRIPTION
## Summary

- Self-review workflow now uses GitHub's new [self-repository syntax](https://github.blog/changelog/2026-07-30-reference-same-repository-actions-with-self-repository-syntax/) (`uses: $/`) instead of pinning `misospace/pr-reviewer-action@<sha>`: every PR is reviewed by its own in-flight action code, so a manifest or publish-path break (like the v1.2.10 duplicate-key incident) fails its own review instead of shipping.
- Adds `.github/actionlint.yaml` with an ignore scoped to this one workflow — actionlint v1.7.12 (and current main) parses `$/` as `{owner}/{repo}@{ref}` and reports "ref is missing". Delete once actionlint supports the syntax.

## Notes

- This ends the Renovate self-pin bump PRs (e.g. #443) — there's no version to bump anymore.
- Fork-PR posture is unchanged: forks get no secrets and fail at the app-token step.
- The docs only show `$/` with a subdirectory path; bare `$/` for a root-level action is the analog of `uses: ./` but unconfirmed — this PR's own AI-review run is the live test. If the job can't resolve it, that failure shows up right here.

## Verification

- `yamllint` key-duplicates check clean; both files parse.
- Runtime behavior of `$/` is validated by this PR's own AI-review job (workflow comes from the merge ref).