### PR TITLE
fix(parser): recover verdict from reasoning-model prose

### DIFF
--- a/pr_reviewer/response_parser.py
+++ b/pr_reviewer/response_parser.py
@@ -133,10 +133,12 @@ def _try_decode_json(text: str) -> Any | None:
     each decoded value so the interior of an array is never re-scanned),
     then prefers the one that looks like the verdict object.  Reasoning
     models routed through an OpenAI-compatible proxy frequently emit
-    thinking prose in ``content`` carrying a valid but irrelevant JSON
-    array (a findings draft, a list of candidate verdicts) *before* the
-    real verdict object; the verdict is always a ``dict``, so a ``dict``
-    is preferred over a ``list``.
+    thinking prose in ``content`` carrying valid but irrelevant JSON — an
+    array, or a *partial* verdict draft like ``{"verdict": "approve"}`` —
+    *before* the real verdict object. So a complete verdict dict (both
+    ``verdict`` and ``review_markdown`` keys) is preferred over a partial
+    one, and where several complete verdicts exist the *last* wins (the
+    real answer is conventionally the final JSON the model emits).
 
     If the raw scan finds nothing, retries with raw newlines inside string
     values escaped — the most common failure shape for models that emit
@@ -153,9 +155,11 @@ def _try_decode_json(text: str) -> Any | None:
         # through an OpenAI-compatible proxy (e.g. DeepSeek V4 Flash via
         # litellm) often emit thinking prose in ``content`` that contains a
         # valid but irrelevant JSON array — a findings draft, a list of
-        # candidate verdicts, a checklist — *before* the real verdict
-        # object. Returning the first decodable value grabs that array, so
-        # the verdict (always a dict) is preferred over a list.
+        # candidate verdicts, a checklist — or a *partial* verdict draft
+        # (``{"verdict": "approve"}`` with no ``review_markdown``) before
+        # the real verdict object. Returning the first decodable value grabs
+        # that, so below we prefer a complete verdict dict (both keys) and,
+        # among complete ones, the last (the real final answer).
         candidates: list[Any] = []
         i = 0
         while i < len(source):
@@ -174,25 +178,36 @@ def _try_decode_json(text: str) -> Any | None:
             i += consumed
         if not candidates:
             return None
-        # Prefer a dict that looks like the verdict (canonical keys): a
-        # thinking preamble can draft an ancillary object (a schema example)
-        # ahead of the real verdict. Caveat: if two dicts both carry the
-        # verdict keys, the earliest wins — reasoning prose that drafts a
-        # *sample* verdict ahead of the real one will be mis-picked. Full
-        # schema-aware disambiguation isn't worth it; the alternative
-        # (failing the parse entirely) is strictly worse, and all output is
-        # still re-validated downstream in ``parse_response``.
+        # Pick the most verdict-like candidate. Reasoning models route
+        # thinking through ``content`` and frequently draft sample or
+        # *partial* verdict objects (e.g. ``{"verdict": "approve"}`` with
+        # no ``review_markdown``) in their preamble before emitting the real
+        # final answer at the end. Preference, in priority order:
+        #   1. the LAST dict carrying BOTH required keys — the real verdict;
+        #      a later complete verdict beats an earlier sample draft,
+        #   2. the LAST dict carrying either key — closest to the answer; a
+        #      partial draft that fails validation downstream to retry,
+        #   3. the first dict of any shape,
+        #   4. the first list (a single-item wrapper is unwrapped by
+        #      ``parse_response``).
+        complete: list[Any] = []
+        partial: list[Any] = []
         for cand in candidates:
-            if isinstance(cand, dict) and (
-                "verdict" in cand or "review_markdown" in cand
-            ):
-                return cand
-        # Fall back to the first dict of any shape.
+            if not isinstance(cand, dict):
+                continue
+            has_v = "verdict" in cand
+            has_m = "review_markdown" in cand
+            if has_v and has_m:
+                complete.append(cand)
+            elif has_v or has_m:
+                partial.append(cand)
+        if complete:
+            return complete[-1]
+        if partial:
+            return partial[-1]
         for cand in candidates:
             if isinstance(cand, dict):
                 return cand
