### PR TITLE
fix(prompt): compose inline and file inputs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -241,11 +241,11 @@ inputs:
     required: false
     default: "false"
   system_prompt:
-    description: Optional system prompt override. When both this and system_prompt_file are set, the file content wins and the inline value is ignored.
+    description: Optional system prompt override. When both this and system_prompt_file are set, the file content is read first and the inline value is appended (separated by two newlines), combining static repo conventions with per-PR steering.
     required: false
     default: ""
   system_prompt_file:
-    description: Optional file path in the reviewed repository to use as the system prompt. When both this and system_prompt are set, the file content wins and the inline system_prompt is ignored.
+    description: Optional file path in the reviewed repository to use as the system prompt. When both this and system_prompt are set, the file content is read first and the inline system_prompt is appended (separated by two newlines).
     required: false
     default: ""
   system_prompt_mode:

--- a/scripts/check_review_needed.sh
+++ b/scripts/check_review_needed.sh
@@ -129,14 +129,19 @@ compute_config_hash() {
     parts+=("anthropic_version:${ANTHROPIC_VERSION}")
   fi
 
-  # System prompt (inline content or file hash). When both are set, the file
-  # wins so only the file hash is included in the fingerprint. Labels are
-  # preserved from the prior single-source layout so fingerprints for
-  # single-input configs are unchanged.
+  # System prompt (inline content and/or file hash). When both are set, both
+  # hashes are included so a change to either source invalidates the review.
+  # Labels are preserved from the prior single-source layout so fingerprints
+  # for single-input configs are unchanged.
   if [[ -n "${SYSTEM_PROMPT_FILE:-}" && -f "${SYSTEM_PROMPT_FILE:-}" ]]; then
     local phash
     phash="$(sha256sum "$SYSTEM_PROMPT_FILE" | awk '{print $1}')"
     parts+=("prompt_file:${SYSTEM_PROMPT_FILE}:${phash}")
+    if [[ -n "${SYSTEM_PROMPT:-}" ]]; then
+      local ihash
+      ihash="$(printf '%s' "$SYSTEM_PROMPT" | sha256sum | awk '{print $1}')"
+      parts+=("prompt:${ihash}")
+    fi
   elif [[ -n "${SYSTEM_PROMPT:-}" ]]; then
     local phash
     phash="$(printf '%s' "$SYSTEM_PROMPT" | sha256sum | awk '{print $1}')"

--- a/scripts/run_tool_harness.py
+++ b/scripts/run_tool_harness.py
@@ -390,16 +390,25 @@ _SUMMARIZER_SYSTEM = (
 def resolve_review_system_prompt():
     """Resolve the reviewer system prompt for the native-loop verdict turn.
 
-    Mirrors run_review.sh's resolve_system_prompt (SYSTEM_PROMPT env, then
-    SYSTEM_PROMPT_FILE, then the bundled default) so the in-conversation verdict
-    is graded under the same reviewer instructions as the standard review call.
+    Bash's run_review.sh already assembles SYSTEM_PROMPT (substituting
+    placeholders, composing file+inline when both are set, and exporting the
+    result). Trust that assembled value directly — re-reading the file here
+    would double-compose it.
+
+    Only fall back to reading file+inline when SYSTEM_PROMPT is absent: this
+    handles direct Python invocations (e.g. standalone smoke tests) where bash
+    never ran the assembly step. Falls back to the bundled default otherwise.
     """
-    inline = os.getenv("SYSTEM_PROMPT", "")
-    if inline.strip():
-        return inline
+    raw = os.getenv("SYSTEM_PROMPT", "")
+    if raw.strip():
+        return raw
     prompt_file = os.getenv("SYSTEM_PROMPT_FILE", "").strip()
     if prompt_file and Path(prompt_file).is_file():
-        return Path(prompt_file).read_text(encoding="utf-8")
+        file_text = Path(prompt_file).read_text(encoding="utf-8")
+        raw_inline = os.getenv("SYSTEM_PROMPT", "")
+        if raw_inline.strip():
+            return file_text + "\n\n" + raw_inline
+        return file_text
     default = _SCRIPTS_DIR / "default_system_prompt.txt"
     try:
         text = default.read_text(encoding="utf-8")

--- a/scripts/sections/config.sh
+++ b/scripts/sections/config.sh
@@ -342,9 +342,10 @@ resolve_standards_file() {
 
 resolve_system_prompt() {
   # Resolve any user-supplied prompt. When both SYSTEM_PROMPT_FILE and
-  # SYSTEM_PROMPT are set, the file content wins and the inline value is
-  # ignored. This lets a repo keep static conventions in a diffable file while
-  # still allowing per-PR steering via the inline value when only that is set.
+  # SYSTEM_PROMPT are set, the file content is read first and the inline value
+  # is concatenated after (separated by two newlines), so a repo can keep
+  # static conventions in a diffable file while still allowing per-PR steering
+  # via the inline value. A missing configured file remains a hard error.
   local user=""
   if [[ -n "$SYSTEM_PROMPT_FILE" ]]; then
     if [[ ! -f "$SYSTEM_PROMPT_FILE" ]]; then
@@ -352,6 +353,9 @@ resolve_system_prompt() {
       exit 1
     fi
     user="$(<"$SYSTEM_PROMPT_FILE")"
+    if [[ -n "$SYSTEM_PROMPT" ]]; then
+      user="${user}"$'\n\n'"${SYSTEM_PROMPT}"
+    fi
   elif [[ -n "$SYSTEM_PROMPT" ]]; then
     user="$SYSTEM_PROMPT"
   fi

--- a/tests/test_system_prompt_fragments.sh
+++ b/tests/test_system_prompt_fragments.sh
@@ -119,24 +119,23 @@ check_contains "append composes the repo addendum on the end" "$OUT" "REPO ADDEN
 check_not_contains "append on app_code still drops irrelevant V3" "$OUT" "HOST PLATFORM"
 check_not_contains "append leaves no unsubstituted placeholder" "$OUT" "{{"
 
-echo "=== resolve_system_prompt: file wins over inline when both are set (#426) ==="
-# When both SYSTEM_PROMPT_FILE and SYSTEM_PROMPT are set, the file content
-# wins and the inline value is ignored. With only one input the result must
-# remain byte-identical to the prior single-source behavior.
+echo "=== resolve_system_prompt: file + inline are concatenated when both are set (#426) ==="
+# When both SYSTEM_PROMPT_FILE and SYSTEM_PROMPT are set, the file content is
+# read first and the inline value is appended after two newlines. With only one
+# input the result must remain byte-identical to the prior single-source
+# behavior.
 TMPF="$(mktemp)"; printf 'STATIC CONVENTIONS FROM FILE' > "$TMPF"
 TMPF_FILE_ONLY="$(mktemp)"; printf 'FILE ONLY SENTINEL' > "$TMPF_FILE_ONLY"
 WORKF="$WORK/CONVENTIONS.md"; printf 'FAKE CONVENTIONS SENTINEL' > "$WORKF"
 
-# Both set: file wins, inline is ignored. We run inside a `cd
-# "$WORK"` subshell the same way the existing tests do, with a few extra
-# SAFETY_DEFAULTS to keep `set -u` happy in the isolated subshell.
+# Both set: file first, then inline, separated by two newlines.
 run_resolve() {
   (
     cd "$WORK"
     set +u
     SYSTEM_PROMPT="$1"
     SYSTEM_PROMPT_FILE="$2"
-    SYSTEM_PROMPT_MODE="replace"
+    SYSTEM_PROMPT_MODE="$3"
     SYSTEM_PROMPT_ADDENDUM=""
     SYSTEM_PROMPT_IS_DEFAULT=0
     set -u
@@ -145,19 +144,27 @@ run_resolve() {
   )
 }
 
-OUT_BOTH="$( run_resolve "PER-PR STEERING" "$TMPF" )"
-check_contains "file wins: keeps the file content" "$OUT_BOTH" "STATIC CONVENTIONS FROM FILE"
-# Inline should be absent when file is set.
-! printf '%s' "$OUT_BOTH" | grep -q "PER-PR STEERING" \
-  && check_contains "file wins: inline is ignored" "$OUT_BOTH" "STATIC CONVENTIONS FROM FILE" \
-  || { echo "FAIL: file wins but inline content leaked through"; FAIL=$((FAIL+1)); }
+OUT_BOTH="$( run_resolve "PER-PR STEERING" "$TMPF" "replace" )"
+check_contains "both set: keeps the file content" "$OUT_BOTH" "STATIC CONVENTIONS FROM FILE"
+check_contains "both set: keeps the inline content" "$OUT_BOTH" "PER-PR STEERING"
+# Ordering: file content must appear before inline content.
+FILE_POS="$(printf '%s' "$OUT_BOTH" | grep -bo "STATIC CONVENTIONS FROM FILE" | head -1 | cut -d: -f1)"
+INLINE_POS="$(printf '%s' "$OUT_BOTH" | grep -bo "PER-PR STEERING" | head -1 | cut -d: -f1)"
+if [[ -n "$FILE_POS" && -n "$INLINE_POS" && "$FILE_POS" -lt "$INLINE_POS" ]]; then
+  check_contains "both set: file content precedes inline" "$OUT_BOTH" "STATIC CONVENTIONS FROM FILE"
+else
+  echo "FAIL: file content does not precede inline content (file_pos=$FILE_POS, inline_pos=$INLINE_POS)"
+  FAIL=$((FAIL+1))
+fi
+# Separator: exactly two newlines between file and inline content.
+check_contains "both set: separated by two newlines" "$OUT_BOTH" "STATIC CONVENTIONS FROM FILE"$'\n\n'"PER-PR STEERING"
 
 # Inline only: unchanged from prior behavior, no file content sneaks in.
-OUT_INLINE_ONLY="$( run_resolve "INLINE ONLY SENTINEL" "" )"
+OUT_INLINE_ONLY="$( run_resolve "INLINE ONLY SENTINEL" "" "replace" )"
 check_contains "inline-only is unchanged" "$OUT_INLINE_ONLY" "INLINE ONLY SENTINEL"
 
 # File only: unchanged from prior behavior, no synthetic separators added.
-OUT_FILE_ONLY="$( run_resolve "" "$TMPF_FILE_ONLY" )"
+OUT_FILE_ONLY="$( run_resolve "" "$TMPF_FILE_ONLY" "replace" )"
 check_contains "file-only is unchanged" "$OUT_FILE_ONLY" "FILE ONLY SENTINEL"
 
 # Missing file is still a hard error even when inline is also set, so a
@@ -177,7 +184,7 @@ check_contains "missing file still errors when inline is also set" "$ERR_OUT" \
 
 rm -f "$TMPF" "$TMPF_FILE_ONLY"
 
-echo "=== append mode: file wins over inline, composes file on the default ==="
+echo "=== append mode: file + inline are concatenated, then composed onto the default ==="
 OUT="$( cd "$WORK"
   printf '{"pr_kind":"app_code"}' > classification.json
   SYSTEM_PROMPT="COMBINED INLINE SENTINEL" SYSTEM_PROMPT_FILE="$WORKF" \
@@ -186,12 +193,60 @@ OUT="$( cd "$WORK"
   apply_system_prompt_fragments
   printf '%s' "$SYSTEM_PROMPT"
 )"
-# When file is set, inline is ignored even in append mode.
+# Both file and inline content are present, file before inline.
 check_contains "append on file+inline: file content present" "$OUT" "FAKE CONVENTIONS SENTINEL"
-! printf '%s' "$OUT" | grep -q "COMBINED INLINE SENTINEL" \
-  && check_contains "append on file+inline: inline dropped" "$OUT" "FAKE CONVENTIONS SENTINEL" \
-  || { echo "FAIL: append mode but inline content leaked through"; FAIL=$((FAIL+1)); }
+check_contains "append on file+inline: inline content present" "$OUT" "COMBINED INLINE SENTINEL"
+FILE_POS="$(printf '%s' "$OUT" | grep -bo "FAKE CONVENTIONS SENTINEL" | head -1 | cut -d: -f1)"
+INLINE_POS="$(printf '%s' "$OUT" | grep -bo "COMBINED INLINE SENTINEL" | head -1 | cut -d: -f1)"
+if [[ -n "$FILE_POS" && -n "$INLINE_POS" && "$FILE_POS" -lt "$INLINE_POS" ]]; then
+  check_contains "append on file+inline: file content precedes inline" "$OUT" "FAKE CONVENTIONS SENTINEL"
+else
+  echo "FAIL: append mode file content does not precede inline (file_pos=$FILE_POS, inline_pos=$INLINE_POS)"
+  FAIL=$((FAIL+1))
+fi
 check_contains "append on file+inline keeps the base output schema" "$OUT" "Return STRICT JSON"
+
+echo "=== fingerprint includes both sources when both are set (#426) ==="
+# Extract compute_config_hash from check_review_needed.sh for fingerprint tests.
+CFUNCS="$(mktemp)"
+python3 - "$SCRIPT_DIR/check_review_needed.sh" "$CFUNCS" <<'PY'
+import re, sys
+src = open(sys.argv[1]).read()
+m = re.search(r"^compute_config_hash\(\) \{\n(.*?)\n\}", src, re.S | re.M)
+if not m:
+    sys.exit("could not extract compute_config_hash")
+open(sys.argv[2], "w").write("compute_config_hash() {\n%s\n}\n" % m.group(1))
+PY
+# shellcheck source=/dev/null
+source "$CFUNCS"; rm -f "$CFUNCS"
+
+TMPF_FP="$(mktemp)"; printf 'FILE CONTENT FOR FP' > "$TMPF_FP"
+
+# Both set: fingerprint must differ from file-only and inline-only.
+FP_BOTH="$(SYSTEM_PROMPT="INLINE FOR FP" SYSTEM_PROMPT_FILE="$TMPF_FP" compute_config_hash)"
+FP_FILE_ONLY="$(SYSTEM_PROMPT="" SYSTEM_PROMPT_FILE="$TMPF_FP" compute_config_hash)"
+FP_INLINE_ONLY="$(SYSTEM_PROMPT="INLINE FOR FP" SYSTEM_PROMPT_FILE="" compute_config_hash)"
+if [[ "$FP_BOTH" != "$FP_FILE_ONLY" && "$FP_BOTH" != "$FP_INLINE_ONLY" \
+   && "$FP_FILE_ONLY" != "$FP_INLINE_ONLY" ]]; then
+  echo "PASS: fingerprint differs across both/file-only/inline-only"
+  PASS=$((PASS+1))
+else
+  echo "FAIL: fingerprint did not distinguish sources (both=$FP_BOTH file=$FP_FILE_ONLY inline=$FP_INLINE_ONLY)"
+  FAIL=$((FAIL+1))
+fi
+
+# Changing the inline content changes the combined fingerprint.
+FP_BOTH_ALT="$(SYSTEM_PROMPT="DIFFERENT INLINE" SYSTEM_PROMPT_FILE="$TMPF_FP" compute_config_hash)"
+if [[ "$FP_BOTH" != "$FP_BOTH_ALT" ]]; then
+  echo "PASS: changing inline content changes the combined fingerprint"
+  PASS=$((PASS+1))
+else
+  echo "FAIL: changing inline content did not change the combined fingerprint"
+  FAIL=$((FAIL+1))
+fi
+
+rm -f "$TMPF_FP"
+
 echo "=== base prompt directs the model to omit unmet conditional sections (#409/#414) ==="
 check_contains "explicit omit-not-filler directive present" "$BASE" "omit the section entirely"
 # Each conditional section's omit instruction is tied to its own trigger

--- a/tests/test_tool_harness_status.py
+++ b/tests/test_tool_harness_status.py
@@ -587,8 +587,102 @@ def test_enforcement_fixture_no_successes():
 # ---------------------------------------------------------------------------
 
 # ---------------------------------------------------------------------------
-# Main
 # ---------------------------------------------------------------------------
+# resolve_review_system_prompt — env-first assembled prompt, defensive fallback
+# ---------------------------------------------------------------------------
+
+def test_system_prompt_env_first_no_double_compose(tmp_path):
+    """When bash exports an assembled SYSTEM_PROMPT, Python trusts it verbatim.
+
+    The production double-composition bug: both SYSTEM_PROMPT and
+    SYSTEM_PROMPT_FILE were set, but Python re-read the file and concatenated
+    inline on top — producing a prompt that contained the file content twice
+    (once from bash's assembly, once from Python's re-read).
+
+    The fix is env-first: if SYSTEM_PROMPT is non-empty, return it immediately.
+    Only fall back to file+inline when SYSTEM_PROMPT is absent (defensive direct
+    invocation for standalone tests).
+    """
+    if str(_SCRIPTS_DIR) not in sys.path:
+        sys.path.insert(0, str(_SCRIPTS_DIR))
+    from run_tool_harness import resolve_review_system_prompt
+
+    file_path = tmp_path / "system_prompt.txt"
+    file_path.write_text("FILE CONTENT HERE")
+
+    # Case 1: SYSTEM_PROMPT set alone → returned verbatim
+    env = {"SYSTEM_PROMPT": "ASSEMBLED BY BASH", "SYSTEM_PROMPT_FILE": ""}
+    with mock.patch.dict(os.environ, env, clear=False):
+        result = resolve_review_system_prompt()
+    assert result == "ASSEMBLED BY BASH"
+
+    # Case 2: Both SYSTEM_PROMPT and SYSTEM_PROMPT_FILE set → SYSTEM_PROMPT wins
+    # (no file re-read, no concatenation)
+    env = {
+        "SYSTEM_PROMPT": "ASSEMBLED BY BASH",
+        "SYSTEM_PROMPT_FILE": str(file_path),
+    }
+    with mock.patch.dict(os.environ, env, clear=False):
+        result = resolve_review_system_prompt()
+    assert result == "ASSEMBLED BY BASH"
+    assert file_path.read_text() not in result
+
+    # Case 3: Only SYSTEM_PROMPT_FILE set (defensive direct invocation) → file read
+    env = {"SYSTEM_PROMPT": "", "SYSTEM_PROMPT_FILE": str(file_path)}
+    with mock.patch.dict(os.environ, env, clear=False):
+        result = resolve_review_system_prompt()
+    assert result == "FILE CONTENT HERE"
+
+    # Case 4: Only SYSTEM_PROMPT set (defensive direct invocation) → inline returned
+    env = {"SYSTEM_PROMPT": "INLINE ONLY", "SYSTEM_PROMPT_FILE": ""}
+    with mock.patch.dict(os.environ, env, clear=False):
+        result = resolve_review_system_prompt()
+    assert result == "INLINE ONLY"
+
+    # Case 5: Neither set → falls back to bundled default (non-empty)
+    env = {"SYSTEM_PROMPT": "", "SYSTEM_PROMPT_FILE": ""}
+    with mock.patch.dict(os.environ, env, clear=False):
+        result = resolve_review_system_prompt()
+    assert isinstance(result, str)
+    assert len(result) > 0
+
+
+def test_system_prompt_preserves_raw_whitespace(tmp_path):
+    """SYSTEM_PROMPT with leading/trailing whitespace must be returned verbatim.
+
+    Bash's resolve_system_prompt() uses SYSTEM_PROMPT verbatim (no strip) when
+    composing the user prompt (config.sh:360, :357), so an operator who sets
+    ``SYSTEM_PROMPT="  hello  \""` intends those spaces to reach the model.
+    Returning stripped would silently alter the review contract — a regression
+    if Python ever re-strips the value.
+    """
+    if str(_SCRIPTS_DIR) not in sys.path:
+        sys.path.insert(0, str(_SCRIPTS_DIR))
+    from run_tool_harness import resolve_review_system_prompt
+
+    # Case 1: leading + trailing whitespace preserved verbatim
+    env = {"SYSTEM_PROMPT": "  hello  ", "SYSTEM_PROMPT_FILE": ""}
+    with mock.patch.dict(os.environ, env, clear=False):
+        result = resolve_review_system_prompt()
+    assert result == "  hello  ", f"Expected raw whitespace preserved, got: {result!r}"
+
+    # Case 2: file + inline where inline has leading whitespace → SYSTEM_PROMPT wins verbatim
+    file_path = tmp_path / "system_prompt.txt"
+    file_path.write_text("FILE CONTENT")
+    env = {
+        "SYSTEM_PROMPT": "  INLINE  ",
+        "SYSTEM_PROMPT_FILE": str(file_path),
+    }
+    with mock.patch.dict(os.environ, env, clear=False):
+        result = resolve_review_system_prompt()
+    assert result == "  INLINE  ", f"Expected raw SYSTEM_PROMPT preserved, got: {result!r}"
+
+    # Case 3: blank-only value (e.g. "   ") must NOT be treated as set — falls through to file
+    env = {"SYSTEM_PROMPT": "   ", "SYSTEM_PROMPT_FILE": str(file_path)}
+    with mock.patch.dict(os.environ, env, clear=False):
+        result = resolve_review_system_prompt()
+    assert result == "FILE CONTENT", f"Expected file-only for blank-only SYSTEM_PROMPT, got: {result!r}"
+
 
 def main():
     tests = [
@@ -623,6 +717,8 @@ def main():
         ("enforcement fixture no successes", test_enforcement_fixture_no_successes),
         ("integration all tools fail", test_integration_all_tools_fail),
         ("integration mixed success/failure", test_integration_mixed_success_and_failure),
+        ("system_prompt env-first no double compose", test_system_prompt_env_first_no_double_compose),
+        ("system_prompt preserves raw whitespace", test_system_prompt_preserves_raw_whitespace),
     ]
 
     passed = 0


### PR DESCRIPTION
Issue #426 currently resolves `system_prompt_file` and `system_prompt` exclusively, so one half of a repo's review guidance is silently discarded. This composes the file first and inline prompt second, preserves replace/append behavior, fingerprints both sources, and keeps the native-loop verdict path aligned with the already-assembled prompt.

Focused shell tests and the full Python suite pass.