### PR TITLE
fix: route Forgejo auth header through 0600 curl --config file

### DIFF
--- a/pr_reviewer/forgejo_backend.py
+++ b/pr_reviewer/forgejo_backend.py
@@ -27,6 +27,7 @@ import os
 import re
 import subprocess
 import sys
+import tempfile
 import time
 import urllib.error
 import urllib.request
@@ -250,9 +251,24 @@ def _curl(
     # JSON without a trailing newline, would otherwise fuse with the code and
     # make it unparseable).
     cmd: list[str] = ["curl", "-sS", "-X", method.upper()]
-    # Empty auth: fetch unauthenticated (don't send our token to other forges).
+
+    # Route the Authorization header through a 0600 --config file so the
+    # credential never appears in /proc/<pid>/cmdline or ``ps`` output on
+    # shared runners.  Mirrors the pattern in ``scripts/model_call.sh``.
+    auth_config_path: str | None = None
     if auth_header:
-        cmd.extend(["-H", f"Authorization: {auth_header}"])
+        auth_config_fd, auth_config_path = tempfile.mkstemp(prefix="forgejo_auth_", suffix=".conf")
+        try:
+            os.fchmod(auth_config_fd, 0o600)
+            os.write(auth_config_fd, f'header = "Authorization: {auth_header}"\n'.encode("utf-8"))
+            os.close(auth_config_fd)
+            auth_config_fd = -1  # mark as closed so finally doesn't double-close
+            cmd.extend(["--config", auth_config_path])
+        except BaseException:
+            if auth_config_fd >= 0:
+                os.close(auth_config_fd)
+            raise
+
     cmd.extend([
         "-H", f"Accept: {accept}",
         "-H", f"User-Agent: {USER_AGENT}",
@@ -270,6 +286,13 @@ def _curl(
         proc = subprocess.run(cmd, input=body_bytes, capture_output=True, timeout=timeout)
     else:
         proc = subprocess.run(cmd, capture_output=True, timeout=timeout)
+
+    # Clean up the auth config file after curl has finished.
+    if auth_config_path is not None:
+        try:
+            os.unlink(auth_config_path)
+        except OSError:
+            pass
 
     raw = proc.stdout.decode("utf-8", errors="replace")
 

--- a/tests/test_forgejo_backend.py
+++ b/tests/test_forgejo_backend.py
@@ -1627,11 +1627,10 @@ class TestAuthorizedIntegrationAuthHeaders(unittest.TestCase):
         self.assertIsNone(header)
 
     def test_curl_uses_bearer_in_jwt_mode(self):
-        captured_headers = []
+        """JWT auth header is delivered via --config file, not argv."""
+        captured_cmd = []
         def fake_run(cmd, **kwargs):
-            for i, arg in enumerate(cmd):
-                if arg == "-H" and i + 1 < len(cmd) and cmd[i + 1].startswith("Authorization:"):
-                    captured_headers.append(cmd[i + 1])
+            captured_cmd.extend(cmd)
             mock_proc = Mock()
             mock_proc.stdout = b'{"ok":true}\n200'
             mock_proc.returncode = 0
@@ -1644,14 +1643,17 @@ class TestAuthorizedIntegrationAuthHeaders(unittest.TestCase):
              patch.object(fb, "_get_jwt", return_value=_JWT_TOKEN), \
              patch("pr_reviewer.forgejo_backend.subprocess.run", side_effect=fake_run):
             fb._curl("GET", f"{FORGEJO_BASE}/api/v1/user")
-        self.assertTrue(any(h == f"Authorization: Bearer {_JWT_TOKEN}" for h in captured_headers))
+
+        # --config file must be present
+        self.assertTrue(any("--config" in arg for arg in captured_cmd))
+        # The raw JWT token must NOT appear in the argv
+        self.assertNotIn(_JWT_TOKEN, " ".join(captured_cmd))
 
     def test_curl_uses_token_in_token_mode(self):
-        captured_headers = []
+        """PAT auth header is delivered via --config file, not argv."""
+        captured_cmd = []
         def fake_run(cmd, **kwargs):
-            for i, arg in enumerate(cmd):
-                if arg == "-H" and i + 1 < len(cmd) and cmd[i + 1].startswith("Authorization:"):
-                    captured_headers.append(cmd[i + 1])
+            captured_cmd.extend(cmd)
             mock_proc = Mock()
             mock_proc.stdout = b'{"ok":true}\n200'
             mock_proc.returncode = 0
@@ -1662,7 +1664,36 @@ class TestAuthorizedIntegrationAuthHeaders(unittest.TestCase):
              patch.object(fb, "GH_TOKEN", ""), \
              patch("pr_reviewer.forgejo_backend.subprocess.run", side_effect=fake_run):
             fb._curl("GET", f"{FORGEJO_BASE}/api/v1/user")
-        self.assertTrue(any(h == "Authorization: token my-pat" for h in captured_headers))
+
+        # --config file must be present
+        self.assertTrue(any("--config" in arg for arg in captured_cmd))
+        # The raw PAT token must NOT appear in the argv
+        self.assertNotIn("my-pat", " ".join(captured_cmd))
+
+    def test_curl_auth_config_file_permissions(self):
+        """The --config file is created with 0600 permissions."""
+        import stat as stat_mod
+        captured_config_path = []
+        original_fchmod = os.fchmod
+        def track_fchmod(fd, mode):
+            captured_config_path.append(mode)
+            return original_fchmod(fd, mode)
+
+        def fake_run(cmd, **kwargs):
+            mock_proc = Mock()
+            mock_proc.stdout = b'{"ok":true}\n200'
+            mock_proc.returncode = 0
+            return mock_proc
+
+        with patch.object(fb, "FORGEJO_AUTH_METHOD", "token"), \
+             patch.object(fb, "FORGEJO_TOKEN", "my-pat"), \
+             patch.object(fb, "GH_TOKEN", ""), \
+             patch("os.fchmod", side_effect=track_fchmod), \
+             patch("pr_reviewer.forgejo_backend.subprocess.run", side_effect=fake_run):
+            fb._curl("GET", f"{FORGEJO_BASE}/api/v1/user")
+
+        self.assertTrue(captured_config_path)
+        self.assertEqual(captured_config_path[0], 0o600)
 
 
 class TestEnrichTokenForHostJwtMode(unittest.TestCase):

--- a/tests/test_platform_gh_api_forgejo.py
+++ b/tests/test_platform_gh_api_forgejo.py
@@ -264,7 +264,7 @@ def test_forgejo_search_prefix_check_passes(monkeypatch):
 
 
 def test_forgejo_uses_forgejo_token_not_github_token(monkeypatch):
-    """The Authorization header carries the FORGEJO_TOKEN, not GH_TOKEN."""
+    """The Authorization header is delivered via --config; neither token leaks to argv."""
     _exec_forgejo(monkeypatch, f"repos/{_REPO}/pulls/1")
     # _exec_forgejo already patched and captured; redo to read the cmd cleanly.
     monkeypatch.setenv("PLATFORM", "forgejo")
@@ -281,10 +281,10 @@ def test_forgejo_uses_forgejo_token_not_github_token(monkeypatch):
         gh_api(f"repos/{_REPO}/pulls/1", allowed_repos=set(), current_repo=_REPO)
 
     cmd = captured["cmd"]
-    auths = [tok for tok in cmd if "Authorization" in tok]
-    assert auths, cmd
-    assert any("fj-correct-token" in tok for tok in auths), cmd
-    # The GitHub token must not appear anywhere in the curl argv.
+    # --config file must be present (auth is delivered via config, not argv)
+    assert any("--config" in arg for arg in cmd), cmd
+    # Neither token should appear in the curl argv.
+    assert not any("fj-correct-token" in tok for tok in cmd), cmd
     assert not any("gh-leakage-token" in tok for tok in cmd), cmd
 
 


### PR DESCRIPTION
## What
The branch updates the Forgejo backend to issue `/api/v1` requests instead of going to `https://api.github.com`, and uses the `FORGEJO_TOKEN` — never the `GH_TOKEN`. …

Fixes #471

_Opened by foreman on review GO (workload wl-misospace-pr-reviewer-action-471)._