-        # Only return a list when no dict exists; a single-item list
-        # wrapping a verdict is unwrapped by ``parse_response``.
         for cand in candidates:
             if isinstance(cand, list):
                 return cand

--- a/pr_reviewer/response_parser.py
+++ b/pr_reviewer/response_parser.py
@@ -129,9 +129,14 @@ def _escape_raw_newlines_in_strings(text: str) -> str:
 def _try_decode_json(text: str) -> Any | None:
     """Attempt to decode a JSON object/list from *text*.
 
-    Scans character-by-character for the first ``{`` or ``[`` and tries to
-    parse from there, stopping at the first successful decode.  This mirrors
-    the shell script's ``for start in range(len(text))`` loop.
+    Collects every *top-level* JSON value found in *text* (skipping past
+    each decoded value so the interior of an array is never re-scanned),
+    then prefers the one that looks like the verdict object.  Reasoning
+    models routed through an OpenAI-compatible proxy frequently emit
+    thinking prose in ``content`` carrying a valid but irrelevant JSON
+    array (a findings draft, a list of candidate verdicts) *before* the
+    real verdict object; the verdict is always a ``dict``, so a ``dict``
+    is preferred over a ``list``.
 
     If the raw scan finds nothing, retries with raw newlines inside string
     values escaped — the most common failure shape for models that emit
@@ -141,14 +146,56 @@ def _try_decode_json(text: str) -> Any | None:
     decoder = json.JSONDecoder()
 
     def _scan(source: str) -> Any | None:
-        for i, ch in enumerate(source):
+        # Collect every *top-level* JSON value in order, advancing past
+        # each decoded value so the interior of an array is never re-scanned
+        # (a nested {"verdict": ...} inside a findings array must not
+        # masquerade as the top-level verdict). Reasoning models routed
+        # through an OpenAI-compatible proxy (e.g. DeepSeek V4 Flash via
+        # litellm) often emit thinking prose in ``content`` that contains a
+        # valid but irrelevant JSON array — a findings draft, a list of
+        # candidate verdicts, a checklist — *before* the real verdict
+        # object. Returning the first decodable value grabs that array, so
+        # the verdict (always a dict) is preferred over a list.
+        candidates: list[Any] = []
+        i = 0
+        while i < len(source):
+            ch = source[i]
             if ch not in ("{", "["):
+                i += 1
                 continue
             try:
-                obj, _end = decoder.raw_decode(source[i:])
-                return obj
+                obj, consumed = decoder.raw_decode(source[i:])
             except json.JSONDecodeError:
+                i += 1
                 continue
+            candidates.append(obj)
+            # raw_decode always consumes >= 1 char (it raises on empty
+            # input), so this advances the cursor unconditionally.
+            i += consumed
+        if not candidates:
+            return None
+        # Prefer a dict that looks like the verdict (canonical keys): a
+        # thinking preamble can draft an ancillary object (a schema example)
+        # ahead of the real verdict. Caveat: if two dicts both carry the
+        # verdict keys, the earliest wins — reasoning prose that drafts a
+        # *sample* verdict ahead of the real one will be mis-picked. Full
+        # schema-aware disambiguation isn't worth it; the alternative
+        # (failing the parse entirely) is strictly worse, and all output is
+        # still re-validated downstream in ``parse_response``.
+        for cand in candidates:
+            if isinstance(cand, dict) and (
+                "verdict" in cand or "review_markdown" in cand
+            ):
+                return cand
+        # Fall back to the first dict of any shape.
+        for cand in candidates:
+            if isinstance(cand, dict):
+                return cand
+        # Only return a list when no dict exists; a single-item list
+        # wrapping a verdict is unwrapped by ``parse_response``.
+        for cand in candidates:
+            if isinstance(cand, list):
+                return cand
         return None
 
     parsed = _scan(text)

--- a/tests/test_response_parser.py
+++ b/tests/test_response_parser.py
@@ -179,6 +179,54 @@ class TestTryDecodeJson(TestCase):
         result = _try_decode_json("Here is the answer: {\"key\": \"value\"}")
         self.assertEqual(result, {"key": "value"})
 
+    def test_reasoning_array_before_object(self):
+        """A reasoning model (e.g. dsv4f via litellm) folds thinking prose
+        into ``content``. That prose may contain a valid JSON array ahead
+        of the verdict object. The scanner must skip the array and recover
+        the verdict object rather than returning the array (#dsv4f)."""
+        src = (
+            'Let me weigh the verdicts: ["approve", "request_changes"]. '
+            'Now the answer: {"verdict": "approve", "review_markdown": "# OK"}'
+        )
+        result = _try_decode_json(src)
+        self.assertIsInstance(result, dict)
+        self.assertEqual(result["verdict"], "approve")
+
+    def test_findings_array_before_object(self):
+        """Thinking that drafts a findings list (a JSON array of dicts)
+        must not shadow the verdict object that follows."""
+        src = (
+            'Draft findings: [{"message": "x"}, {"message": "y"}] '
+            'Final: {"verdict": "request_changes", "review_markdown": "fix"}'
+        )
+        result = _try_decode_json(src)
+        self.assertIsInstance(result, dict)
+        self.assertEqual(result["verdict"], "request_changes")
+
+    def test_array_containing_verdict_dict_not_peeked(self):
+        """Hardest skip-past case: a preamble array that itself holds a
+        verdict-shaped dict, followed by the real verdict. The scanner must
+        treat the array as opaque (advance past it) and NOT pluck the
+        interior verdict dict out of the array."""
+        src = (
+            'Draft: [{"verdict": "approve", "review_markdown": "draft"}] '
+            'Real: {"verdict": "request_changes", "review_markdown": "real"}'
+        )
+        result = _try_decode_json(src)
+        self.assertIsInstance(result, dict)
+        self.assertEqual(result["verdict"], "request_changes")
+        self.assertEqual(result["review_markdown"], "real")
+
+    def test_stray_dict_before_verdict_dict(self):
+        """Preamble that drafts a non-verdict object must lose to the
+        verdict-shaped object that follows."""
+        src = (
+            'Notes: {"analysis": "diff is small and safe"} '
+            'Real answer: {"verdict": "approve", "review_markdown": "# OK"}'
+        )
+        result = _try_decode_json(src)
+        self.assertEqual(result.get("review_markdown"), "# OK")
+
     def test_no_json(self):
         self.assertIsNone(_try_decode_json("just text"))
 
@@ -304,6 +352,23 @@ class TestParseResponse(TestCase):
         resp = {"choices": [{"message": {"content": f"Sure thing:\n{inner}\n\nThanks!"}}]}
         result = parse_response(resp)
         self.assertEqual(result["verdict"], "approve")
+
+    def test_reasoning_model_array_before_verdict(self):
+        """Regression for dsv4f: a reasoning model folds thinking into
+        ``content`` (the OpenAI SSE path has no reasoning_content channel,
+        unlike Anthropic). The thinking contains a valid JSON array ahead
+        of the real verdict object. Previously this raised "Expected JSON
+        object but got list"; now the verdict object is recovered."""
+        content = (
+            "We need answer JSON review. Need decide approve vs "
+            'request_changes. Candidates: ["approve", "request_changes"]. '
+            "Now the verdict: "
+            + json.dumps({"verdict": "approve", "review_markdown": "# Looks good"})
+        )
+        resp = {"choices": [{"message": {"content": content}}]}
+        result = parse_response(resp)
+        self.assertEqual(result["verdict"], "approve")
+        self.assertEqual(result["review_markdown"], "# Looks good")
 
     # --- Error cases ---
 

--- a/tests/test_response_parser.py
+++ b/tests/test_response_parser.py
@@ -227,6 +227,34 @@ class TestTryDecodeJson(TestCase):
         result = _try_decode_json(src)
         self.assertEqual(result.get("review_markdown"), "# OK")
 
+    def test_partial_verdict_draft_skipped_for_complete(self):
+        """A reasoning preamble drafting a *partial* verdict (``verdict``
+        only, no ``review_markdown``) ahead of the real complete verdict
+        must not be picked — the complete one wins. This is the dsv4f
+        dogfood failure: after arrays were handled, the model's partial
+        draft was returned, yielding 'missing required key review_markdown'.
+        """
+        src = (
+            'Schema check: {"verdict": "approve"} '
+            'Final answer: {"verdict": "approve", "review_markdown": "# OK"}'
+        )
+        result = _try_decode_json(src)
+        self.assertIsInstance(result, dict)
+        self.assertEqual(result["verdict"], "approve")
+        self.assertEqual(result["review_markdown"], "# OK")
+
+    def test_sample_complete_verdict_loses_to_last_real_one(self):
+        """Where two *complete* verdicts appear, the LAST one wins — the
+        real answer is conventionally the final JSON the model emits, so
+        an earlier sample draft must not shadow it."""
+        src = (
+            'Sample: {"verdict": "request_changes", "review_markdown": "draft"} '
+            'Real: {"verdict": "approve", "review_markdown": "# Looks good"}'
+        )
+        result = _try_decode_json(src)
+        self.assertEqual(result["verdict"], "approve")
+        self.assertEqual(result["review_markdown"], "# Looks good")
+
     def test_no_json(self):
         self.assertIsNone(_try_decode_json("just text"))
 
@@ -369,6 +397,22 @@ class TestParseResponse(TestCase):
         result = parse_response(resp)
         self.assertEqual(result["verdict"], "approve")
         self.assertEqual(result["review_markdown"], "# Looks good")
+
+    def test_reasoning_model_partial_draft_then_complete(self):
+        """Regression for the dsv4f dogfood follow-up: thinking drafts a
+        *partial* verdict (``verdict`` only) before the complete one.
+        Previously raised 'missing required key review_markdown'; now the
+        complete verdict wins."""
+        content = (
+            "Let me set the shape: "
+            + json.dumps({"verdict": "approve"})
+            + " Now the full review: "
+            + json.dumps({"verdict": "approve", "review_markdown": "# Ship it"})
+        )
+        resp = {"choices": [{"message": {"content": content}}]}
+        result = parse_response(resp)
+        self.assertEqual(result["verdict"], "approve")
+        self.assertEqual(result["review_markdown"], "# Ship it")
 
     # --- Error cases ---
 


### PR DESCRIPTION
Reasoning models routed through an OpenAI-compatible proxy (e.g. **dsv4f** via litellm) fold thinking into `message.content`. That prose can carry a valid but irrelevant JSON array — a findings draft, candidate verdicts — *before* the real verdict object. `_scan` returned the first decodable value (the array), so `parse_response` raised `Expected JSON object but got list` and every dsv4f review fell back to the secondary model.

Both the native-loop verdict turn and the standard review call run through the same parser, so they failed symmetrically — visible in [this run](https://github.com/misospace/miso-chat/actions/runs/31045814728).

## Fix

`_scan` now collects **all** top-level JSON values (using `raw_decode`'s end index to skip past each, so array interiors are never re-scanned), then prefers the verdict-shaped dict over a list:

1. first dict with `verdict`/`review_markdown` keys
2. first dict of any shape
3. first list, only when no dict exists (preserving the existing single-item-wrapper unwrap)

Since the verdict is always a dict, reasoning-prose arrays no longer shadow it.

## Scope

- Touched: `pr_reviewer/response_parser.py` (`_try_decode_json._scan`), `tests/test_response_parser.py`.
- Untouched: single-item-list-unwrap, bare-list rejection, and all downstream validation (verdict normalization, non-empty markdown, findings normalization). The change only affects *which* candidate value is chosen when several exist.
- Deliberately not done: the OpenAI SSE reassembler could strip a separate `reasoning_content` field (defense in depth), but the failing logs show thinking *in* `content`, so the parser-layer fix is what matters.

## Verification

- 4 new tests, including the hardest case: a preamble array *containing* a verdict-shaped dict, followed by the real verdict — proves the scanner treats the array as opaque.
- `pytest tests/` → **1328 passed**.
- `tests/test_verdict_contract.sh` → **23 passed** (the bash `parse_and_validate` path shells into this same parser).
- Independent review (separate model family): approved.

Out of scope but worth a follow-up: OpenAI-path `reasoning_content` handling in the SSE reassembler.