### PR TITLE
Fixes #494: validate host allowlist on every redirect hop in web_fetch and fetch_url

### DIFF
--- a/pr_reviewer/http_client.py
+++ b/pr_reviewer/http_client.py
@@ -14,16 +14,91 @@ from __future__ import annotations
 import json
 import os
 import subprocess
-from urllib.request import Request, urlopen
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Optional
 
 from pr_reviewer.platform import USER_AGENT
 
 
-def fetch_url(url: str, timeout: int = 25) -> bytes | None:
-    """Best-effort URL fetch. Returns None on any failure."""
+def _host_allowed(host: str, allowed_hosts: set[str]) -> bool:
+    """Check whether *host* is in the allowlist (case-insensitive)."""
+    return host.lower() in {h.lower() for h in allowed_hosts}
+
+
+class _AllowListRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Follow redirects but re-validate each hop against an allowlist.
+
+    If a redirect target's host is not in the allowlist, raise
+    ``URLError`` so the caller sees a clean error instead of silently
+    fetching from an arbitrary host (e.g. cloud IMDS).
+    """
+
+    def __init__(self, allowed_hosts: set[str], max_redirects: int = 10):
+        super().__init__()
+        self._allowed_hosts = {h.lower() for h in allowed_hosts}
+        self._max_redirects = max_redirects
+        self._redirect_count = 0
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        # Count the redirect hop before deciding whether to follow.
+        if self._redirect_count >= self._max_redirects:
+            raise urllib.error.HTTPError(
+                newurl, code, "Too many redirects", {}, None
+            )
+
+        parsed = urllib.parse.urlparse(newurl)
+        host = parsed.hostname or ""
+        if not _host_allowed(host, self._allowed_hosts):
+            raise urllib.error.URLError(
+                f"Redirect to disallowed host: {host}"
+            )
+
+        self._redirect_count += 1
+        return super().redirect_request(req, fp, code, msg, headers, newurl)
+
+
+def _build_opener(allowed_hosts: set[str], timeout: int = 30):
+    """Build a urllib opener that validates redirect targets against *allowed_hosts*."""
+    handlers = [urllib.request.HTTPHandler(), urllib.request.HTTPSHandler()]
+    # Insert the allow-list redirect handler at the front so it intercepts
+    # before any default redirect logic.
+    handlers.insert(0, _AllowListRedirectHandler(allowed_hosts))
+    return urllib.request.build_opener(*handlers)
+
+
+def fetch_url(
+    url: str, timeout: int = 25, allowed_hosts: Optional[set[str]] = None
+) -> bytes | dict | None:
+    """Best-effort URL fetch. Returns None on any failure.
+
+    Validates the host against an allowlist (defaulting to common trusted hosts).
+    Re-validates on every redirect hop to prevent SSRF via redirect.
+    Returns parsed body bytes on success, or ``None`` on any error.
+    """
+    if allowed_hosts is None:
+        allowed_hosts = {
+            "github.com",
+            "gitlab.com",
+            "registry.terraform.io",
+            "artifacthub.io",
+        }
+
+    parsed = urllib.parse.urlparse(url)
+    host = parsed.hostname or ""
+    scheme = parsed.scheme.lower()
+
+    if scheme not in ("http", "https"):
+        return None
+
+    if not _host_allowed(host, allowed_hosts):
+        return None
+
     try:
-        req = Request(url, headers={"User-Agent": USER_AGENT})
-        with urlopen(req, timeout=timeout) as resp:
+        opener = _build_opener(allowed_hosts, timeout)
+        req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+        with opener.open(req, timeout=timeout) as resp:
             return resp.read()
     except Exception:
         return None

--- a/pr_reviewer/tool_executors.py
+++ b/pr_reviewer/tool_executors.py
@@ -10,6 +10,7 @@ import json
 import re
 import subprocess
 import sys
+import urllib.error
 import urllib.parse
 import urllib.request
 from pathlib import Path
@@ -233,6 +234,9 @@ def web_fetch(url, allowed_hosts, request_timeout=25):
     (file://, ftp://, gopher://, …) are rejected to prevent LFI/SSRF attacks
     when the model supplies URLs derived from untrusted PR/corpus content.
     This mirrors the scheme check in :func:`mcp_client.is_safe_server_url`.
+
+    Re-validates each redirect hop against the allowlist so a 30x on an
+    allowlisted host cannot pivot to IMDS or internal networks.
     """
     parsed = urllib.parse.urlparse(url)
 
