### PR TITLE
feat: let system_prompt_file win over system_prompt when both are set (#426)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -241,11 +241,11 @@ inputs:
     required: false
     default: "false"
   system_prompt:
-    description: Optional system prompt override. When combined with system_prompt_file the file is read first and the inline value is appended, so static conventions can live in a file while per-PR steering stays inline.
+    description: Optional system prompt override. When both this and system_prompt_file are set, the file content wins and the inline value is ignored.
     required: false
     default: ""
   system_prompt_file:
-    description: Optional file path in the reviewed repository to use as the system prompt. When combined with system_prompt the file is read first and the inline system_prompt is appended, so static conventions can live in a file while per-PR steering stays inline.
+    description: Optional file path in the reviewed repository to use as the system prompt. When both this and system_prompt are set, the file content wins and the inline system_prompt is ignored.
     required: false
     default: ""
   system_prompt_mode:

--- a/action.yml
+++ b/action.yml
@@ -241,11 +241,11 @@ inputs:
     required: false
     default: "false"
   system_prompt:
-    description: Optional system prompt override
+    description: Optional system prompt override. When combined with system_prompt_file the file is read first and the inline value is appended, so static conventions can live in a file while per-PR steering stays inline.
     required: false
     default: ""
   system_prompt_file:
-    description: Optional file path in the reviewed repository to use as the full system prompt
+    description: Optional file path in the reviewed repository to use as the system prompt. When combined with system_prompt the file is read first and the inline system_prompt is appended, so static conventions can live in a file while per-PR steering stays inline.
     required: false
     default: ""
   system_prompt_mode:

--- a/scripts/check_review_needed.sh
+++ b/scripts/check_review_needed.sh
@@ -129,19 +129,18 @@ compute_config_hash() {
     parts+=("anthropic_version:${ANTHROPIC_VERSION}")
   fi
 
-  # System prompt (inline content or file hash). Inline and file are
-  # independent: when both are set, a change to either invalidates the
-  # fingerprint. Labels are preserved from the prior single-source layout so
-  # fingerprints for single-input configs are unchanged.
-  if [[ -n "${SYSTEM_PROMPT:-}" ]]; then
-    local phash
-    phash="$(printf '%s' "$SYSTEM_PROMPT" | sha256sum | awk '{print $1}')"
-    parts+=("prompt:${phash}")
-  fi
+  # System prompt (inline content or file hash). When both are set, the file
+  # wins so only the file hash is included in the fingerprint. Labels are
+  # preserved from the prior single-source layout so fingerprints for
+  # single-input configs are unchanged.
   if [[ -n "${SYSTEM_PROMPT_FILE:-}" && -f "${SYSTEM_PROMPT_FILE:-}" ]]; then
     local phash
     phash="$(sha256sum "$SYSTEM_PROMPT_FILE" | awk '{print $1}')"
     parts+=("prompt_file:${SYSTEM_PROMPT_FILE}:${phash}")
+  elif [[ -n "${SYSTEM_PROMPT:-}" ]]; then
+    local phash
+    phash="$(printf '%s' "$SYSTEM_PROMPT" | sha256sum | awk '{print $1}')"
+    parts+=("prompt:${phash}")
   fi
 
   # Standards file (resolved or candidate)

--- a/scripts/check_review_needed.sh
+++ b/scripts/check_review_needed.sh
@@ -129,12 +129,16 @@ compute_config_hash() {
     parts+=("anthropic_version:${ANTHROPIC_VERSION}")
   fi
 
-  # System prompt (inline content or file hash)
+  # System prompt (inline content or file hash). Inline and file are
+  # independent: when both are set, a change to either invalidates the
+  # fingerprint. Labels are preserved from the prior single-source layout so
+  # fingerprints for single-input configs are unchanged.
   if [[ -n "${SYSTEM_PROMPT:-}" ]]; then
     local phash
     phash="$(printf '%s' "$SYSTEM_PROMPT" | sha256sum | awk '{print $1}')"
     parts+=("prompt:${phash}")
-  elif [[ -n "${SYSTEM_PROMPT_FILE:-}" && -f "${SYSTEM_PROMPT_FILE:-}" ]]; then
+  fi
+  if [[ -n "${SYSTEM_PROMPT_FILE:-}" && -f "${SYSTEM_PROMPT_FILE:-}" ]]; then
     local phash
     phash="$(sha256sum "$SYSTEM_PROMPT_FILE" | awk '{print $1}')"
     parts+=("prompt_file:${SYSTEM_PROMPT_FILE}:${phash}")

--- a/scripts/sections/config.sh
+++ b/scripts/sections/config.sh
@@ -341,32 +341,19 @@ resolve_standards_file() {
 }
 
 resolve_system_prompt() {
-  # Resolve any user-supplied prompt by combining file + inline, file first
-  # and inline second. The order keeps the static repo conventions (file) as
-  # the base and the per-PR steering (inline) as the most specific instruction
-  # at the end of the prompt. When only one input is set the result is
-  # byte-identical to the prior single-source behavior, so existing configs
-  # that set exactly one of the two are unchanged.
+  # Resolve any user-supplied prompt. When both SYSTEM_PROMPT_FILE and
+  # SYSTEM_PROMPT are set, the file content wins and the inline value is
+  # ignored. This lets a repo keep static conventions in a diffable file while
+  # still allowing per-PR steering via the inline value when only that is set.
   local user=""
-  local -a parts=()
   if [[ -n "$SYSTEM_PROMPT_FILE" ]]; then
     if [[ ! -f "$SYSTEM_PROMPT_FILE" ]]; then
       error "SYSTEM_PROMPT_FILE does not exist: $SYSTEM_PROMPT_FILE"
       exit 1
     fi
-    parts+=("$(<"$SYSTEM_PROMPT_FILE")")
-  fi
-  if [[ -n "$SYSTEM_PROMPT" ]]; then
-    parts+=("$SYSTEM_PROMPT")
-  fi
-  if [[ "${#parts[@]}" -gt 0 ]]; then
-    local joined="" sep=""
-    local p
-    for p in "${parts[@]}"; do
-      joined+="${sep}${p}"
-      sep=$'\n\n'
-    done
-    user="$joined"
+    user="$(<"$SYSTEM_PROMPT_FILE")"
+  elif [[ -n "$SYSTEM_PROMPT" ]]; then
+    user="$SYSTEM_PROMPT"
   fi
 
   # replace mode (default): a supplied prompt is used verbatim — no default,

--- a/scripts/sections/config.sh
+++ b/scripts/sections/config.sh
@@ -341,16 +341,32 @@ resolve_standards_file() {
 }
 
 resolve_system_prompt() {
-  # Resolve any user-supplied prompt (inline takes precedence over file).
+  # Resolve any user-supplied prompt by combining file + inline, file first
+  # and inline second. The order keeps the static repo conventions (file) as
+  # the base and the per-PR steering (inline) as the most specific instruction
+  # at the end of the prompt. When only one input is set the result is
+  # byte-identical to the prior single-source behavior, so existing configs
+  # that set exactly one of the two are unchanged.
   local user=""
-  if [[ -n "$SYSTEM_PROMPT" ]]; then
-    user="$SYSTEM_PROMPT"
-  elif [[ -n "$SYSTEM_PROMPT_FILE" ]]; then
+  local -a parts=()
+  if [[ -n "$SYSTEM_PROMPT_FILE" ]]; then
     if [[ ! -f "$SYSTEM_PROMPT_FILE" ]]; then
       error "SYSTEM_PROMPT_FILE does not exist: $SYSTEM_PROMPT_FILE"
       exit 1
     fi
-    user="$(<"$SYSTEM_PROMPT_FILE")"
+    parts+=("$(<"$SYSTEM_PROMPT_FILE")")
+  fi
+  if [[ -n "$SYSTEM_PROMPT" ]]; then
+    parts+=("$SYSTEM_PROMPT")
+  fi
+  if [[ "${#parts[@]}" -gt 0 ]]; then
+    local joined="" sep=""
+    local p
+    for p in "${parts[@]}"; do
+      joined+="${sep}${p}"
+      sep=$'\n\n'
+    done
+    user="$joined"
   fi
 
   # replace mode (default): a supplied prompt is used verbatim — no default,

--- a/tests/test_system_prompt_fragments.sh
+++ b/tests/test_system_prompt_fragments.sh
@@ -119,6 +119,78 @@ check_contains "append composes the repo addendum on the end" "$OUT" "REPO ADDEN
 check_not_contains "append on app_code still drops irrelevant V3" "$OUT" "HOST PLATFORM"
 check_not_contains "append leaves no unsubstituted placeholder" "$OUT" "{{"
 
+echo "=== resolve_system_prompt combines file + inline when both are set (#426) ==="
+# Static repo conventions live in a file; per-PR steering stays inline. The
+# combined prompt should contain both, file first and inline last, joined by a
+# blank line. With only one input the result must remain byte-identical to the
+# prior single-source behavior.
+TMPF="$(mktemp)"; printf 'STATIC CONVENTIONS FROM FILE' > "$TMPF"
+TMPF_FILE_ONLY="$(mktemp)"; printf 'FILE ONLY SENTINEL' > "$TMPF_FILE_ONLY"
+WORKF="$WORK/CONVENTIONS.md"; printf 'FAKE CONVENTIONS SENTINEL' > "$WORKF"
+
+# Both set: file then inline, joined by a blank line. We run inside a `cd
+# "$WORK"` subshell the same way the existing tests do, with a few extra
+# SAFETY_DEFAULTS to keep `set -u` happy in the isolated subshell.
+run_resolve() {
+  (
+    cd "$WORK"
+    set +u
+    SYSTEM_PROMPT="$1"
+    SYSTEM_PROMPT_FILE="$2"
+    SYSTEM_PROMPT_MODE="replace"
+    SYSTEM_PROMPT_ADDENDUM=""
+    SYSTEM_PROMPT_IS_DEFAULT=0
+    set -u
+    resolve_system_prompt
+    printf '%s' "$SYSTEM_PROMPT"
+  )
+}
+
+OUT_BOTH="$( run_resolve "PER-PR STEERING" "$TMPF" )"
+check_contains "combine keeps the file content" "$OUT_BOTH" "STATIC CONVENTIONS FROM FILE"
+check_contains "combine keeps the inline content" "$OUT_BOTH" "PER-PR STEERING"
+check_contains "combine puts the file before the inline" "$OUT_BOTH" \
+  "STATIC CONVENTIONS FROM FILE
+
+PER-PR STEERING"
+
+# Inline only: unchanged from prior behavior, no file content sneaks in.
+OUT_INLINE_ONLY="$( run_resolve "INLINE ONLY SENTINEL" "" )"
+check_contains "inline-only is unchanged" "$OUT_INLINE_ONLY" "INLINE ONLY SENTINEL"
+
+# File only: unchanged from prior behavior, no synthetic separators added.
+OUT_FILE_ONLY="$( run_resolve "" "$TMPF_FILE_ONLY" )"
+check_contains "file-only is unchanged" "$OUT_FILE_ONLY" "FILE ONLY SENTINEL"
+
+# Missing file is still a hard error even when inline is also set, so a
+# typo in the path doesn't silently fall back to inline-only. The function
+# calls `error` (defined in common.sh) and then `exit 1`, so we stub `error`
+# to record the message and capture the exit status in a subshell.
+ERR_OUT="$( ( cd "$WORK"
+   set +u
+   SYSTEM_PROMPT="PER-PR STEERING" SYSTEM_PROMPT_FILE="/nonexistent/path"
+   SYSTEM_PROMPT_MODE="replace" SYSTEM_PROMPT_ADDENDUM="" SYSTEM_PROMPT_IS_DEFAULT=0
+   set -u
+   error() { echo "ERROR: $*" >&2; }
+   resolve_system_prompt
+ ) 2>&1 )" || true
+check_contains "missing file still errors when inline is also set" "$ERR_OUT" \
+  "SYSTEM_PROMPT_FILE does not exist"
+
+rm -f "$TMPF" "$TMPF_FILE_ONLY"
+
+echo "=== append mode composes the combined file+inline prompt on the default ==="
+OUT="$( cd "$WORK"
+  printf '{"pr_kind":"app_code"}' > classification.json
+  SYSTEM_PROMPT="COMBINED INLINE SENTINEL" SYSTEM_PROMPT_FILE="$WORKF" \
+    SYSTEM_PROMPT_MODE="append" SYSTEM_PROMPT_ADDENDUM="" SYSTEM_PROMPT_IS_DEFAULT=0
+  resolve_system_prompt
+  apply_system_prompt_fragments
+  printf '%s' "$SYSTEM_PROMPT"
+)"
+check_contains "append on file+inline keeps the inline content" "$OUT" "COMBINED INLINE SENTINEL"
+check_contains "append on file+inline keeps the file content" "$OUT" "FAKE CONVENTIONS SENTINEL"
+check_contains "append on file+inline keeps the base output schema" "$OUT" "Return STRICT JSON"
 echo "=== base prompt directs the model to omit unmet conditional sections (#409/#414) ==="
 check_contains "explicit omit-not-filler directive present" "$BASE" "omit the section entirely"
 # Each conditional section's omit instruction is tied to its own trigger

--- a/tests/test_system_prompt_fragments.sh
+++ b/tests/test_system_prompt_fragments.sh
@@ -119,16 +119,15 @@ check_contains "append composes the repo addendum on the end" "$OUT" "REPO ADDEN
 check_not_contains "append on app_code still drops irrelevant V3" "$OUT" "HOST PLATFORM"
 check_not_contains "append leaves no unsubstituted placeholder" "$OUT" "{{"
 
-echo "=== resolve_system_prompt combines file + inline when both are set (#426) ==="
-# Static repo conventions live in a file; per-PR steering stays inline. The
-# combined prompt should contain both, file first and inline last, joined by a
-# blank line. With only one input the result must remain byte-identical to the
-# prior single-source behavior.
+echo "=== resolve_system_prompt: file wins over inline when both are set (#426) ==="
+# When both SYSTEM_PROMPT_FILE and SYSTEM_PROMPT are set, the file content
+# wins and the inline value is ignored. With only one input the result must
+# remain byte-identical to the prior single-source behavior.
 TMPF="$(mktemp)"; printf 'STATIC CONVENTIONS FROM FILE' > "$TMPF"
 TMPF_FILE_ONLY="$(mktemp)"; printf 'FILE ONLY SENTINEL' > "$TMPF_FILE_ONLY"
 WORKF="$WORK/CONVENTIONS.md"; printf 'FAKE CONVENTIONS SENTINEL' > "$WORKF"
 
-# Both set: file then inline, joined by a blank line. We run inside a `cd
+# Both set: file wins, inline is ignored. We run inside a `cd
 # "$WORK"` subshell the same way the existing tests do, with a few extra
 # SAFETY_DEFAULTS to keep `set -u` happy in the isolated subshell.
 run_resolve() {
@@ -147,12 +146,11 @@ run_resolve() {
 }
 
 OUT_BOTH="$( run_resolve "PER-PR STEERING" "$TMPF" )"
-check_contains "combine keeps the file content" "$OUT_BOTH" "STATIC CONVENTIONS FROM FILE"
-check_contains "combine keeps the inline content" "$OUT_BOTH" "PER-PR STEERING"
-check_contains "combine puts the file before the inline" "$OUT_BOTH" \
-  "STATIC CONVENTIONS FROM FILE
-
-PER-PR STEERING"
+check_contains "file wins: keeps the file content" "$OUT_BOTH" "STATIC CONVENTIONS FROM FILE"
+# Inline should be absent when file is set.
+! printf '%s' "$OUT_BOTH" | grep -q "PER-PR STEERING" \
+  && check_contains "file wins: inline is ignored" "$OUT_BOTH" "STATIC CONVENTIONS FROM FILE" \
+  || { echo "FAIL: file wins but inline content leaked through"; FAIL=$((FAIL+1)); }
 
 # Inline only: unchanged from prior behavior, no file content sneaks in.
 OUT_INLINE_ONLY="$( run_resolve "INLINE ONLY SENTINEL" "" )"
@@ -179,7 +177,7 @@ check_contains "missing file still errors when inline is also set" "$ERR_OUT" \
 
 rm -f "$TMPF" "$TMPF_FILE_ONLY"
 
-echo "=== append mode composes the combined file+inline prompt on the default ==="
+echo "=== append mode: file wins over inline, composes file on the default ==="
 OUT="$( cd "$WORK"
   printf '{"pr_kind":"app_code"}' > classification.json
   SYSTEM_PROMPT="COMBINED INLINE SENTINEL" SYSTEM_PROMPT_FILE="$WORKF" \
@@ -188,8 +186,11 @@ OUT="$( cd "$WORK"
   apply_system_prompt_fragments
   printf '%s' "$SYSTEM_PROMPT"
 )"
-check_contains "append on file+inline keeps the inline content" "$OUT" "COMBINED INLINE SENTINEL"
-check_contains "append on file+inline keeps the file content" "$OUT" "FAKE CONVENTIONS SENTINEL"
+# When file is set, inline is ignored even in append mode.
+check_contains "append on file+inline: file content present" "$OUT" "FAKE CONVENTIONS SENTINEL"
+! printf '%s' "$OUT" | grep -q "COMBINED INLINE SENTINEL" \
+  && check_contains "append on file+inline: inline dropped" "$OUT" "FAKE CONVENTIONS SENTINEL" \
+  || { echo "FAIL: append mode but inline content leaked through"; FAIL=$((FAIL+1)); }
 check_contains "append on file+inline keeps the base output schema" "$OUT" "Return STRICT JSON"
 echo "=== base prompt directs the model to omit unmet conditional sections (#409/#414) ==="
 check_contains "explicit omit-not-filler directive present" "$BASE" "omit the section entirely"


### PR DESCRIPTION
## What

Reverses the precedence between `system_prompt` (inline) and `system_prompt_file`: when both are set, the file content now wins and the inline value is ignored. Updates `resolve_system_prompt()` in `scripts/sections/config.sh`, the config-hash fingerprinting in `scrip…

Fixes #426

_Opened by foreman on review GO (workload wl-misospace-pr-reviewer-action-426)._