### PR TITLE
Add requirements.txt dependency manifest

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
           python-version: '3.14'
 
       - name: Install test dependencies
-        run: pip install pytest pytest-cov yamllint
+        run: pip install -r requirements.txt
 
       - name: Validate action metadata YAML
         run: ruby -e 'require "yaml"; YAML.load_file("action.yml")'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+# Test dependencies — installed via `pip install -r requirements.txt`
+# Keep in sync with .github/workflows/ci.yaml "Install test dependencies" step.
+pytest
+pytest-cov
+yamllint


### PR DESCRIPTION
## Summary
- Recovers completed coder work that was stranded on an unreviewable branch.

Refs #421

## Provenance

The coder finished this successfully (verdict GO) on `foreman/wl-misospace-pr-reviewer-action-0/issue-0`, commit `5145770ad`. The review never ran: foreman's litellm key was not scoped to the `reviewer` alias, so every review request was rejected and the task ended INCOMPLETE, and no PR was opened.

That branch name is derived from issue number `0`, which is a bug — it is shared by every third-attempt retry in this repo, so the commit was one retry away from being force-pushed over. Cherry-picked onto a non-`foreman/*` branch to preserve it.

Not using a closing keyword: foreman may still redo this issue, and it owns the issue lifecycle.

## Verification
- Cherry-pick applied cleanly onto `main`; no conflicts.
- No manual edits — the diff is the original commit.