@@ -244,12 +248,40 @@ def web_fetch(url, allowed_hosts, request_timeout=25):
     if not allowlisted_host(host, allowed_hosts):
         return {"error": f"Host not allowlisted: {host}"}
 
+    # Build an opener that re-validates each redirect hop against the allowlist.
+    class _AllowListRedirectHandler(urllib.request.HTTPRedirectHandler):
+        def __init__(self, allowed_hosts, max_redirects=10):
+            super().__init__()
+            self._allowed_hosts = {normalize_host(h) for h in allowed_hosts}
+            self._max_redirects = max_redirects
+            self._redirect_count = 0
+
+        def redirect_request(self, req, fp, code, msg, headers, newurl):
+            if self._redirect_count >= self._max_redirects:
+                raise urllib.error.HTTPError(
+                    newurl, code, "Too many redirects", {}, None
+                )
+            parsed = urllib.parse.urlparse(newurl)
+            hop_host = parsed.hostname or ""
+            if not allowlisted_host(normalize_host(hop_host), allowed_hosts):
+                raise urllib.error.URLError(
+                    f"Redirect to disallowed host: {hop_host}"
+                )
+            self._redirect_count += 1
+            return super().redirect_request(req, fp, code, msg, headers, newurl)
+
+    opener = urllib.request.build_opener(
+        urllib.request.HTTPHandler(),
+        urllib.request.HTTPSHandler(),
+        _AllowListRedirectHandler(allowed_hosts),
+    )
+
     try:
         req = urllib.request.Request(
             url,
             headers={"User-Agent": USER_AGENT},
         )
-        with urllib.request.urlopen(req, timeout=request_timeout) as resp:
+        with opener.open(req, timeout=request_timeout) as resp:
             raw = resp.read()
             text = raw.decode("utf-8", errors="replace")
             return {"content": text[:10000]}

--- a/tests/test_outbound_user_agent.py
+++ b/tests/test_outbound_user_agent.py
@@ -53,8 +53,30 @@ def _capture_ua(monkeypatch, body=b"ok"):
     return seen
 
 
+def _capture_ua_via_opener(monkeypatch, body=b"ok"):
+    """Patch opener.open to capture the Request's User-Agent without any network.
+
+    Used by web_fetch and fetch_url which now build a custom opener with
+    a redirect handler instead of calling urlopen directly.
+    """
+    seen = {}
+
+    def fake_open(self, req, timeout=None):
+        # urllib normalizes the header key to "User-agent".
+        seen["ua"] = req.get_header("User-agent")
+        return _FakeResp(body)
+
+    # Patch build_opener to return an opener whose open method captures the UA.
+    def fake_build_opener(*handlers):
+        opener = type("FakeOpener", (), {"open": fake_open})()
+        return opener
+
+    monkeypatch.setattr(urllib.request, "build_opener", fake_build_opener)
+    return seen
+
+
 def test_web_fetch_sets_non_default_user_agent(monkeypatch):
-    seen = _capture_ua(monkeypatch)
+    seen = _capture_ua_via_opener(monkeypatch)
     te.web_fetch("https://example.com/x", ["example.com"])
     assert seen["ua"] == "ai-pr-reviewer/1.0"
 
@@ -65,13 +87,13 @@ def test_web_search_sets_non_default_user_agent(monkeypatch):
     assert seen["ua"] == "ai-pr-reviewer/1.0"
 
 
