### PR TITLE
Treat flattened review_markdown from json_schema as a validation failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -987,6 +987,8 @@ ai_response_format: json_schema   # vLLM guided decoding, llama.cpp grammars, ne
 
 If the endpoint rejects the request after enabling this (HTTP 400 mentioning `response_format`), the server does not support that mode — drop back to `json_object` or `off`. Ignored entirely for `ai_api_format: anthropic`.
 
+> **Fireworks / LiteLLM note:** grammar-constrained decoding under `json_schema` can cause some models (e.g. `glm-4p5`, `qwen3-coder`) to under-emit `\n` inside the `review_markdown` string, producing a single-line wall of bolded headings. The action validates that a payload containing multiple `## ` heading markers also contains newlines and will fail such a response into the retry path — but the reliable fix is to use `ai_response_format: json_object` for Fireworks / LiteLLM endpoints.
+
 ### ⏱️ Timeouts, streaming, and retries
 
 - **Slow prompt eval** (big corpus, CPU offload): raise `ai_request_timeout_sec` (default 300). The tool-planning call is non-streaming and has its own `tool_planning_timeout_sec` — raise it too if planning times out.

--- a/pr_reviewer/response_parser.py
+++ b/pr_reviewer/response_parser.py
@@ -364,6 +364,25 @@ def parse_response(response: dict[str, Any]) -> dict[str, Any]:
     if not isinstance(markdown, str) or not markdown.strip():
         raise SystemExit(f"Parsed JSON has empty or missing 'review_markdown'{trunc}")
 
+    # Detect a flattened review_markdown: grammar-constrained decoding under
+    # ai_response_format: json_schema (observed on Fireworks, see issue #447)
+    # can strip the "\n" escapes that markdown formatting requires, producing
+    # a single-line "wall of bolded headings". A well-formed review with
+    # multiple sections always contains newlines; if we see several heading
+    # markers and zero newlines, the payload is not publishable as-is, so we
+    # fail validation and let the retry path kick in (or the user switch to
+    # ai_response_format: json_object).
+    if "\n" not in markdown and markdown.count("## ") >= 2:
+        raise SystemExit(
+            "Parsed JSON 'review_markdown' appears flattened: contains "
+            "multiple '## ' heading markers but no newlines. This is a "
+            "known artefact of grammar-constrained decoding under "
+            "ai_response_format: json_schema (e.g., Fireworks). Retry "
+            "with ai_response_format: json_object or increase "
+            "ai_max_tokens."
+            + trunc
+        )
+
     # Optional structured findings: normalised when present, empty when the
     # model (typically a weaker local one) does not produce them.
     parsed["findings"] = _normalize_findings(parsed.get("findings"))

--- a/tests/test_response_parser.py
+++ b/tests/test_response_parser.py
@@ -236,6 +236,51 @@ class TestParseResponse(TestCase):
             parse_response(resp)
         self.assertIn("empty or missing", str(ctx.exception))
 
+    def test_flattened_review_markdown_multiple_headings_no_newlines(self):
+        # Issue #447: grammar-constrained decoding under
+        # ai_response_format: json_schema (e.g. Fireworks) can strip the
+        # "\\n" escapes that markdown requires, yielding a wall of bolded
+        # headings on a single line. Such a payload is not publishable.
+        inner = json.dumps({
+            "verdict": "request_changes",
+            "review_markdown": (
+                "## Summary This PR looks great overall ## Strengths "
+                "Clean code and good tests ## Concerns Possible "
+                "race condition in worker startup"
+            ),
+        })
+        resp = {"choices": [{"message": {"content": inner}}]}
+        with self.assertRaises(SystemExit) as ctx:
+            parse_response(resp)
+        msg = str(ctx.exception)
+        self.assertIn("flattened", msg)
+        self.assertIn("## ", msg)
+        self.assertIn("json_object", msg)
+
+    def test_single_heading_no_newlines_still_accepted(self):
+        # Only one heading marker -> not flattened; pass through as-is.
+        inner = json.dumps({
+            "verdict": "approve",
+            "review_markdown": "## Summary Looks good to me",
+        })
+        resp = {"choices": [{"message": {"content": inner}}]}
+        result = parse_response(resp)
+        self.assertEqual(result["verdict"], "approve")
+        self.assertEqual(result["review_markdown"], "## Summary Looks good to me")
+
+    def test_multiple_headings_with_newlines_accepted(self):
+        # Well-formed review with proper newlines -> no false positive.
+        inner = json.dumps({
+            "verdict": "approve",
+            "review_markdown": (
+                "## Summary\n\nLooks good.\n\n## Details\n\nNo issues found."
+            ),
+        })
+        resp = {"choices": [{"message": {"content": inner}}]}
+        result = parse_response(resp)
+        self.assertEqual(result["verdict"], "approve")
+        self.assertIn("\n", result["review_markdown"])
+
 
 # ---------------------------------------------------------------------------
 # parse_response_file


### PR DESCRIPTION
## What

Adds a validation guard in `pr_reviewer/response_parser.py` that treats a `review_markdown` containing multiple `## ` heading markers but zero newlines as a parse failure (raising `SystemExit`), so the payload goes through the existing retry path instead of being publ…

Fixes #447

_Opened by foreman on review GO (workload wl-misospace-pr-reviewer-action-447)._