### PR TITLE
fix(security): restrict web_fetch URL scheme to http/https

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -20,7 +20,8 @@ This action reviews pull requests with an LLM and optional auxiliary tooling. Th
 - `gh_api` can optionally include specific upstream repos via explicit allowlist (`tool_allowed_gh_api_repos`) or all repos via `*` while preserving endpoint/path denylist checks
 - Anthropic responses are parsed from `text` blocks only; non-text blocks such as `thinking` are not added to review output
 - `read_file` is constrained to workspace-relative paths and blocks sensitive path patterns
-- `web_fetch` is constrained to `allowed_source_hosts`
+- `web_fetch` is constrained to `allowed_source_hosts` and rejects non-http/https URL schemes (file://, ftp://, gopher://, …)
+- `web_search` uses an operator-configured search endpoint and strips non-http(s) URLs from results
 - `run_command` rejects raw shell text and permits only named read-only argv definitions (`git_status_short`, `git_diff_stat`, `git_diff_name_only`)
 - Tool outputs are size-limited and pass through shared secret redaction before corpus inclusion
 - Evidence provider stdout and stderr are passed through the same secret-redaction pipeline before being written to JSON summaries or markdown output

--- a/pr_reviewer/tool_executors.py
+++ b/pr_reviewer/tool_executors.py
@@ -227,8 +227,18 @@ def gh_api(endpoint, allowed_repos, current_repo, request_timeout=25):
     return _platform_gh_api(endpoint, allowed_repos, current_repo, request_timeout)
 
 def web_fetch(url, allowed_hosts, request_timeout=25):
-    """Fetch a URL using the same host-allowlist logic."""
+    """Fetch a URL using the same host-allowlist logic.
+
+    Only ``http`` and ``https`` schemes are permitted; all other schemes
+    (file://, ftp://, gopher://, …) are rejected to prevent LFI/SSRF attacks
+    when the model supplies URLs derived from untrusted PR/corpus content.
+    This mirrors the scheme check in :func:`mcp_client.is_safe_server_url`.
+    """
     parsed = urllib.parse.urlparse(url)
+
+    if parsed.scheme not in ("http", "https"):
+        return {"error": f"URL scheme '{parsed.scheme}' is not allowed; only http and https are permitted"}
+
     host = parsed.hostname or ""
 
     if not allowlisted_host(host, allowed_hosts):
@@ -255,6 +265,10 @@ def web_search(query, search_url, request_timeout=20, max_results=5):
     ``max_results``, or ``{"error": ...}``. The endpoint is a single trusted,
     operator-configured URL — unlike web_fetch it is not host-allowlisted,
     because the model supplies only the query string, never the host.
+
+    Result URLs containing non-http(s) schemes (file://, ftp://, gopher://, …)
+    are stripped to prevent LFI/SSRF attacks when search results are fed back
+    into the review corpus.
     """
     if not search_url:
         return {"error": "Search is not configured (no search_url)."}
@@ -274,9 +288,14 @@ def web_search(query, search_url, request_timeout=20, max_results=5):
     for item in (data.get("results") or [])[:max_results]:
         if not isinstance(item, dict):
             continue
+        url = str(item.get("url", ""))
+        # Strip non-http(s) result URLs to prevent LFI/SSRF via search results
+        parsed_url = urllib.parse.urlparse(url)
+        if parsed_url.scheme and parsed_url.scheme not in ("http", "https"):
+            url = ""
         results.append({
             "title": str(item.get("title", ""))[:300],
-            "url": str(item.get("url", "")),
+            "url": url,
             "snippet": str(item.get("content", ""))[:500],
         })
     return {"results": results}

--- a/tests/test_tool_harness_status.py
+++ b/tests/test_tool_harness_status.py
@@ -684,6 +684,93 @@ def test_system_prompt_preserves_raw_whitespace(tmp_path):
     assert result == "FILE CONTENT", f"Expected file-only for blank-only SYSTEM_PROMPT, got: {result!r}"
 
 
+# ---------------------------------------------------------------------------
+# Tests for issue #468: restrict web_fetch URL scheme to http/https
+# ---------------------------------------------------------------------------
+
+
+def test_web_fetch_rejects_file_scheme():
+    """web_fetch rejects file:// URLs even with wildcard allowlist."""
+    web_fetch = _import_tool("web_fetch")
+
+    result = web_fetch("file:///etc/hostname", ["*"])
+    assert "error" in result, f"Expected error for file:// scheme, got: {result}"
+    assert "scheme" in result["error"].lower(), f"Error should mention scheme: {result['error']}"
+
+
+def test_web_fetch_rejects_ftp_scheme():
+    """web_fetch rejects ftp:// URLs even with wildcard allowlist."""
+    web_fetch = _import_tool("web_fetch")
+
+    result = web_fetch("ftp://example.com/file.txt", ["*"])
+    assert "error" in result, f"Expected error for ftp:// scheme, got: {result}"
+    assert "scheme" in result["error"].lower(), f"Error should mention scheme: {result['error']}"
+
+
+def test_web_fetch_rejects_gopher_scheme():
+    """web_fetch rejects gopher:// URLs even with wildcard allowlist."""
+    web_fetch = _import_tool("web_fetch")
+
+    result = web_fetch("gopher://example.com/", ["*"])
+    assert "error" in result, f"Expected error for gopher:// scheme, got: {result}"
+    assert "scheme" in result["error"].lower(), f"Error should mention scheme: {result['error']}"
+
+
+def test_web_fetch_allows_http_scheme():
+    """web_fetch allows http:// URLs under wildcard allowlist (no urlopen call)."""
+    web_fetch = _import_tool("web_fetch")
+
+    fake_response = mock.Mock()
+    fake_response.read.return_value = b"<html>ok</html>"
+    fake_response.__enter__ = mock.Mock(return_value=fake_response)
+    fake_response.__exit__ = mock.Mock(return_value=False)
+    with mock.patch("urllib.request.urlopen", return_value=fake_response) as mock_urlopen:
+        result = web_fetch("http://example.com/page", ["*"])
+    assert "error" not in result, f"Expected success for http:// scheme, got: {result}"
+    mock_urlopen.assert_called_once()
+
+
+def test_web_fetch_allows_https_scheme():
+    """web_fetch allows https:// URLs under wildcard allowlist (no urlopen call)."""
+    web_fetch = _import_tool("web_fetch")
+
+    fake_response = mock.Mock()
+    fake_response.read.return_value = b"<html>ok</html>"
+    fake_response.__enter__ = mock.Mock(return_value=fake_response)
+    fake_response.__exit__ = mock.Mock(return_value=False)
+    with mock.patch("urllib.request.urlopen", return_value=fake_response) as mock_urlopen:
+        result = web_fetch("https://example.com/page", ["*"])
+    assert "error" not in result, f"Expected success for https:// scheme, got: {result}"
+    mock_urlopen.assert_called_once()
+
+
+def test_web_search_strips_non_http_results():
+    """web_search strips non-http(s) URLs from search results."""
+    # Import directly from tool_executors since web_search is not exported by run_tool_harness
+    if str(_SCRIPTS_DIR) not in sys.path:
+        sys.path.insert(0, str(_SCRIPTS_DIR))
+    from pr_reviewer.tool_executors import web_search
+
+    fake_response = mock.Mock()
+    fake_response.read.return_value = json.dumps({
+        "results": [
+            {"title": "Safe", "url": "https://example.com/safe", "content": "ok"},
+            {"title": "File LFI", "url": "file:///etc/passwd", "content": "bad"},
+            {"title": "FTP", "url": "ftp://evil.com/malware", "content": "bad"},
+        ]
+    }).encode()
+    fake_response.__enter__ = mock.Mock(return_value=fake_response)
+    fake_response.__exit__ = mock.Mock(return_value=False)
+    with mock.patch("urllib.request.urlopen", return_value=fake_response):
+        result = web_search("test query", "https://search.example.com/search")
+    assert "error" not in result, f"Expected success, got: {result}"
+    results = result["results"]
+    assert len(results) == 3
+    assert results[0]["url"] == "https://example.com/safe"
+    assert results[1]["url"] == "", f"file:// URL should be stripped, got: {results[1]['url']}"
+    assert results[2]["url"] == "", f"ftp:// URL should be stripped, got: {results[2]['url']}"
+
+
 def main():
     tests = [
         ("old path counts zero", test_old_path_counts_zero),
@@ -719,6 +806,12 @@ def main():
         ("integration mixed success/failure", test_integration_mixed_success_and_failure),
         ("system_prompt env-first no double compose", test_system_prompt_env_first_no_double_compose),
         ("system_prompt preserves raw whitespace", test_system_prompt_preserves_raw_whitespace),
+        ("web_fetch rejects file scheme", test_web_fetch_rejects_file_scheme),
+        ("web_fetch rejects ftp scheme", test_web_fetch_rejects_ftp_scheme),
+        ("web_fetch rejects gopher scheme", test_web_fetch_rejects_gopher_scheme),
+        ("web_fetch allows http scheme", test_web_fetch_allows_http_scheme),
+        ("web_fetch allows https scheme", test_web_fetch_allows_https_scheme),
+        ("web_search strips non-http results", test_web_search_strips_non_http_results),
     ]
 
     passed = 0


### PR DESCRIPTION
## What
Restricts web_fetch URL scheme to http/https to prevent LFI/SSRF attacks.

## Why
Issue #468 requires restricting web_fetch URL scheme to http/https to prevent LFI/SSRF attacks when the model supplies URLs derived from untrusted PR/corpus content.

## How
Modified web_…

Fixes #468

_Opened by foreman on review GO (workload wl-misospace-pr-reviewer-action-468)._