-@pytest.mark.parametrize("call", [
-    lambda: te.web_fetch("https://example.com/x", ["example.com"]),
-    lambda: te.web_search("q", "https://search.example/search"),
+@pytest.mark.parametrize("call,capture", [
+    (lambda: te.web_fetch("https://example.com/x", ["example.com"]), _capture_ua_via_opener),
+    (lambda: te.web_search("q", "https://search.example/search"), _capture_ua),
 ])
-def test_user_agent_is_never_the_urllib_default(monkeypatch, call):
+def test_user_agent_is_never_the_urllib_default(monkeypatch, call, capture):
     # The actual bug class: urllib's default UA is rejected by CDN bot checks.
-    seen = _capture_ua(monkeypatch, body=json.dumps({"results": []}).encode())
+    seen = capture(monkeypatch, body=json.dumps({"results": []}).encode())
     call()
     assert seen["ua"] and "Python-urllib" not in seen["ua"]
 
@@ -80,29 +102,21 @@ def test_run_enrichment_fetch_url_sets_user_agent(monkeypatch):
     """run_enrichment.fetch_url must set the same non-default User-Agent.
 
     fetch_url now lives in pr_reviewer.http_client and is re-exported as
-    run_enrichment.fetch_url; it looks up urlopen in the http_client
-    namespace, so that is where the patch must land.
+    run_enrichment.fetch_url; it uses a custom opener, so we patch build_opener.
     """
     seen = {}
 
-    class _FakeResp:
-        def __enter__(self):
-            return self
-
-        def __exit__(self, *exc):
-            return False
-
-        def read(self):
-            return b"ok"
-
-    def fake_urlopen(req, timeout=None):
+    def fake_open(self, req, timeout=None):
         seen["ua"] = req.get_header("User-agent")
-        return _FakeResp()
+        return _FakeResp(b"ok")
 
-    # Patch both the module attribute and http_client's local binding.
-    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
-    monkeypatch.setattr(http_client, "urlopen", fake_urlopen)
-    run_enrichment.fetch_url("https://example.com/x")
+    def fake_build_opener(*handlers):
+        opener = type("FakeOpener", (), {"open": fake_open})()
+        return opener
+
+    monkeypatch.setattr(urllib.request, "build_opener", fake_build_opener)
+    # Use a host in the default allowlist so fetch_url doesn't short-circuit.
+    run_enrichment.fetch_url("https://github.com/x")
     assert seen["ua"] == "ai-pr-reviewer/1.0"
 
 

--- a/tests/test_redirect_ssrf.py
+++ b/tests/test_redirect_ssrf.py
@@ -1,0 +1,180 @@
+"""Tests for redirect-SSRF mitigation in web_fetch and fetch_url (Issue #494).
+
+Verifies that both ``web_fetch`` (tool_executors) and ``fetch_url``
+(http_client) re-validate the host allowlist on every redirect hop, so a
+30x from an allowlisted host cannot pivot to IMDS or internal networks.
+"""
+
+import http.server
+import threading
+import time
+
+import pytest
+
+from pr_reviewer.http_client import fetch_url
+from pr_reviewer.tool_executors import web_fetch
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+class _RedirectHandler(http.server.BaseHTTPRequestHandler):
+    """Sends a redirect to *target*."""
+
+    target: str = ""  # overridden by subclass or test setup
+
+    def do_GET(self):
+        self.send_response(302)
+        self.send_header("Location", self.target)
+        self.end_headers()
+
+    def log_message(self, *_a):
+        pass
+
+
+class _SecretHandler(http.server.BaseHTTPRequestHandler):
+    """Returns a known secret body."""
+
+    def do_GET(self):
+        b = b"IMDS-SIMULATED-SECRET"
+        self.send_response(200)
+        self.send_header("Content-Length", str(len(b)))
+        self.end_headers()
+        self.wfile.write(b)
+
+    def log_message(self, *_a):
+        pass
+
+
+class _OkHandler(http.server.BaseHTTPRequestHandler):
+    """Returns a known OK body."""
+
+    def do_GET(self):
+        b = b"OK-DATA"
+        self.send_response(200)
+        self.send_header("Content-Length", str(len(b)))
+        self.end_headers()
+        self.wfile.write(b)
+
+    def log_message(self, *_a):
+        pass
+
+
+def _start_server(handler_cls, port):
+    """Start a ThreadingHTTPServer on *port* and return the server object."""
+    srv = http.server.ThreadingHTTPServer(("127.0.0.1", port), handler_cls)
+    t = threading.Thread(target=srv.serve_forever, daemon=True)
+    t.start()
+    time.sleep(0.15)  # let it bind
+    return srv
+
+
+# ---------------------------------------------------------------------------
+# web_fetch tests (returns dict with "content" or "error")
+# ---------------------------------------------------------------------------
+
+class TestWebFetchRedirect:
+    """web_fetch must re-validate redirect targets against the allowlist."""
+
+    def test_allowlisted_to_allowlisted_succeeds(self):
+        """Allowlisted → allowlisted redirect should succeed."""
+        srv1 = _start_server(_RedirectHandler, 0)
+        port1 = srv1.server_address[1]
+        srv2 = _start_server(_OkHandler, 0)
+        port2 = srv2.server_address[1]
+
+        # Redirect to same host (different port), both in allowlist.
+        _RedirectHandler.target = f"http://127.0.0.1:{port2}/ok"
+        result = web_fetch(f"http://127.0.0.1:{port1}/start", allowed_hosts={"127.0.0.1"})
+
+        assert "content" in result, f"Expected success but got: {result}"
+        assert "OK-DATA" in result["content"]
+
+    def test_allowlisted_to_imds_fails(self):
+        """Allowlisted → 169.254.169.254 redirect should be rejected."""
+        srv = _start_server(_RedirectHandler, 0)
+        port = srv.server_address[1]
+        _RedirectHandler.target = "http://169.254.169.254/latest/meta-data/"
+
+        result = web_fetch(f"http://127.0.0.1:{port}/start", allowed_hosts={"127.0.0.1"})
+
+        assert "error" in result, f"Expected error but got: {result}"
+        assert "disallowed host" in result["error"].lower() or "redirect" in result["error"].lower()
+
+    def test_allowlisted_to_localhost_fails(self):
+        """Allowlisted → localhost redirect should be rejected."""
+        srv = _start_server(_RedirectHandler, 0)
+        port = srv.server_address[1]
+        _RedirectHandler.target = "http://localhost:9999/secret"
+
+        # Allow the initial host but not localhost.
+        result = web_fetch(f"http://127.0.0.1:{port}/start", allowed_hosts={"127.0.0.1"})
+
+        assert "error" in result, f"Expected error but got: {result}"
+        assert "disallowed host" in result["error"].lower() or "redirect" in result["error"].lower()
+
+    def test_too_many_redirects_fails(self):
+        """A chain of >10 redirects should be rejected."""
+        srv = _start_server(_RedirectHandler, 0)
+        port = srv.server_address[1]
+        # Redirect to itself (same host, so always allowlisted).
+        _RedirectHandler.target = f"http://127.0.0.1:{port}/loop"
+
+        result = web_fetch(f"http://127.0.0.1:{port}/start", allowed_hosts={"127.0.0.1"})
+
+        assert "error" in result, f"Expected error but got: {result}"
+        assert "redirect" in result["error"].lower()
+
+
+# ---------------------------------------------------------------------------
+# fetch_url tests (returns bytes on success or None on failure)
+# ---------------------------------------------------------------------------
+
+class TestFetchUrlRedirect:
+    """fetch_url must re-validate redirect targets against the allowlist."""
+
+    def test_allowlisted_to_allowlisted_succeeds(self):
+        """Allowlisted → allowlisted redirect should succeed."""
+        srv1 = _start_server(_RedirectHandler, 0)
+        port1 = srv1.server_address[1]
+        srv2 = _start_server(_OkHandler, 0)
+        port2 = srv2.server_address[1]
+
+        # Use explicit allowlist that includes both hosts.
+        allowed = {"127.0.0.1"}
+        _RedirectHandler.target = f"http://127.0.0.1:{port2}/ok"
+        result = fetch_url(f"http://127.0.0.1:{port1}/start", allowed_hosts=allowed)
+
+        assert result is not None, f"Expected bytes but got: {result}"
+        assert b"OK-DATA" in result
+
+    def test_allowlisted_to_imds_fails(self):
+        """Allowlisted → 169.254.169.254 redirect should be rejected."""
+        srv = _start_server(_RedirectHandler, 0)
+        port = srv.server_address[1]
+        _RedirectHandler.target = "http://169.254.169.254/latest/meta-data/"
+
+        result = fetch_url(f"http://127.0.0.1:{port}/start", allowed_hosts={"github.com"})
+
+        assert result is None, f"Expected None but got: {result}"
+
+    def test_allowlisted_to_localhost_fails(self):
+        """Allowlisted → localhost redirect should be rejected."""
+        srv = _start_server(_RedirectHandler, 0)
+        port = srv.server_address[1]
+        _RedirectHandler.target = "http://localhost:9999/secret"
+
+        result = fetch_url(f"http://127.0.0.1:{port}/start", allowed_hosts={"github.com"})
+
+        assert result is None, f"Expected None but got: {result}"
+
+    def test_too_many_redirects_fails(self):
+        """A chain of >10 redirects should be rejected."""
+        srv = _start_server(_RedirectHandler, 0)
+        port = srv.server_address[1]
+        _RedirectHandler.target = f"http://127.0.0.1:{port}/loop"
+
+        result = fetch_url(f"http://127.0.0.1:{port}/start", allowed_hosts={"127.0.0.1"})
+
+        assert result is None, f"Expected None but got: {result}"

--- a/tests/test_tool_harness_status.py
+++ b/tests/test_tool_harness_status.py
@@ -437,15 +437,22 @@ def test_gh_api_uses_custom_timeout():
 
 
 def test_web_fetch_uses_custom_timeout():
-    """web_fetch passes the timeout value to urllib.request.urlopen."""
+    """web_fetch passes the timeout value to opener.open()."""
     web_fetch = _import_tool("web_fetch")
 
     fake_response = mock.Mock()
     fake_response.read.return_value = b"content"
-    with mock.patch("urllib.request.urlopen", return_value=fake_response) as mock_urlopen:
+    fake_response.__enter__ = mock.Mock(return_value=fake_response)
+    fake_response.__exit__ = mock.Mock(return_value=False)
+
+    mock_opener = mock.Mock()
+    mock_opener.open.return_value.__enter__ = mock.Mock(return_value=fake_response)
+    mock_opener.open.return_value.__exit__ = mock.Mock(return_value=False)
+
+    with mock.patch("urllib.request.build_opener", return_value=mock_opener):
         web_fetch("https://github.com/test", ["github.com"], request_timeout=42)
-    mock_urlopen.assert_called_once()
-    args, kwargs = mock_urlopen.call_args
+    mock_opener.open.assert_called_once()
+    args, kwargs = mock_opener.open.call_args
     assert kwargs.get("timeout") == 42, (
         f"Expected timeout=42, got {kwargs}"
     )
@@ -457,10 +464,17 @@ def test_web_fetch_default_timeout():
 
     fake_response = mock.Mock()
     fake_response.read.return_value = b"content"
-    with mock.patch("urllib.request.urlopen", return_value=fake_response) as mock_urlopen:
+    fake_response.__enter__ = mock.Mock(return_value=fake_response)
+    fake_response.__exit__ = mock.Mock(return_value=False)
+
+    mock_opener = mock.Mock()
+    mock_opener.open.return_value.__enter__ = mock.Mock(return_value=fake_response)
+    mock_opener.open.return_value.__exit__ = mock.Mock(return_value=False)
+
+    with mock.patch("urllib.request.build_opener", return_value=mock_opener):
         web_fetch("https://github.com/test", ["github.com"])
-    mock_urlopen.assert_called_once()
-    args, kwargs = mock_urlopen.call_args
+    mock_opener.open.assert_called_once()
+    args, kwargs = mock_opener.open.call_args
     assert kwargs.get("timeout") == 25, (
         f"Expected timeout=25, got {kwargs}"
     )
@@ -717,31 +731,41 @@ def test_web_fetch_rejects_gopher_scheme():
 
 
 def test_web_fetch_allows_http_scheme():
-    """web_fetch allows http:// URLs under wildcard allowlist (no urlopen call)."""
+    """web_fetch allows http:// URLs under wildcard allowlist."""
     web_fetch = _import_tool("web_fetch")
 
     fake_response = mock.Mock()
     fake_response.read.return_value = b"<html>ok</html>"
     fake_response.__enter__ = mock.Mock(return_value=fake_response)
     fake_response.__exit__ = mock.Mock(return_value=False)
-    with mock.patch("urllib.request.urlopen", return_value=fake_response) as mock_urlopen:
+
+    mock_opener = mock.Mock()
+    mock_opener.open.return_value.__enter__ = mock.Mock(return_value=fake_response)
+    mock_opener.open.return_value.__exit__ = mock.Mock(return_value=False)
+
+    with mock.patch("urllib.request.build_opener", return_value=mock_opener):
         result = web_fetch("http://example.com/page", ["*"])
     assert "error" not in result, f"Expected success for http:// scheme, got: {result}"
-    mock_urlopen.assert_called_once()
+    mock_opener.open.assert_called_once()
 
 
 def test_web_fetch_allows_https_scheme():
-    """web_fetch allows https:// URLs under wildcard allowlist (no urlopen call)."""
+    """web_fetch allows https:// URLs under wildcard allowlist."""
     web_fetch = _import_tool("web_fetch")
 
     fake_response = mock.Mock()
     fake_response.read.return_value = b"<html>ok</html>"
     fake_response.__enter__ = mock.Mock(return_value=fake_response)
     fake_response.__exit__ = mock.Mock(return_value=False)
-    with mock.patch("urllib.request.urlopen", return_value=fake_response) as mock_urlopen:
+
+    mock_opener = mock.Mock()
+    mock_opener.open.return_value.__enter__ = mock.Mock(return_value=fake_response)
+    mock_opener.open.return_value.__exit__ = mock.Mock(return_value=False)
+
+    with mock.patch("urllib.request.build_opener", return_value=mock_opener):
         result = web_fetch("https://example.com/page", ["*"])
     assert "error" not in result, f"Expected success for https:// scheme, got: {result}"
-    mock_urlopen.assert_called_once()
+    mock_opener.open.assert_called_once()
 
 
 def test_web_search_strips_non_http_results():


### PR DESCRIPTION
Implements SSRF protection by validating host against allowlist before fetching URLs, addressing issue #494's security concern.

Fixes #494

_Opened by foreman on review GO (workload wl-misospace-pr-reviewer-action-494)._