### PR TITLE
Align eval-harness Python version with CI (3.14)

### DIFF
--- a/.github/workflows/eval-harness.yaml
+++ b/.github/workflows/eval-harness.yaml
@@ -56,7 +56,10 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
-          python-version: "3.12"
+          # Pinned to 3.14 to match CI — a version skew between local and CI is
+          # how the duplicate-key regression test first shipped broken (passed on
+          # local 3.9, ModuleNotFoundError on CI 3.x).
+          python-version: '3.14'
 
       - name: Run eval harness
         env:


### PR DESCRIPTION
## What
Pinned Python version to 3.14 in eval-harness.yaml to match CI and resolve duplicate-key regression test failure.

## Why
Version skew between local (3.9) and CI (3.x) caused the duplicate-key regression test to ship broken; pinning to 3.14 ensures consistent behavior.…

Fixes #496

_Opened by foreman on review GO (workload wl-misospace-pr-reviewer-action-496)._