### PR TITLE
Add unit tests for five previously-uncovered pr_reviewer modules

### DIFF
--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -1,0 +1,180 @@
+"""Unit tests for pr_reviewer.http_client.
+
+Target: >= 50% line coverage of pr_reviewer/http_client.py.
+"""
+from __future__ import annotations
+
+import urllib.error
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from pr_reviewer import http_client
+
+
+def test_module_exposes_expected_symbols() -> None:
+    """Module exposes the public surface expected by callers."""
+    for name in ("_build_opener", "fetch_url", "gh_api_call"):
+        assert hasattr(http_client, name), f"missing symbol: {name}"
+
+
+def test_fetch_url_returns_none_for_blocked_host(monkeypatch: pytest.MonkeyPatch) -> None:
+    """fetch_url returns None for a host not in the allowed set."""
+    # Patch _build_opener to prove it is never invoked when host is blocked.
+    def _fake_opener(*args: Any, **kwargs: Any):
+        raise AssertionError("_build_opener should not be called for blocked hosts")
+
+    monkeypatch.setattr(http_client, "_build_opener", _fake_opener)
+
+    out = http_client.fetch_url(
+        "http://169.254.169.254/latest/meta-data/",
+        allowed_hosts={"github.com"},
+    )
+    assert out is None
+
+
+def test_fetch_url_returns_none_for_non_http_scheme(monkeypatch: pytest.MonkeyPatch) -> None:
+    """fetch_url returns None for non-http schemes like file://."""
+    monkeypatch.setattr(
+        http_client, "_build_opener",
+        lambda *a, **k: pytest.fail("_build_opener should not be called for file://"),
+    )
+    out = http_client.fetch_url("file:///etc/passwd", allowed_hosts={"github.com"})
+    assert out is None
+
+
+def test_fetch_url_returns_bytes_on_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A successful fetch returns the response body as bytes."""
+    body = b"hello world"
+
+    fake_resp = MagicMock()
+    fake_resp.read.return_value = body
+    fake_resp.__enter__.return_value = fake_resp
+    fake_resp.__exit__.return_value = False
+
+    fake_opener = MagicMock()
+    fake_opener.open.return_value = fake_resp
+
+    monkeypatch.setattr(http_client, "_build_opener", lambda *a, **k: fake_opener)
+
+    out = http_client.fetch_url(
+        "https://github.com/foo/bar", allowed_hosts={"github.com"}
+    )
+    assert out is not None, "successful mock must not return None"
+    assert isinstance(out, bytes)
+    assert out == body
+
+
+def test_fetch_url_returns_none_on_http_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """HTTPError from urllib should be swallowed and return None."""
+    fake_opener = MagicMock()
+    fake_opener.open.side_effect = urllib.error.HTTPError(
+        "https://github.com/missing", 404, "Not Found", {}, None
+    )
+    monkeypatch.setattr(http_client, "_build_opener", lambda *a, **k: fake_opener)
+
+    out = http_client.fetch_url(
+        "https://github.com/missing", allowed_hosts={"github.com"}
+    )
+    assert out is None
+
+
+def test_fetch_url_returns_none_on_url_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """URLError should be swallowed and return None."""
+    fake_opener = MagicMock()
+    fake_opener.open.side_effect = urllib.error.URLError("dns failure")
+    monkeypatch.setattr(http_client, "_build_opener", lambda *a, **k: fake_opener)
+
+    out = http_client.fetch_url(
+        "https://github.com/whatever", allowed_hosts={"github.com"}
+    )
+    assert out is None
+
+
+def test_fetch_url_github_com_with_mocked_opener(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Successful fetch from github.com must yield bytes (not None)."""
+    body = b'{"login": "octocat"}'
+
+    fake_resp = MagicMock()
+    fake_resp.read.return_value = body
+    fake_resp.__enter__.return_value = fake_resp
+    fake_resp.__exit__.return_value = False
+
+    fake_opener = MagicMock()
+    fake_opener.open.return_value = fake_resp
+
+    monkeypatch.setattr(http_client, "_build_opener", lambda *a, **k: fake_opener)
+
+    out = http_client.fetch_url(
+        "https://github.com/_render_node/foo", allowed_hosts={"github.com"}
+    )
+    # Tighten: a successful mock against github.com should yield bytes.
+    assert out is not None, "successful mock must not return None"
+    assert isinstance(out, bytes)
+    assert out == body
+
+
+def test_fetch_url_blocks_localhost(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Localhost is blocked when not in the allowed_hosts set."""
+    monkeypatch.setattr(
+        http_client, "_build_opener",
+        lambda *a, **k: pytest.fail("_build_opener should not run for localhost"),
+    )
+    out = http_client.fetch_url("http://localhost/admin", allowed_hosts={"github.com"})
+    assert out is None
+
+
+def test_fetch_url_default_allowed_hosts_includes_github(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Default allowed_hosts should include github.com so it works out of the box."""
+    captured = {}
+
+    def _fake_opener(allowed_hosts, timeout=30):
+        captured["allowed"] = set(allowed_hosts)
+        op = MagicMock()
+        op.open.return_value = MagicMock(
+            read=MagicMock(return_value=b"ok"),
+            __enter__=MagicMock(return_value=op.open.return_value),
+            __exit__=MagicMock(return_value=False),
+        )
+        # chain: open() -> ctx mgr -> read()
+        fake = MagicMock()
+        fake.open.return_value.__enter__.return_value.read.return_value = b"ok"
+        fake.open.return_value.__exit__.return_value = False
+        return fake
+
+    monkeypatch.setattr(http_client, "_build_opener", _fake_opener)
+    out = http_client.fetch_url("https://github.com/foo")
+    assert isinstance(out, bytes) and out == b"ok"
+    assert "github.com" in captured["allowed"]
+
+
+def test_gh_api_call_returns_none_without_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Without GH_TOKEN and failing subprocess, gh_api_call returns None or a dict.
+
+    We monkeypatch subprocess.run to fail so we never actually call `gh`.
+    """
+    import subprocess as sp
+
+    def _fake_run(*args: Any, **kwargs: Any):
+        raise sp.CalledProcessError(returncode=1, cmd=["gh"], stderr="auth required")
+
+    monkeypatch.setattr("subprocess.run", _fake_run)
+    out = http_client.gh_api_call("repos/example/repo")
+    assert out is None or isinstance(out, dict)
+
+
+def test_gh_api_call_returns_parsed_json_on_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A successful subprocess run with valid JSON should be parsed and returned."""
+    import json as _json
+    import subprocess as sp
+
+    fake = MagicMock()
+    fake.returncode = 0
+    fake.stdout = _json.dumps({"login": "octocat"})
+    fake.stderr = ""
+
+    monkeypatch.setattr("subprocess.run", lambda *a, **kw: fake)
+    out = http_client.gh_api_call("repos/example/repo", token="sk-test")
+    assert isinstance(out, dict)
+    assert out.get("login") == "octocat"

--- a/tests/test_linked_sources.py
+++ b/tests/test_linked_sources.py
@@ -1,0 +1,152 @@
+"""Unit tests for pr_reviewer.linked_sources.
+
+Target: >= 50% line coverage of pr_reviewer/linked_sources.py.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from pr_reviewer import budget, linked_sources
+
+
+def test_module_exposes_expected_symbols() -> None:
+    """Module exposes the public symbols referenced by other modules and tests."""
+    for name in ("strip_source_to_text", "render_linked_sources"):
+        assert hasattr(linked_sources, name), f"missing symbol: {name}"
+
+
+def test_module_imports_cleanly() -> None:
+    """The module should import without side effects."""
+    import importlib
+
+    mod = importlib.reload(linked_sources)
+    assert mod is linked_sources
+
+
+# ---------------------------------------------------------------------------
+# strip_source_to_text  (thin wrapper around scripts/strip_source_text.reduce_source)
+# ---------------------------------------------------------------------------
+
+
+def test_strip_source_to_text_handles_plain_bytes() -> None:
+    """A plain UTF-8 byte string should pass through with whitespace preserved."""
+    out = linked_sources.strip_source_to_text(b"hello world")
+    assert out == "hello world"
+
+
+def test_strip_source_to_text_unwraps_paragraph_tags() -> None:
+    """A simple <p>...</p> should be reduced to its inner text."""
+    out = linked_sources.strip_source_to_text(b"<p>hello</p>")
+    assert "<p>" not in out and "hello" in out
+
+
+def test_strip_source_to_text_replaces_null_bytes() -> None:
+    """Null bytes should be replaced with spaces (not crash decode)."""
+    out = linked_sources.strip_source_to_text(b"a\x00b")
+    assert "\x00" not in out
+    assert out.startswith("a")
+
+
+def test_strip_source_to_text_respects_max_bytes() -> None:
+    """Truncation should occur when input exceeds max_bytes."""
+    raw = ("a" * 5000).encode("utf-8")
+    out = linked_sources.strip_source_to_text(raw, max_bytes=200)
+    # After decoding + truncation, the result should be small.
+    assert isinstance(out, str)
+    assert len(out) <= 300  # generous upper bound after collapse + truncation
+
+
+def test_strip_source_to_text_empty_input() -> None:
+    """Empty input should return empty string."""
+    assert linked_sources.strip_source_to_text(b"") == ""
+
+
+# ---------------------------------------------------------------------------
+# render_linked_sources
+# ---------------------------------------------------------------------------
+
+
+def _kwargs(**overrides):
+    defaults = dict(
+        urls=[],
+        allowed_hosts={"github.com"},
+        gh_token="",
+        target_version="",
+        ghcr_images=[],
+        compare_shas=None,
+        budget=budget.BudgetTracker(max_seconds=5),
+    )
+    defaults.update(overrides)
+    return defaults
+
+
+def test_render_linked_sources_with_empty_list() -> None:
+    """Empty urls: the function should short-circuit to an empty string."""
+    out = linked_sources.render_linked_sources(**_kwargs())
+    assert out == ""
+
+
+def test_render_linked_sources_returns_str_for_input() -> None:
+    """A non-empty list of URLs should return a string (possibly empty)."""
+    out = linked_sources.render_linked_sources(
+        **_kwargs(urls=["https://github.com/foo/bar"])
+    )
+    assert isinstance(out, str)
+
+
+def test_render_linked_sources_with_unreachable_url() -> None:
+    """If fetch_url returns None and gh_api_call returns None, no exception."""
+    with patch.object(linked_sources, "fetch_url", return_value=None), \
+         patch.object(linked_sources, "gh_api_call", return_value=None):
+        out = linked_sources.render_linked_sources(
+            **_kwargs(urls=["https://github.com/foo/bar"])
+        )
+    assert isinstance(out, str)
+
+
+def test_render_linked_sources_respects_budget_zero() -> None:
+    """A zero-second budget should yield an empty string."""
+    out = linked_sources.render_linked_sources(
+        **_kwargs(
+            urls=["https://github.com/foo/bar"],
+            budget=budget.BudgetTracker(max_seconds=0),
+        )
+    )
+    # With exhausted budget, no fetches should occur → empty string.
+    assert isinstance(out, str)
+
+
+# ---------------------------------------------------------------------------
+# BudgetTracker / DeadlineBudget light smoke tests
+# ---------------------------------------------------------------------------
+
+
+def test_budget_tracker_ok_returns_true_initially() -> None:
+    """BudgetTracker.ok() should be True when within the time window."""
+    bt = budget.BudgetTracker(max_seconds=60)
+    assert bt.ok() is True
+
+
+def test_budget_tracker_ok_returns_false_when_exceeded() -> None:
+    """After the budget window elapses, ok() returns False."""
+    bt = budget.BudgetTracker(max_seconds=1)
+    # Force the tracker into the past by rewinding its start.
+    bt.start = bt.start - 10_000
+    assert bt.ok() is False
+
+
+def test_deadline_budget_disabled_when_max_seconds_le_zero() -> None:
+    """DeadlineBudget with max_seconds<=0 returns None deadline and never exceeds."""
+    db = budget.DeadlineBudget(max_seconds=0)
+    assert db.deadline is None
+    assert db.exceeded() is False
+
+
+def test_deadline_budget_from_env_default() -> None:
+    """DeadlineBudget.from_env reads a numeric env var with fallback default."""
+    db = budget.DeadlineBudget.from_env(
+        "TEST_DEADLINE_BUDGET_NOT_SET", default=120
+    )
+    assert db is not None

--- a/tests/test_tool_executors.py
+++ b/tests/test_tool_executors.py
@@ -1,0 +1,214 @@
+"""Unit tests for pr_reviewer.tool_executors.
+
+Target: >= 50% line coverage of pr_reviewer/tool_executors.py.
+
+All tests are hermetic: every external dependency (read_file, git_log,
+git_blame, git_grep, gh_api, web_fetch, web_search, run_command) is
+patched so no live subprocess or network call is made.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict
+from unittest.mock import patch
+
+import pytest
+
+from pr_reviewer import tool_executors
+
+
+def _call(name: str, args: Dict[str, Any], **kwargs: Any) -> Dict[str, Any]:
+    """Call execute_tool_request with sensible default kwargs."""
+    defaults = dict(
+        workspace_root="/tmp",
+        allowed_gh_repos=["*"],
+        current_repo="example/repo",
+        allowed_hosts=["*"],
+        max_response_bytes=10_000,
+        request_timeout=1,
+        search_url="",
+        max_search_results=5,
+    )
+    defaults.update(kwargs)
+    return tool_executors.execute_tool_request(name, args, **defaults)
+
+
+def test_module_exposes_expected_symbols() -> None:
+    """Module exposes execute_tool_request as the public entry point."""
+    assert hasattr(tool_executors, "execute_tool_request")
+    assert callable(tool_executors.execute_tool_request)
+
+
+def test_execute_tool_request_unknown_tool_returns_error_status() -> None:
+    """An unknown tool name should produce status=='error' with an error message."""
+    res = _call("does_not_exist", {})
+    assert isinstance(res, dict)
+    assert res.get("status") == "error"
+    assert "result" in res
+    assert "Unknown tool" in res["result"].get("error", "")
+
+
+def test_execute_tool_request_empty_arguments_dict() -> None:
+    """Empty args should be accepted (no crash)."""
+    res = _call("does_not_exist", {})
+    assert isinstance(res, dict)
+    assert res.get("status") == "error"
+
+
+def test_execute_tool_request_read_file_happy_path() -> None:
+    """read_file tool with valid path should return content via mocked reader."""
+    fake_res: Dict[str, Any] = {"content": "the file body", "range": None}
+
+    with patch.object(tool_executors, "read_file", return_value=fake_res) as rd:
+        res = _call("read_file", {"path": "README.md"})
+    assert rd.called
+    assert isinstance(res, dict)
+    assert res.get("status") == "ok"
+    assert "result" in res
+    assert res["result"].get("content") == "the file body"
+
+
+def test_execute_tool_request_read_file_missing_path() -> None:
+    """read_file without 'path' should surface an error."""
+    res = _call("read_file", {})
+    assert isinstance(res, dict)
+    assert res.get("status") == "error"
+    assert "path" in res.get("result", {}).get("error", "").lower()
+
+
+def test_execute_tool_request_read_file_returns_error_from_reader() -> None:
+    """If the reader returns an error key, the executor should surface it."""
+    fake_res: Dict[str, Any] = {"error": "File not found", "content": ""}
+    with patch.object(tool_executors, "read_file", return_value=fake_res):
+        res = _call("read_file", {"path": "missing.md"})
+    assert res.get("status") == "error"
+    assert "error" in res.get("result", {})
+
+
+def test_execute_tool_request_git_log_happy_path() -> None:
+    """git_log tool should accept path + max_count and return a 'log' field."""
+    fake_log = {"log": ["commit abc", "commit def"]}
+    with patch.object(tool_executors, "git_log", return_value=fake_log) as gl:
+        res = _call("git_log", {"path": ".", "max_count": 5})
+    assert gl.called
+    assert res.get("status") == "ok"
+    assert "log" in res.get("result", {})
+
+
+def test_execute_tool_request_git_log_missing_path_defaults() -> None:
+    """git_log without 'path' should still call git_log with empty path."""
+    fake_log = {"log": []}
+    with patch.object(tool_executors, "git_log", return_value=fake_log) as gl:
+        res = _call("git_log", {})
+    assert gl.called
+    assert res.get("status") == "ok"
+
+
+def test_execute_tool_request_git_blame_happy_path() -> None:
+    """git_blame tool should accept path and return a 'blame' field."""
+    fake_blame = {"blame": "alice 1 line one"}
+    with patch.object(tool_executors, "git_blame", return_value=fake_blame) as gb:
+        res = _call("git_blame", {"path": "a.py", "start": 1, "end": 5})
+    assert gb.called
+    assert res.get("status") == "ok"
+    assert "blame" in res.get("result", {})
+
+
+def test_execute_tool_request_git_blame_missing_path() -> None:
+    """git_blame without 'path' should surface a clear error."""
+    res = _call("git_blame", {})
+    assert res.get("status") == "error"
+    assert "path" in res.get("result", {}).get("error", "").lower()
+
+
+def test_execute_tool_request_git_grep_happy_path() -> None:
+    """git_grep tool should accept pattern and return matches."""
+    fake_grep = {"matches": ["a.py:1:foo", "b.py:2:foo"]}
+    with patch.object(tool_executors, "git_grep", return_value=fake_grep) as gg:
+        res = _call("git_grep", {"pattern": "foo"})
+    assert gg.called
+    assert res.get("status") == "ok"
+    assert "matches" in res.get("result", {})
+
+
+def test_execute_tool_request_git_grep_missing_pattern() -> None:
+    """git_grep without 'pattern' should surface an error."""
+    res = _call("git_grep", {})
+    assert res.get("status") == "error"
+    assert "pattern" in res.get("result", {}).get("error", "").lower()
+
+
+def test_execute_tool_request_gh_api_returns_dict_for_known_tool() -> None:
+    """gh_api tool: mock gh_api to avoid any live subprocess call."""
+    fake_res: Dict[str, Any] = {"data": {"login": "octocat"}, "error": None}
+    with patch.object(tool_executors, "gh_api", return_value=fake_res) as gh:
+        res = _call("gh_api", {"endpoint": "repos/example/repo"})
+    assert gh.called
+    assert isinstance(res, dict)
+    assert res.get("status") == "ok"
+    assert "response" in res.get("result", {})
+    assert "octocat" in res["result"]["response"]
+
+
+def test_execute_tool_request_gh_api_missing_endpoint() -> None:
+    """gh_api without endpoint should error."""
+    res = _call("gh_api", {})
+    assert res.get("status") == "error"
+    assert "endpoint" in res.get("result", {}).get("error", "").lower()
+
+
+def test_execute_tool_request_web_fetch_happy_path() -> None:
+    """web_fetch tool should accept a URL and return content (mocked)."""
+    fake_fetch = {"content": "<html>hi</html>"}
+    with patch.object(tool_executors, "web_fetch", return_value=fake_fetch) as wf:
+        res = _call("web_fetch", {"url": "https://example.com/"})
+    assert wf.called
+    assert res.get("status") == "ok"
+    assert "content" in res.get("result", {})
+
+
+def test_execute_tool_request_web_fetch_missing_url() -> None:
+    """web_fetch without url should error."""
+    res = _call("web_fetch", {})
+    assert res.get("status") == "error"
+    assert "url" in res.get("result", {}).get("error", "").lower()
+
+
+def test_execute_tool_request_web_search_happy_path() -> None:
+    """web_search tool should accept a query and return results (mocked)."""
+    fake_search = {"results": [{"title": "x", "url": "https://x.test"}]}
+    with patch.object(tool_executors, "web_search", return_value=fake_search) as ws:
+        res = _call("web_search", {"query": "pytest"})
+    assert ws.called
+    assert res.get("status") == "ok"
+    assert "results" in res.get("result", {})
+
+
+def test_execute_tool_request_web_search_missing_query() -> None:
+    """web_search without query should error."""
+    res = _call("web_search", {})
+    assert res.get("status") == "error"
+    assert "query" in res.get("result", {}).get("error", "").lower()
+
+
+def test_execute_tool_request_run_command_happy_path() -> None:
+    """run_command tool should accept a command and return stdout/stderr (mocked)."""
+    fake_rc = {
+        "stdout": "hello\n",
+        "stderr": "",
+        "exit_code": 0,
+        "command": "echo hello",
+    }
+    with patch.object(tool_executors, "run_command", return_value=fake_rc) as rc:
+        res = _call("run_command", {"command": "echo hello"})
+    assert rc.called
+    assert res.get("status") == "ok"
+    payload = res["result"]
+    assert payload["stdout"] == "hello\n"
+    assert payload["exit_code"] == 0
+
+
+def test_execute_tool_request_run_command_missing_command() -> None:
+    """run_command without command should error."""
+    res = _call("run_command", {})
+    assert res.get("status") == "error"
+    assert "command" in res.get("result", {}).get("error", "").lower()

--- a/tests/test_tool_loop.py
+++ b/tests/test_tool_loop.py
@@ -1,0 +1,231 @@
+"""Unit tests for pr_reviewer.tool_loop.
+
+Target: >= 50% line coverage of pr_reviewer/tool_loop.py.
+
+These tests complement tests/test_native_tool_loop.py with focused smoke tests
+for the module surface, dataclasses, and helper exports.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import pytest
+
+from pr_reviewer import tool_loop
+from pr_reviewer.tool_loop import (
+    STOP_MODEL_DONE,
+    STOP_NO_TOOL_CALLS,
+    STOP_MAX_ROUNDS,
+    STOP_BUDGET,
+    STOP_WALL_CLOCK,
+    STOP_REQUEST_ERROR,
+)
+
+
+# ---------------------------------------------------------------------------
+# Module surface
+# ---------------------------------------------------------------------------
+
+
+def test_module_exposes_expected_symbols() -> None:
+    """The module must expose the public API used by callers."""
+    for name in (
+        "drive_tool_loop",
+        "extract_tool_calls",
+        "LoopBudgets",
+        "ExecutedCall",
+        "LoopOutcome",
+        "STOP_MODEL_DONE",
+        "STOP_NO_TOOL_CALLS",
+        "STOP_MAX_ROUNDS",
+        "STOP_BUDGET",
+        "STOP_WALL_CLOCK",
+        "STOP_REQUEST_ERROR",
+    ):
+        assert hasattr(tool_loop, name), f"missing symbol: {name}"
+
+
+def test_module_imports_cleanly() -> None:
+    """The module should import without side effects."""
+    import importlib
+
+    mod = importlib.reload(tool_loop)
+    assert mod is tool_loop
+
+
+def test_stop_reason_constants_are_strings() -> None:
+    """Stop reason constants should be non-empty strings and all distinct."""
+    constants = [
+        STOP_MODEL_DONE,
+        STOP_NO_TOOL_CALLS,
+        STOP_MAX_ROUNDS,
+        STOP_BUDGET,
+        STOP_WALL_CLOCK,
+        STOP_REQUEST_ERROR,
+    ]
+    for v in constants:
+        assert isinstance(v, str) and v
+    assert len(set(constants)) == len(constants), "stop reasons must be distinct"
+
+
+# ---------------------------------------------------------------------------
+# LoopBudgets
+# ---------------------------------------------------------------------------
+
+
+def test_loop_budgets_defaults() -> None:
+    """LoopBudgets default values are positive numbers."""
+    b = tool_loop.LoopBudgets()
+    assert b.max_tool_calls >= 1
+    assert b.max_rounds >= 1
+    assert b.wall_clock_sec >= 1
+
+
+def test_loop_budgets_custom() -> None:
+    """LoopBudgets accepts custom values and exposes them as attributes."""
+    b = tool_loop.LoopBudgets(max_tool_calls=7, wall_clock_sec=12.5, max_rounds=4)
+    assert b.max_tool_calls == 7
+    assert b.wall_clock_sec == 12.5
+    assert b.max_rounds == 4
+
+
+# ---------------------------------------------------------------------------
+# ExecutedCall
+# ---------------------------------------------------------------------------
+
+
+def test_executed_call_construction() -> None:
+    """ExecutedCall is a dataclass-like record carrying tool-call metadata."""
+    ec = tool_loop.ExecutedCall(
+        tool="read_file",
+        args={"path": "x.py"},
+        result={"content": "hi"},
+    )
+    assert ec.tool == "read_file"
+    assert ec.args == {"path": "x.py"}
+    assert ec.result == {"content": "hi"}
+
+
+# ---------------------------------------------------------------------------
+# LoopOutcome
+# ---------------------------------------------------------------------------
+
+
+def test_loop_outcome_defaults() -> None:
+    """LoopOutcome defaults are sensible (empty executed list, no-tool-calls stop reason)."""
+    out = tool_loop.LoopOutcome()
+    assert isinstance(out.executed, list)
+    assert out.executed == []
+    assert out.stop_reason == STOP_NO_TOOL_CALLS
+
+
+def test_adaptive_loop_budgets_scales_rounds() -> None:
+    """adaptive_loop_budgets scales rounds with a cap of 8."""
+    b = tool_loop.adaptive_loop_budgets(
+        max_rounds=2, max_tool_calls=5, wall_clock_sec=30.0
+    )
+    # rounds should be at least 1 and at most 8.
+    assert 1 <= b.max_rounds <= 8
+    assert b.max_tool_calls == 5
+    assert b.wall_clock_sec == 30.0
+
+
+# ---------------------------------------------------------------------------
+# extract_tool_calls (returns (calls, text))
+# ---------------------------------------------------------------------------
+
+
+def test_extract_tool_calls_handles_openai_format() -> None:
+    """OpenAI-style response: tool_calls on the assistant message."""
+    response: Dict[str, Any] = {
+        "choices": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "c1",
+                            "function": {
+                                "name": "read_file",
+                                "arguments": '{"path": "a.py"}',
+                            },
+                        }
+                    ],
+                }
+            }
+        ]
+    }
+    calls, text = tool_loop.extract_tool_calls(response, "openai")
+    assert isinstance(calls, list)
+    assert isinstance(text, str)
+    assert len(calls) == 1
+    assert calls[0]["name"] == "read_file"
+    assert calls[0]["id"] == "c1"
+    # arguments is kept as opaque JSON string per the #233 contract.
+    assert calls[0]["arguments"] == '{"path": "a.py"}'
+
+
+def test_extract_tool_calls_no_calls_returns_text() -> None:
+    """When no tool_calls are present, text is returned in the second slot."""
+    response: Dict[str, Any] = {
+        "choices": [{"message": {"role": "assistant", "content": "hello"}}]
+    }
+    calls, text = tool_loop.extract_tool_calls(response, "openai")
+    assert calls == []
+    assert text == "hello"
+
+
+def test_extract_tool_calls_handles_anthropic_format() -> None:
+    """Anthropic-style response: content blocks of type 'tool_use'."""
+    response: Dict[str, Any] = {
+        "content": [
+            {"type": "text", "text": "thinking..."},
+            {
+                "type": "tool_use",
+                "id": "tu1",
+                "name": "git_log",
+                "input": {"path": ".", "max_count": 3},
+            },
+        ]
+    }
+    calls, text = tool_loop.extract_tool_calls(response, "anthropic")
+    assert isinstance(calls, list)
+    # text may include any text blocks; tool_use blocks become calls
+    assert any(c.get("name") == "git_log" for c in calls)
+    assert "thinking" in text
+
+
+def test_extract_tool_calls_handles_anthropic_no_tool_use() -> None:
+    """Anthropic response without tool_use should yield no calls and the text."""
+    response: Dict[str, Any] = {
+        "content": [{"type": "text", "text": "plain text only"}]
+    }
+    calls, text = tool_loop.extract_tool_calls(response, "anthropic")
+    assert calls == []
+    assert text == "plain text only"
+
+
+def test_extract_tool_calls_keeps_non_serializable_args_as_string() -> None:
+    """Non-JSON arguments should be preserved as opaque strings."""
+    response: Dict[str, Any] = {
+        "choices": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "c2",
+                            "function": {"name": "echo", "arguments": "not json"},
+                        }
+                    ],
+                }
+            }
+        ]
+    }
+    calls, text = tool_loop.extract_tool_calls(response, "openai")
+    assert len(calls) == 1
+    assert calls[0]["name"] == "echo"
+    # arguments kept as the opaque string we passed in
+    assert calls[0]["arguments"] == "not json"

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -1,0 +1,165 @@
+"""Unit tests for pr_reviewer.transport.
+
+Target: >= 50% line coverage of pr_reviewer/transport.py.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+from typing import Any, Dict
+from unittest.mock import MagicMock
+
+import pytest
+
+from pr_reviewer import transport
+
+
+# ---------------------------------------------------------------------------
+# Module surface
+# ---------------------------------------------------------------------------
+
+
+def test_module_exposes_expected_symbols() -> None:
+    """Module exposes safe_run, run_chat_request, and mask_secrets."""
+    for name in ("safe_run", "run_chat_request", "mask_secrets"):
+        assert hasattr(transport, name), f"missing symbol: {name}"
+
+
+# ---------------------------------------------------------------------------
+# safe_run
+# ---------------------------------------------------------------------------
+
+
+def test_safe_run_captures_stdout_and_exit_code(monkeypatch: pytest.MonkeyPatch) -> None:
+    """safe_run returns a CompletedProcess-like result for a successful command."""
+    fake_result = MagicMock()
+    fake_result.returncode = 0
+    fake_result.stdout = "out\n"
+    fake_result.stderr = ""
+
+    monkeypatch.setattr("subprocess.run", lambda *a, **kw: fake_result)
+    out = transport.safe_run(["echo", "out"], timeout_sec=5)
+    assert out.returncode == 0
+    assert out.stdout == "out\n"
+    assert out.stderr == ""
+
+
+def test_safe_run_returns_timeout_flag(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A TimeoutExpired should produce a structured timeout=True result."""
+    def fake_run(*a: Any, **kw: Any):
+        raise subprocess.TimeoutExpired(cmd=["sleep", "1"], timeout=0.01)
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    out = transport.safe_run(["sleep", "1"], timeout_sec=0.01)
+    assert out.get("timeout") is True
+
+
+# ---------------------------------------------------------------------------
+# run_chat_request (subprocess path)
+# ---------------------------------------------------------------------------
+
+
+def _completed(stdout: str = '{"ok": true}', returncode: int = 0) -> MagicMock:
+    fake = MagicMock()
+    fake.returncode = returncode
+    fake.stdout = stdout
+    fake.stderr = ""
+    return fake
+
+
+def test_run_chat_request_openai_endpoint(monkeypatch: pytest.MonkeyPatch) -> None:
+    """For OpenAI the endpoint should be /chat/completions and request must succeed."""
+    monkeypatch.setattr("subprocess.run", lambda *a, **kw: _completed())
+    res = transport.run_chat_request(
+        base_url="https://api.example.test/v1",
+        api_format="openai",
+        payload={"model": "m", "messages": []},
+        api_key="sk-test",
+        timeout_sec=5,
+    )
+    assert isinstance(res, dict)
+    assert res.get("ok") is True
+
+
+def test_run_chat_request_anthropic_endpoint(monkeypatch: pytest.MonkeyPatch) -> None:
+    """For Anthropic the endpoint should be /messages."""
+    captured: Dict[str, Any] = {}
+
+    def fake_run(cmd, *args: Any, **kwargs: Any):
+        captured["cmd"] = list(cmd)
+        return _completed()
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    res = transport.run_chat_request(
+        base_url="https://api.anthropic.com/v1",
+        api_format="anthropic",
+        payload={"model": "claude", "max_tokens": 8, "messages": []},
+        api_key="sk-anthropic-test",
+        timeout_sec=5,
+    )
+    cmd = captured.get("cmd", [])
+    assert any("https://api.anthropic.com/v1/messages" == c for c in cmd), cmd
+    assert isinstance(res, dict)
+
+
+def test_run_chat_request_handles_curl_failure_exit_22(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Curl exit code 22 should raise a RuntimeError (HTTP 4xx response)."""
+    monkeypatch.setattr("subprocess.run", lambda *a, **kw: _completed(returncode=22))
+    with pytest.raises(RuntimeError):
+        transport.run_chat_request(
+            base_url="https://example.test/v1",
+            api_format="openai",
+            payload={"model": "m", "messages": []},
+            api_key="sk-test",
+            timeout_sec=5,
+        )
+
+
+def test_run_chat_request_raises_on_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    """safe_run returning a timeout dict should surface a RuntimeError."""
+
+    def fake_run(*args: Any, **kwargs: Any):
+        return {"timeout": True, "stdout": "", "stderr": ""}
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    with pytest.raises(RuntimeError):
+        transport.run_chat_request(
+            base_url="https://example.test/v1",
+            api_format="openai",
+            payload={"model": "m", "messages": []},
+            api_key="sk-test",
+            timeout_sec=5,
+        )
+
+
+# ---------------------------------------------------------------------------
+# mask_secrets
+# ---------------------------------------------------------------------------
+
+
+def test_mask_secrets_replaces_bearer_tokens() -> None:
+    """mask_secrets must replace bearer-style authorization headers."""
+    text = "Authorization: Bearer abcdef-token-xyz-1234567890"
+    out = transport.mask_secrets(text)
+    assert "[REDACTED]" in out
+    assert "abcdef-token-xyz-1234567890" not in out
+
+
+def test_mask_secrets_handles_empty_text() -> None:
+    """mask_secrets must be a no-op for empty/None text."""
+    assert transport.mask_secrets("") == ""
+    assert transport.mask_secrets(None) == ""
+
+
+def test_mask_secrets_handles_plain_text() -> None:
+    """Plain text with no credential-like patterns should pass through."""
+    text = "hello world, this is a normal log line"
+    assert transport.mask_secrets(text) == text
+
+
+def test_mask_secrets_replaces_github_pat() -> None:
+    """GitHub personal access tokens (ghp_/ghs_) should be redacted."""
+    text = "GITHUB_TOKEN=ghp_abcdefghijklmnopqrstuvwxyz1234567890"
+    out = transport.mask_secrets(text)
+    assert "[REDACTED]" in out
+    assert "ghp_abcdefghijklmnopqrstuvwxyz1234567890" not in out


### PR DESCRIPTION
Added unit tests for http_client, linked_sources, tool_executors, tool_loop, and transport to meet coverage gate and hermetic CI requirements.

Fixes #420

_Opened by foreman on review GO (workload wl-misospace-pr-reviewer-action-420)._