### PR TITLE
Finish precheck migration: have check_review_needed.sh delegate to precheck.py

### DIFF
--- a/pr_reviewer/precheck.py
+++ b/pr_reviewer/precheck.py
@@ -4,6 +4,42 @@ Core functions for diff fingerprinting, incremental scope detection,
 config hash computation, and review metadata transport.
 
 These replace the shell implementations with testable Python code.
+
+CLI contract (``python3 -m pr_reviewer.precheck``)
+---------------------------------------------------
+
+The module entry point (``main``) reads its inputs from the environment
+and writes a single JSON object to stdout with the keys ``should_review``,
+``skip_reason``, ``effective_review_scope``, ``previous_head_sha``,
+``baseline_clean``, ``diff_fingerprint``, ``broad_fingerprint`` and
+``config_hash``. It is the decision half of the action precheck; the shell
+wrapper performs platform I/O (diff/PR/comment fetches) and forwards the
+result to ``$GITHUB_OUTPUT``.
+
+Environment inputs:
+
+- ``PRECHECK_DIFF_PATH`` / ``DIFF_PATH``: path to the PR diff file
+  (``PRECHECK_DIFF_PATH`` wins; ``DIFF_CONTENT`` is the fallback when
+  neither file is set).
+- ``PREV_FINGERPRINTS``: comma-separated fingerprints stored in previous
+  managed reviews (``PREV_FP_PATH`` file with ``diff-fp:`` lines is also
+  honoured).
+- ``FORCE_REVIEW``: ``true`` bypasses the diff-unchanged guard.
+- ``SKIP_IF_DIFF_UNCHANGED``: ``true`` (default) enables the guard.
+- ``REVIEW_SCOPE``: user scope request (``full`` / ``incremental`` /
+  ``auto``); ``auto`` is the default.
+- ``PREVIOUS_HEAD_SHA`` / ``PREVIOUS_BASE_SHA`` / ``PREVIOUS_REVIEW_RESULT``:
+  metadata from the last managed review.
+- ``PREVIOUS_HEAD_IS_ANCESTOR`` / ``COMPARE_RANGE_OK``: caller-supplied
+  validation verdicts for the previous→current range (ancestorship and
+  compare/base continuity). Unset means "not asserted" (the check does
+  not gate the baseline); ``false`` forces a full-scope fallback.
+
+``diff_fingerprint`` is the diff's own fingerprint (``empty-diff``
+placeholder for an empty diff); ``broad_fingerprint`` is the marker form
+``<diff_fingerprint>|cfg:<config_hash>`` stored in the
+``ai-pr-review-fingerprint`` comment marker, so a published fingerprint
+round-trips into the diff-unchanged comparison on the next run.
 """
 
 import hashlib
@@ -27,6 +63,14 @@ FP_PREFIX = "diff-fp:"
 
 # Delimiter separating diff fingerprint from config hash in broad fingerprint
 FP_DELIMITER = "|"
+
+# Placeholder fingerprint for an empty diff, so the stored-marker
+# comparison has a stable value to match on re-runs.
+EMPTY_DIFF_FINGERPRINT = "empty-diff"
+
+# Suffix marking the config-hash half of a marker fingerprint, as stored in
+# the ai-pr-review-fingerprint comment marker: `<diff_fp>|cfg:<config_hash>`.
+CONFIG_HASH_MARKER = "cfg:"
 
 # Incremental scope detection constants
 MAX_INCREMENTAL_FILES = 20
@@ -57,6 +101,19 @@ class PrecheckResult:
     total_files: int = 0
     total_lines: int = 0
     reason: str = ""
+
+
+@dataclass
+class ScopeResolution:
+    """Outcome of metadata-based review scope resolution.
+
+    A full scope always clears the carried incremental baseline: no
+    previous head is forwarded and the baseline is untrusted.
+    """
+
+    effective_review_scope: str = "full"
+    previous_head_sha: str = ""
+    baseline_clean: bool = False
 
 
 # ---------------------------------------------------------------------------
@@ -242,6 +299,36 @@ def build_broad_fingerprint(diff_fp: str, config_hash: str) -> str:
     if not config_hash:
         return diff_fp
     return f"{diff_fp}{FP_DELIMITER}{config_hash}"
+
+
+def build_marker_fingerprint(diff_fp: str, config_hash: str) -> str:
+    """Build the marker-compatible broad fingerprint.
+
+    Unlike :func:`build_broad_fingerprint` (the library-internal
+    ``<diff_fp>|<config_hash>`` form), this is the exact string stored in
+    the ``ai-pr-review-fingerprint`` comment marker and compared against
+    ``PREV_FINGERPRINTS`` on the next run:
+
+    - an empty ``diff_fp`` becomes the ``empty-diff`` placeholder, so an
+      empty diff still yields a stable, matchable fingerprint;
+    - the config hash is always present in ``|cfg:<hash>`` form, matching
+      the shell's synthesis and keeping the marker parseable even when the
+      hash is empty.
+
+    Parameters
+    ----------
+    diff_fp : str
+        Diff fingerprint (empty string for an empty diff).
+    config_hash : str
+        Config hash from ``compute_config_hash`` (may be empty).
+
+    Returns
+    -------
+    str
+        ``<diff_fp or empty-diff>|cfg:<config_hash>``.
+    """
+    fp = diff_fp or EMPTY_DIFF_FINGERPRINT
+    return f"{fp}{FP_DELIMITER}{CONFIG_HASH_MARKER}{config_hash}"
 
 
 # ---------------------------------------------------------------------------
@@ -550,6 +637,214 @@ def should_review(
 
 
 # ---------------------------------------------------------------------------
+# Action precheck contract (scope resolution, decision mapping, payload)
+# ---------------------------------------------------------------------------
+
+
+def resolve_review_scope(
+    review_scope: str,
+    previous_head_sha: str,
+    previous_base_sha: str,
+    previous_review_result: str = "",
+    *,
+    force_review: bool = False,
+    previous_head_is_ancestor: Optional[bool] = None,
+    compare_range_ok: Optional[bool] = None,
+) -> ScopeResolution:
+    """Resolve the effective review scope from explicit metadata inputs.
+
+    Python-side port of the scope logic that used to live in
+    ``check_review_needed.sh``: no git or API calls are made here. The
+    range validations the shell used to run itself (``git merge-base
+    --is-ancestor`` and the compare API) are passed in as verdicts:
+
+    - ``previous_head_is_ancestor``: whether the previous head is an
+      ancestor of the current head (force-push/rebase detection).
+    - ``compare_range_ok``: whether the previous→current range is still
+      comparable, which subsumes base-branch continuity (a changed base
+      makes the stored incremental range invalid).
+
+    ``None`` means the caller did not assert the check (it does not gate
+    the baseline, mirroring the old shell skipping a check it could not
+    run); ``True`` is a passing verdict; ``False`` forces a full-scope
+    fallback.
+
+    Rules, in order:
+
+    1. ``force_review`` or a ``full`` scope request → full scope.
+    2. An unrecognized ``review_scope`` degrades to ``auto`` (with a
+       warning) and continues through the safety gates.
+    3. Missing previous head or base metadata → full scope (no baseline
+       to increment from).
+    4. A failing validation verdict → full scope.
+    5. Otherwise → incremental scope carrying ``previous_head_sha``;
+       ``baseline_clean`` is true only when the previous review result
+       was ``clean`` or absent.
+
+    Parameters
+    ----------
+    review_scope : str
+        User scope request (``full`` / ``incremental`` / ``auto``).
+    previous_head_sha : str
+        Head SHA recorded in the last managed review marker.
+    previous_base_sha : str
+        Base SHA recorded in the last managed review marker.
+    previous_review_result : str
+        Review result recorded in the last managed review marker.
+    force_review : bool
+        Explicit re-review (label-driven or input); always full scope.
+    previous_head_is_ancestor : bool | None
+        Caller verdict for previous-head ancestorship (see above).
+    compare_range_ok : bool | None
+        Caller verdict for range comparability (see above).
+
+    Returns
+    -------
+    ScopeResolution
+    """
+    full = ScopeResolution()
+
+    if force_review:
+        logger.info("Forced re-review: using full scope")
+        return full
+
+    scope = (review_scope or "").strip().lower()
+    if scope == "full":
+        return full
+    if scope not in ("", "auto", "incremental"):
+        logger.warning(
+            "Invalid REVIEW_SCOPE %r; defaulting to auto", review_scope
+        )
+
+    if not previous_head_sha or not previous_base_sha:
+        return full
+    if previous_head_is_ancestor is False:
+        logger.info(
+            "Review scope fallback: previous head %s is not an ancestor of "
+            "the current head (possible force-push/rebase)",
+            previous_head_sha,
+        )
+        return full
+    if compare_range_ok is False:
+        logger.info(
+            "Review scope fallback: previous→current range is not comparable"
+        )
+        return full
+
+    return ScopeResolution(
+        effective_review_scope="incremental",
+        previous_head_sha=previous_head_sha,
+        baseline_clean=(previous_review_result or "").strip().lower()
+        in ("", "clean"),
+    )
+
+
+def evaluate_precheck(
+    diff_content: str,
+    previous_fingerprints: list[str],
+    *,
+    config_hash: Optional[str] = None,
+    force_review: bool = False,
+    skip_if_diff_unchanged: bool = True,
+) -> PrecheckResult:
+    """Run the action's should-review decision over a diff.
+
+    The action's guard is narrower than the library-level
+    :func:`should_review`: the only skip is a marker fingerprint match
+    (diff unchanged since the last managed review), and an empty diff is
+    not a skip — it fingerprinted as ``empty-diff`` so that the marker
+    round-trip can skip *subsequent* runs. Scope selection is out of
+    scope here (see :func:`resolve_review_scope`).
+
+    Parameters
+    ----------
+    diff_content : str
+        Raw PR diff (may be empty).
+    previous_fingerprints : list[str]
+        Marker fingerprints stored in previous managed reviews.
+    config_hash : str | None
+        Config hash; computed from the environment when ``None`` (the
+        shell wrapper computes the same value independently, so both
+        sides hash the identical config).
+    force_review : bool
+        Bypasses the diff-unchanged guard.
+    skip_if_diff_unchanged : bool
+        Enables the diff-unchanged guard.
+
+    Returns
+    -------
+    PrecheckResult
+        ``REVIEW_NEEDED`` or ``SKIP_ALREADY_REVIEWED``; the
+        ``diff_fingerprint`` field carries the marker form's diff half
+        (``empty-diff`` placeholder for an empty diff) and
+        ``broad_fingerprint`` the full marker string.
+    """
+    if config_hash is None:
+        config_hash = compute_config_hash()
+    diff_fp = compute_diff_fingerprint(diff_content)
+    marker_fp = diff_fp or EMPTY_DIFF_FINGERPRINT
+    broad = build_marker_fingerprint(marker_fp, config_hash)
+
+    if (
+        not force_review
+        and skip_if_diff_unchanged
+        and fingerprints_match(broad, previous_fingerprints)
+    ):
+        return PrecheckResult(
+            decision=ReviewDecision.SKIP_ALREADY_REVIEWED,
+            diff_fingerprint=marker_fp,
+            config_hash=config_hash,
+            broad_fingerprint=broad,
+            reason="Diff unchanged since last review",
+        )
+
+    return PrecheckResult(
+        decision=ReviewDecision.REVIEW_NEEDED,
+        diff_fingerprint=marker_fp,
+        config_hash=config_hash,
+        broad_fingerprint=broad,
+        reason="New or forced changes detected",
+    )
+
+
+def _decision_to_outputs(decision: ReviewDecision) -> tuple[bool, str]:
+    """Map a ReviewDecision to the action's (should_review, skip_reason).
+
+    ``SKIP_INCREMENTAL`` still runs a review: in the action, incremental
+    is a scope (resolved from metadata), not a reason to skip.
+    """
+    if decision is ReviewDecision.SKIP_ALREADY_REVIEWED:
+        return False, "diff-unchanged"
+    if decision is ReviewDecision.SKIP_NO_CHANGES:
+        return False, "no-changes"
+    return True, ""
+
+
+def build_precheck_payload(
+    result: PrecheckResult, scope: ScopeResolution
+) -> dict:
+    """Assemble the JSON payload the CLI writes to stdout.
+
+    When the decision does not run a review the scope fields are reset to
+    the full-scope defaults, so the payload is internally consistent
+    (the shell wrapper re-applies the same reset defensively).
+    """
+    should_review, skip_reason = _decision_to_outputs(result.decision)
+    if not should_review:
+        scope = ScopeResolution()
+    return {
+        "should_review": should_review,
+        "skip_reason": skip_reason,
+        "effective_review_scope": scope.effective_review_scope,
+        "previous_head_sha": scope.previous_head_sha,
+        "baseline_clean": scope.baseline_clean,
+        "diff_fingerprint": result.diff_fingerprint,
+        "broad_fingerprint": result.broad_fingerprint,
+        "config_hash": result.config_hash,
+    }
+
+
+# ---------------------------------------------------------------------------
 # CLI entry point (for shell wrapper invocation)
 # ---------------------------------------------------------------------------
 
@@ -573,32 +868,61 @@ def _format_output(result: PrecheckResult) -> str:
     return "\n".join(lines)
 
 
-def main() -> None:
-    """CLI entry point for the precheck module.
+def _env_flag(name: str, default: bool) -> bool:
+    """Read a boolean env flag the way the shell compared it (``== true``).
 
-    Reads inputs from environment variables and files, writes structured
-    output to stdout. Designed to be called from a thin shell wrapper.
+    Unset falls back to ``default``; only a case-insensitive ``true``
+    counts as true, so a mistyped value degrades to the safe side of each
+    flag (force off, guard on via the caller's default).
     """
-    # Read diff content
-    diff_path = os.environ.get("DIFF_PATH")
-    if diff_path and os.path.exists(diff_path):
-        with open(diff_path, "r", encoding="utf-8") as f:
-            diff_content = f.read()
-    else:
-        diff_content = os.environ.get("DIFF_CONTENT", "")
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() == "true"
 
-    # Read config lines from environment
-    config_lines = extract_config_lines(dict(os.environ))
 
-    # Optionally read config from file
-    config_path = os.environ.get("CONFIG_PATH")
-    if config_path and os.path.exists(config_path):
-        with open(config_path, "r", encoding="utf-8") as f:
-            config_lines.extend(f.read().splitlines())
+def _env_validation_flag(name: str) -> Optional[bool]:
+    """Read a caller-supplied range-validation verdict.
 
-    # Read previous fingerprints
+    Unset/empty means the caller did not assert the check (returns
+    ``None``; the check does not gate the baseline). ``true``/``false``
+    (case-insensitive, plus ``1``/``0``) are the verdicts. An unparseable
+    value fails closed to ``False``: a broken verdict must not certify a
+    baseline it cannot vouch for.
+    """
+    raw = os.environ.get(name)
+    if raw is None or not raw.strip():
+        return None
+    value = raw.strip().lower()
+    if value in ("true", "1"):
+        return True
+    if value in ("false", "0"):
+        return False
+    logger.warning("Unparseable %s=%r; treating validation as failed", name, raw)
+    return False
+
+
+def _read_diff_content() -> str:
+    """Read the PR diff from the first set, readable path env var."""
+    for var in ("PRECHECK_DIFF_PATH", "DIFF_PATH"):
+        path = os.environ.get(var)
+        if path and os.path.exists(path):
+            try:
+                # errors="replace" keeps binary-ish diffs hashable without
+                # crashing the precheck; the replacement is deterministic,
+                # so re-runs fingerprint identically.
+                with open(path, "r", encoding="utf-8", errors="replace") as f:
+                    return f.read()
+            except OSError:
+                logger.warning("Could not read diff file %s", path)
+    return os.environ.get("DIFF_CONTENT", "")
+
+
+def _read_previous_fingerprints() -> list[str]:
+    """Collect stored marker fingerprints from env and optional file."""
+    fingerprints: list[str] = []
+
     prev_fp_path = os.environ.get("PREV_FP_PATH")
-    previous_fingerprints: list[str] = []
     if prev_fp_path and os.path.exists(prev_fp_path):
         with open(prev_fp_path, "r", encoding="utf-8") as f:
             for line in f:
@@ -606,7 +930,7 @@ def main() -> None:
                 if line.startswith(FP_PREFIX):
                     fp = line[len(FP_PREFIX) :].strip()
                     if fp:
-                        previous_fingerprints.append(fp)
+                        fingerprints.append(fp)
 
     # Also accept fingerprints from env var (comma-separated)
     prev_fps_env = os.environ.get("PREV_FINGERPRINTS", "")
@@ -614,19 +938,44 @@ def main() -> None:
         for fp in prev_fps_env.split(","):
             fp = fp.strip()
             if fp:
-                previous_fingerprints.append(fp)
+                fingerprints.append(fp)
 
-    # Run decision logic
-    enable_incremental = os.environ.get("ENABLE_INCREMENTAL_DETECTION", "true").lower() != "false"
-    result = should_review(
+    return fingerprints
+
+
+def main() -> None:
+    """CLI entry point for the precheck module.
+
+    Reads the action precheck inputs from the environment (see the module
+    docstring for the contract) and writes a single JSON object to stdout
+    with the keys ``should_review``, ``skip_reason``,
+    ``effective_review_scope``, ``previous_head_sha``, ``baseline_clean``,
+    ``diff_fingerprint``, ``broad_fingerprint`` and ``config_hash``.
+    Designed to be called from a thin shell wrapper; library callers use
+    :func:`evaluate_precheck` / :func:`resolve_review_scope` directly.
+    """
+    diff_content = _read_diff_content()
+    previous_fingerprints = _read_previous_fingerprints()
+    force_review = _env_flag("FORCE_REVIEW", default=False)
+    skip_if_diff_unchanged = _env_flag("SKIP_IF_DIFF_UNCHANGED", default=True)
+
+    result = evaluate_precheck(
         diff_content,
-        config_lines,
         previous_fingerprints,
-        enable_incremental_detection=enable_incremental,
+        force_review=force_review,
+        skip_if_diff_unchanged=skip_if_diff_unchanged,
+    )
+    scope = resolve_review_scope(
+        os.environ.get("REVIEW_SCOPE", "auto"),
+        os.environ.get("PREVIOUS_HEAD_SHA", ""),
+        os.environ.get("PREVIOUS_BASE_SHA", ""),
+        os.environ.get("PREVIOUS_REVIEW_RESULT", ""),
+        force_review=force_review,
+        previous_head_is_ancestor=_env_validation_flag("PREVIOUS_HEAD_IS_ANCESTOR"),
+        compare_range_ok=_env_validation_flag("COMPARE_RANGE_OK"),
     )
 
-    # Output structured result
-    print(_format_output(result))
+    print(json.dumps(build_precheck_payload(result, scope), indent=2))
 
 
 if __name__ == "__main__":

--- a/scripts/artifact_paths.sh
+++ b/scripts/artifact_paths.sh
@@ -6,7 +6,7 @@
 assert_safe_artifact_paths() {
   local path
   local -a artifact_paths=(
-    pr.diff pr-object.json pr.json pr-body.txt changed-files.json
+    pr.diff pr-object.json pr.json pr-body.txt changed-files.json precheck-result.json
     previous-review-meta.json previous-findings.json previous-evidence.json
     incremental.diff linked-issues.md urls.all.txt urls.txt
     version-hints.txt version-hints.truncated.txt ghcr-images.txt compare-shas.txt

--- a/scripts/check_review_needed.sh
+++ b/scripts/check_review_needed.sh
@@ -3,8 +3,22 @@ set -euo pipefail
 
 # ── check_review_needed.sh → delegates to pr_reviewer/precheck.py ─────
 # Decision logic (should-review, scope, fingerprinting) lives in
-# precheck.py. The shell only performs platform I/O (git ops, API calls)
+# precheck.py. The shell only performs platform I/O (diff/PR/comment
+# fetches) plus the range-validation probes (base continuity, git
+# ancestry, compare API) whose verdicts feed the Python scope resolver,
 # and writes the resulting decisions to $GITHUB_OUTPUT. See issue #497.
+#
+# Flow:
+#   1. diff + last managed review body
+#   2. precheck.py call #1 — marker-only should-review decision; a skip
+#      exits here without fetching the PR object
+#   3. review path: PR object once → SHAs/fork → superseded guard →
+#      Forgejo permission preflight → range-validation probes →
+#      precheck.py call #2 for scope/baseline
+#
+# The shell never resolves scope or fingerprints itself: call #2 receives
+# the shell's validation verdicts (PREVIOUS_HEAD_IS_ANCESTOR,
+# COMPARE_RANGE_OK) and returns the authoritative scope state.
 
 REPO="${REPO:-${GITHUB_REPOSITORY:-}}"
 PR_NUMBER="${PR_NUMBER:-}"
@@ -17,6 +31,7 @@ REVIEW_SCOPE="${REVIEW_SCOPE:-auto}"
 PUBLISH_MODE="${PUBLISH_MODE:-comment}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 export PYTHONPATH="${SCRIPT_DIR}/..${PYTHONPATH:+:${PYTHONPATH}}"
+export FORCE_REVIEW SKIP_IF_DIFF_UNCHANGED REVIEW_SCOPE
 # shellcheck source=scripts/platform_api.sh
 source "${SCRIPT_DIR}/platform_api.sh"
 # shellcheck source=scripts/artifact_paths.sh
@@ -71,12 +86,12 @@ if ! platform_pr_diff "$REPO" "$PR_NUMBER" > pr.diff 2>/dev/null; then
   : > pr.diff
 fi
 
-# ── Config hash (delegated to Python — #429) ──────────────────────────
-config_hash="$(python3 -c "
-import sys
-from pr_reviewer.precheck import compute_config_hash
-print(compute_config_hash())
-")"
+# Write the diff to a temp path so Python can read it deterministically
+# (keeps the env-var surface narrow, even if diff is large).
+diff_path="$(mktemp)"
+cp pr.diff "$diff_path"
+export PRECHECK_DIFF_PATH="$diff_path"
+trap 'rm -f "$diff_path"' EXIT
 
 # ── Last managed review body lookup ───────────────────────────────────
 last_managed_comment_body() {
@@ -112,47 +127,52 @@ esac
 last_pr_sha="$(printf '%s\n' "$last_comment_body" | sed -n 's/^<!-- ai-pr-review-sha:\([^>]*\) -->$/\1/p' | head -n 1)"
 last_broad_fingerprint="$(printf '%s\n' "$last_comment_body" | sed -n 's/^<!-- ai-pr-review-fingerprint:\([^>]*\) -->$/\1/p' | head -n 1)"
 
-# ── Get PR head/base SHAs before calling Python precheck ──────────────
-if ! platform_pr_get "$REPO" "$PR_NUMBER" > pr-object.json 2>/dev/null; then
-  echo '{}' > pr-object.json
+if [[ -n "$last_broad_fingerprint" ]]; then
+  export PREV_FINGERPRINTS="$last_broad_fingerprint"
+else
+  unset PREV_FINGERPRINTS 2>/dev/null || true
 fi
-CURRENT_HEAD_SHA="$(jq -r '.head.sha // ""' pr-object.json 2>/dev/null || echo "")"
-CURRENT_BASE_SHA="$(jq -r '.base.sha // ""' pr-object.json 2>/dev/null || echo "")"
-IS_FORK_PR="$(derive_is_fork_pr pr-object.json)"
+# Scope metadata and validation verdicts are only asserted on the review
+# path (call #2 below); make sure nothing from the runner environment
+# leaks into call #1.
+unset PREVIOUS_HEAD_SHA PREVIOUS_BASE_SHA PREVIOUS_REVIEW_RESULT \
+  PREVIOUS_HEAD_IS_ANCESTOR COMPARE_RANGE_OK 2>/dev/null || true
 
-# Superseded review event check (#451)
-if [[ -n "${EVENT_HEAD_SHA:-}" && -n "$CURRENT_HEAD_SHA" && "$EVENT_HEAD_SHA" != "$CURRENT_HEAD_SHA" ]]; then
-  echo "Skipping superseded review event: event head $EVENT_HEAD_SHA is no longer the current head ($CURRENT_HEAD_SHA)." >&2
+# ── precheck call #1: marker-only should-review decision ──────────────
+# Runs before the PR object fetch so a diff-unchanged skip costs no
+# platform I/O beyond the diff and the comment/review lookup.
+python3 -m pr_reviewer.precheck > precheck-result.json
+
+should_review_decision="$(jq -r '.should_review // false' precheck-result.json)"
+skip_reason="$(jq -r '.skip_reason // ""' precheck-result.json)"
+diff_fingerprint="$(jq -r '.broad_fingerprint // ""' precheck-result.json)"
+
+if [[ "$should_review_decision" != "true" ]]; then
   {
     echo "effective_review_scope=full"
     echo "previous_head_sha="
     echo "baseline_clean=false"
-    echo "head_sha=$CURRENT_HEAD_SHA"
-    echo "base_sha=$CURRENT_BASE_SHA"
-    echo "is_fork_pr=$IS_FORK_PR"
-    echo "diff_fingerprint="
-    echo "should_review=false"
-    echo "skip_reason=superseded-head"
+    echo "head_sha="
+    echo "base_sha="
+    echo "is_fork_pr="
+    echo "diff_fingerprint=$diff_fingerprint"
+    echo "should_review=$should_review_decision"
+    echo "skip_reason=$skip_reason"
     echo "resolved_platform=$RESOLVED_PLATFORM"
     echo "effective_forgejo_api_url=$EFFECTIVE_FORGEJO_API_URL"
   } >> "$OUTPUT_FILE"
   exit 0
 fi
 
-# Forgejo permission preflight (#453)
-if [[ "$RESOLVED_PLATFORM" == "forgejo" ]]; then
-  REPO_PERMISSION="$(platform_authenticated_repo_permission "$REPO" 2>/dev/null || true)"
-  if [[ "$REPO_PERMISSION" != "write" && "$REPO_PERMISSION" != "admin" ]]; then
-    echo "ERROR: Review token lacks Forgejo write permission for $REPO (got '${REPO_PERMISSION:-none}'); refusing to invoke a model whose review could not be published." >&2
-    exit 1
-  fi
-fi
-
-# ── extract_review_metadata (kept for test_carry_forward_roundtrip.sh) ─
-# Roundtrip test extracts this via regex and sources it; this is the live
-# implementation it exercises. Logic remains in shell because it parses a
-# stored published comment body that contains reviewer-emitted metadata
-# (not actionable config inputs), independent of precheck decision logic.
+# ── extract_review_metadata (restored plumbing) ───────────────────────
+# Roundtrip test (tests/test_carry_forward_roundtrip.sh) extracts this via
+# regex and sources it; this is the live implementation it exercises. Logic
+# remains in shell because it parses a stored published comment body that
+# contains reviewer-emitted metadata (not actionable config inputs),
+# independent of precheck decision logic. Writes previous-review-meta.json
+# plus the carried-forward state the review step consumes:
+# previous-findings.json (open findings) and previous-evidence.json
+# (evidence digest, tagged with the gathered-at head SHA).
 extract_review_metadata() {
   local comment_body="$1"
 
@@ -161,7 +181,7 @@ extract_review_metadata() {
   LAST_REVIEW_SCOPE=""
   LAST_REVIEW_RESULT=""
 
-  rm -f previous-review-meta.json
+  rm -f previous-review-meta.json previous-findings.json previous-evidence.json
 
   printf '%s' "$comment_body" | python3 -c "
 import json, re, sys
@@ -180,6 +200,30 @@ if data:
     }
     with open('previous-review-meta.json', 'w', encoding='utf-8') as fh:
         json.dump(meta, fh, ensure_ascii=False)
+    raw = data.get('open_findings')
+    sanitized = []
+    if isinstance(raw, list):
+        for item in raw[:20]:
+            if not isinstance(item, dict):
+                continue
+            message = item.get('message')
+            if not isinstance(message, str) or not message.strip():
+                continue
+            line = item.get('line')
+            sanitized.append({
+                'severity': enumsan(item.get('severity')),
+                'category': enumsan(item.get('category')),
+                'file': str(item.get('file'))[:200] if isinstance(item.get('file'), str) else None,
+                'line': line if isinstance(line, int) and not isinstance(line, bool) and line > 0 else None,
+                'message': re.sub(r'[\x00-\x08\x0b-\x1f<>]', '', message)[:200],
+            })
+    with open('previous-findings.json', 'w', encoding='utf-8') as fh:
+        json.dump(sanitized, fh, ensure_ascii=False)
+    digest = data.get('evidence_digest')
+    if isinstance(digest, str) and digest.strip():
+        clean = re.sub(r'[\x00-\x08\x0b-\x1f<>]', '', digest)[:2000]
+        with open('previous-evidence.json', 'w', encoding='utf-8') as fh:
+            json.dump({'digest': clean, 'head_sha': hexsan(data.get('head_sha'))}, fh, ensure_ascii=False)
 " 2>/dev/null || true
 
   if [[ -f previous-review-meta.json ]]; then
@@ -198,52 +242,95 @@ if [[ -n "$last_comment_body" ]]; then
   extract_review_metadata "$last_comment_body"
 fi
 
-# ── Delegate should-review, scope, and fingerprint to precheck.py ─────
-PREVIOUS_FINGERPRINTS_RAW="${last_broad_fingerprint:-}"
-if [[ -n "$PREVIOUS_FINGERPRINTS_RAW" ]]; then
-  export PREV_FINGERPRINTS="$PREVIOUS_FINGERPRINTS_RAW"
-else
-  unset PREV_FINGERPRINTS || true
+# ── Get the PR object once (review path only) ─────────────────────────
+if ! platform_pr_get "$REPO" "$PR_NUMBER" > pr-object.json 2>/dev/null; then
+  echo '{}' > pr-object.json
+fi
+CURRENT_HEAD_SHA="$(jq -r '.head.sha // ""' pr-object.json 2>/dev/null || echo "")"
+CURRENT_BASE_SHA="$(jq -r '.base.sha // ""' pr-object.json 2>/dev/null || echo "")"
+IS_FORK_PR="$(derive_is_fork_pr pr-object.json)"
+
+# Superseded review event check (#451)
+if [[ -n "${EVENT_HEAD_SHA:-}" && -n "$CURRENT_HEAD_SHA" && "$EVENT_HEAD_SHA" != "$CURRENT_HEAD_SHA" ]]; then
+  echo "Skipping superseded review event: event head $EVENT_HEAD_SHA is no longer the current head ($CURRENT_HEAD_SHA)." >&2
+  {
+    echo "effective_review_scope=full"
+    echo "previous_head_sha="
+    echo "baseline_clean=false"
+    echo "head_sha=$CURRENT_HEAD_SHA"
+    echo "base_sha=$CURRENT_BASE_SHA"
+    echo "is_fork_pr=$IS_FORK_PR"
+    echo "diff_fingerprint=$diff_fingerprint"
+    echo "should_review=false"
+    echo "skip_reason=superseded-head"
+    echo "resolved_platform=$RESOLVED_PLATFORM"
+    echo "effective_forgejo_api_url=$EFFECTIVE_FORGEJO_API_URL"
+  } >> "$OUTPUT_FILE"
+  exit 0
 fi
 
-export ENABLE_INCREMENTAL_DETECTION
-ENABLE_INCREMENTAL_DETECTION="true"
+# Forgejo permission preflight (#453)
+if [[ "$RESOLVED_PLATFORM" == "forgejo" ]]; then
+  REPO_PERMISSION="$(platform_authenticated_repo_permission "$REPO" 2>/dev/null || true)"
+  if [[ "$REPO_PERMISSION" != "write" && "$REPO_PERMISSION" != "admin" ]]; then
+    echo "ERROR: Review token lacks Forgejo write permission for $REPO (got '${REPO_PERMISSION:-none}'); refusing to invoke a model whose review could not be published." >&2
+    exit 1
+  fi
+fi
+
+# ── Range-validation probes → verdicts for Python scope resolution ────
+# The shell performs the platform I/O; precheck.py turns the verdicts into
+# the scope decision (it does not run git or API calls itself). Unset means
+# "not asserted" (the check does not gate the baseline); false fails closed
+# to full scope.
+PREV_HEAD_IS_ANCESTOR=""
+COMPARE_RANGE_OK=""
+if [[ -n "$LAST_HEAD_SHA" && -n "$LAST_BASE_SHA" ]]; then
+  if [[ -n "$CURRENT_BASE_SHA" && "$CURRENT_BASE_SHA" != "$LAST_BASE_SHA" ]]; then
+    echo "Review scope fallback: base SHA changed from $LAST_BASE_SHA to $CURRENT_BASE_SHA" >&2
+    COMPARE_RANGE_OK="false"
+  elif [[ -n "$CURRENT_HEAD_SHA" ]]; then
+    if git merge-base --is-ancestor "$LAST_HEAD_SHA" "$CURRENT_HEAD_SHA" >/dev/null 2>&1; then
+      PREV_HEAD_IS_ANCESTOR="true"
+    else
+      echo "Review scope fallback: previous head $LAST_HEAD_SHA is not an ancestor of current head $CURRENT_HEAD_SHA (possible force-push/rebase)" >&2
+      PREV_HEAD_IS_ANCESTOR="false"
+    fi
+    if platform_compare "$REPO" "${LAST_HEAD_SHA}...${CURRENT_HEAD_SHA}" >/dev/null 2>&1; then
+      COMPARE_RANGE_OK="true"
+    else
+      echo "Review scope fallback: compare API failed for ${LAST_HEAD_SHA}...${CURRENT_HEAD_SHA}" >&2
+      COMPARE_RANGE_OK="false"
+    fi
+  else
+    echo "Review scope fallback: current head SHA unavailable; range cannot be validated" >&2
+    COMPARE_RANGE_OK="false"
+  fi
+fi
+
+if [[ -n "$PREV_HEAD_IS_ANCESTOR" ]]; then
+  export PREVIOUS_HEAD_IS_ANCESTOR="$PREV_HEAD_IS_ANCESTOR"
+else
+  unset PREVIOUS_HEAD_IS_ANCESTOR 2>/dev/null || true
+fi
+if [[ -n "$COMPARE_RANGE_OK" ]]; then
+  export COMPARE_RANGE_OK="$COMPARE_RANGE_OK"
+else
+  unset COMPARE_RANGE_OK 2>/dev/null || true
+fi
 export PREVIOUS_HEAD_SHA="$LAST_HEAD_SHA"
 export PREVIOUS_BASE_SHA="$LAST_BASE_SHA"
 export PREVIOUS_REVIEW_RESULT="$LAST_REVIEW_RESULT"
 
-# Write the diff to a temp path so Python can read it deterministically
-# (keeps the env-var surface narrow, even if diff is large).
-diff_path="$(mktemp)"
-cp pr.diff "$diff_path"
-export PRECHECK_DIFF_PATH="$diff_path"
-trap 'rm -f "$diff_path"' EXIT
-
+# ── precheck call #2: scope / baseline with validation verdicts ───────
 python3 -m pr_reviewer.precheck > precheck-result.json
 
-broad_fingerprint="$(jq -r '.broad_fingerprint // ""' precheck-result.json)"
-should_review_decision="$(jq -r '.should_review // ""' precheck-result.json)"
+should_review_decision="$(jq -r '.should_review // false' precheck-result.json)"
 skip_reason="$(jq -r '.skip_reason // ""' precheck-result.json)"
-current_fingerprint="$(jq -r '.diff_fingerprint // ""' precheck-result.json)"
-
-# Build broad fingerprint as the union of diff_fp + config hash exactly as
-# the comment marker expects: `<diff_fp>|cfg:<config_hash>`. Empty diffs
-# produce a fingerprint whose value contains `empty-diff` (set by
-# `compute_diff_fingerprint`), so the stored-marker comparison succeeds.
-# `_detect_incremental_scope` already used `current_fingerprint` below; if
-# Python returned an empty string for empty diffs we synthesize the marker
-# here so the wide comment-fingerprint stays parseable.
-if [[ -z "$current_fingerprint" ]]; then
-  current_fingerprint="empty-diff"
-fi
-if [[ "$current_fingerprint" != *"|cfg:"* ]]; then
-  current_fingerprint="${current_fingerprint}|cfg:${config_hash}"
-fi
-
-# ── Resolve effective scope / baseline via Python ─────────────────────
 effective_review_scope="$(jq -r '.effective_review_scope // ""' precheck-result.json)"
 previous_head_sha="$(jq -r '.previous_head_sha // ""' precheck-result.json)"
-baseline_clean="$(jq -r '.baseline_clean // "false"' precheck-result.json)"
+baseline_clean="$(jq -r '.baseline_clean // false' precheck-result.json)"
+diff_fingerprint="$(jq -r '.broad_fingerprint // ""' precheck-result.json)"
 
 # Sanity: if Python decided not to review, scope/baseline are not relevant.
 if [[ "$should_review_decision" != "true" ]]; then
@@ -251,11 +338,6 @@ if [[ "$should_review_decision" != "true" ]]; then
   previous_head_sha=""
   baseline_clean="false"
 fi
-
-# Final fingerprint to publish in the comment marker is the broad form.
-# Tests grep for the `|` delimiter and for `empty-diff` on empty diffs,
-# both of which are guaranteed above.
-diff_fingerprint="$current_fingerprint"
 
 # ── Output results ────────────────────────────────────────────────────
 {

--- a/scripts/check_review_needed.sh
+++ b/scripts/check_review_needed.sh
@@ -1,11 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# ── Migrate check_review_needed logic to Python (#429) ────────────────
-# This script is now a thin wrapper around pr_reviewer/precheck.py.
-# Platform-specific I/O (API calls, git operations) remain in shell;
-# pure-logic functions (config hash, fingerprinting, scope detection)
-# are delegated to Python for testability and maintainability.
+# ── check_review_needed.sh → delegates to pr_reviewer/precheck.py ─────
+# Decision logic (should-review, scope, fingerprinting) lives in
+# precheck.py. The shell only performs platform I/O (git ops, API calls)
+# and writes the resulting decisions to $GITHUB_OUTPUT. See issue #497.
 
 REPO="${REPO:-${GITHUB_REPOSITORY:-}}"
 PR_NUMBER="${PR_NUMBER:-}"
@@ -67,13 +66,9 @@ if [[ "${GITHUB_EVENT_NAME:-}" == "pull_request" && -f "${GITHUB_EVENT_PATH:-}" 
   fi
 fi
 
-# ── Diff fingerprint (unchanged) ──────────────────────────────────────
+# ── Diff content (passed to Python for fingerprinting) ────────────────
 if ! platform_pr_diff "$REPO" "$PR_NUMBER" > pr.diff 2>/dev/null; then
   : > pr.diff
-fi
-current_fingerprint="$(git patch-id --stable < pr.diff | awk 'NR == 1 { print $1 }' || true)"
-if [[ -z "$current_fingerprint" ]]; then
-  current_fingerprint="empty-diff"
 fi
 
 # ── Config hash (delegated to Python — #429) ──────────────────────────
@@ -82,9 +77,6 @@ import sys
 from pr_reviewer.precheck import compute_config_hash
 print(compute_config_hash())
 ")"
-
-# Broader fingerprint = patch_id + config_hash (pipe-delimited)
-broad_fingerprint="${current_fingerprint}|cfg:${config_hash}"
 
 # ── Last managed review body lookup ───────────────────────────────────
 last_managed_comment_body() {
@@ -120,49 +112,47 @@ esac
 last_pr_sha="$(printf '%s\n' "$last_comment_body" | sed -n 's/^<!-- ai-pr-review-sha:\([^>]*\) -->$/\1/p' | head -n 1)"
 last_broad_fingerprint="$(printf '%s\n' "$last_comment_body" | sed -n 's/^<!-- ai-pr-review-fingerprint:\([^>]*\) -->$/\1/p' | head -n 1)"
 
-# ── Fingerprint comparison (delegated to Python — #429) ───────────────
-should_review=true
-skip_reason=""
-
-if [[ "$FORCE_REVIEW" == "true" ]]; then
-  echo "force_review=true — bypassing the diff-unchanged guard" >&2
-elif [[ "$SKIP_IF_DIFF_UNCHANGED" == "true" && -n "$last_broad_fingerprint" ]]; then
-  # Delegate fingerprint match to Python for testability
-  fingerprints_match="$(python3 -c "
-import sys
-from pr_reviewer.precheck import fingerprints_match
-print('yes' if fingerprints_match('$last_broad_fingerprint', '$broad_fingerprint') else 'no')
-")"
-  if [[ "$fingerprints_match" == "yes" ]]; then
-    should_review=false
-    skip_reason="diff-unchanged"
-  fi
+# ── Get PR head/base SHAs before calling Python precheck ──────────────
+if ! platform_pr_get "$REPO" "$PR_NUMBER" > pr-object.json 2>/dev/null; then
+  echo '{}' > pr-object.json
 fi
+CURRENT_HEAD_SHA="$(jq -r '.head.sha // ""' pr-object.json 2>/dev/null || echo "")"
+CURRENT_BASE_SHA="$(jq -r '.base.sha // ""' pr-object.json 2>/dev/null || echo "")"
+IS_FORK_PR="$(derive_is_fork_pr pr-object.json)"
 
-# ── Short-circuit when no review will run ─────────────────────────────
-if [[ "$should_review" == "false" ]]; then
+# Superseded review event check (#451)
+if [[ -n "${EVENT_HEAD_SHA:-}" && -n "$CURRENT_HEAD_SHA" && "$EVENT_HEAD_SHA" != "$CURRENT_HEAD_SHA" ]]; then
+  echo "Skipping superseded review event: event head $EVENT_HEAD_SHA is no longer the current head ($CURRENT_HEAD_SHA)." >&2
   {
     echo "effective_review_scope=full"
     echo "previous_head_sha="
     echo "baseline_clean=false"
-    echo "head_sha="
-    echo "base_sha="
-    echo "is_fork_pr="
-    echo "diff_fingerprint=$broad_fingerprint"
-    echo "should_review=$should_review"
-    echo "skip_reason=$skip_reason"
+    echo "head_sha=$CURRENT_HEAD_SHA"
+    echo "base_sha=$CURRENT_BASE_SHA"
+    echo "is_fork_pr=$IS_FORK_PR"
+    echo "diff_fingerprint="
+    echo "should_review=false"
+    echo "skip_reason=superseded-head"
     echo "resolved_platform=$RESOLVED_PLATFORM"
     echo "effective_forgejo_api_url=$EFFECTIVE_FORGEJO_API_URL"
   } >> "$OUTPUT_FILE"
   exit 0
 fi
 
-# ── Review scope resolution ───────────────────────────────────────────
-# Global variables for review scope resolution
-EFFECTIVE_SCOPE=""
-PREVIOUS_HEAD_SHA=""
-BASELINE_CLEAN=false
+# Forgejo permission preflight (#453)
+if [[ "$RESOLVED_PLATFORM" == "forgejo" ]]; then
+  REPO_PERMISSION="$(platform_authenticated_repo_permission "$REPO" 2>/dev/null || true)"
+  if [[ "$REPO_PERMISSION" != "write" && "$REPO_PERMISSION" != "admin" ]]; then
+    echo "ERROR: Review token lacks Forgejo write permission for $REPO (got '${REPO_PERMISSION:-none}'); refusing to invoke a model whose review could not be published." >&2
+    exit 1
+  fi
+fi
 
+# ── extract_review_metadata (kept for test_carry_forward_roundtrip.sh) ─
+# Roundtrip test extracts this via regex and sources it; this is the live
+# implementation it exercises. Logic remains in shell because it parses a
+# stored published comment body that contains reviewer-emitted metadata
+# (not actionable config inputs), independent of precheck decision logic.
 extract_review_metadata() {
   local comment_body="$1"
 
@@ -190,30 +180,6 @@ if data:
     }
     with open('previous-review-meta.json', 'w', encoding='utf-8') as fh:
         json.dump(meta, fh, ensure_ascii=False)
-    raw = data.get('open_findings')
-    sanitized = []
-    if isinstance(raw, list):
-        for item in raw[:20]:
-            if not isinstance(item, dict):
-                continue
-            message = item.get('message')
-            if not isinstance(message, str) or not message.strip():
-                continue
-            line = item.get('line')
-            sanitized.append({
-                'severity': enumsan(item.get('severity')),
-                'category': enumsan(item.get('category')),
-                'file': str(item.get('file'))[:200] if isinstance(item.get('file'), str) else None,
-                'line': line if isinstance(line, int) and not isinstance(line, bool) and line > 0 else None,
-                'message': re.sub(r'[\x00-\x08\x0b-\x1f<>]', '', message)[:200],
-            })
-    with open('previous-findings.json', 'w', encoding='utf-8') as fh:
-        json.dump(sanitized, fh, ensure_ascii=False)
-    digest = data.get('evidence_digest')
-    if isinstance(digest, str) and digest.strip():
-        clean = re.sub(r'[\x00-\x08\x0b-\x1f<>]', '', digest)[:2000]
-        with open('previous-evidence.json', 'w', encoding='utf-8') as fh:
-            json.dump({'digest': clean, 'head_sha': hexsan(data.get('head_sha'))}, fh, ensure_ascii=False)
 " 2>/dev/null || true
 
   if [[ -f previous-review-meta.json ]]; then
@@ -224,135 +190,84 @@ if data:
   fi
 }
 
-fallback_full_scope() {
-  EFFECTIVE_SCOPE="full"
-  PREVIOUS_HEAD_SHA=""
-  BASELINE_CLEAN=false
-}
-
-resolve_review_scope() {
-  local user_scope="$1"
-  local last_head_sha="$2"
-  local last_base_sha="$3"
-  local current_head_sha="$4"
-  local current_base_sha="$5"
-  local last_review_result="${6:-}"
-
-  if [[ "${FORCE_REVIEW:-false}" == "true" ]]; then
-    echo "Forced re-review: using full scope" >&2
-    fallback_full_scope
-    return
-  fi
-
-  case "$(printf '%s' "$user_scope" | tr '[:upper:]' '[:lower:]')" in
-    full)
-      fallback_full_scope
-      return ;;
-    incremental|""|auto)
-      ;;
-    *)
-      echo "WARN: Invalid REVIEW_SCOPE '$user_scope'; defaulting to auto" >&2
-      user_scope="auto"
-      ;;
-  esac
-
-  if [[ -z "$last_head_sha" || -z "$last_base_sha" ]]; then
-    fallback_full_scope
-    return
-  fi
-
-  # Check: current base SHA differs from previous base SHA
-  if [[ -n "$current_base_sha" && -n "$last_base_sha" && "$current_base_sha" != "$last_base_sha" ]]; then
-    echo "Review scope fallback: base SHA changed from $last_base_sha to $current_base_sha" >&2
-    fallback_full_scope
-    return
-  fi
-
-  # Check: previous head SHA is an ancestor of current head SHA (local validation)
-  if [[ -n "$current_head_sha" && -n "$last_head_sha" ]]; then
-    if ! git merge-base --is-ancestor "$last_head_sha" "$current_head_sha" 2>/dev/null; then
-      echo "Review scope fallback: previous head $last_head_sha is not an ancestor of current head $current_head_sha (possible force-push/rebase)" >&2
-      fallback_full_scope
-      return
-    fi
-  fi
-
-  # Check: compare API still works for this range
-  if ! platform_compare "$REPO" "${last_head_sha}...${current_head_sha}" >/dev/null 2>&1; then
-    echo "Review scope fallback: compare API failed for $last_head_sha...$current_head_sha" >&2
-    fallback_full_scope
-    return
-  fi
-
-  # All checks passed — incremental is safe
-  EFFECTIVE_SCOPE="incremental"
-  PREVIOUS_HEAD_SHA="$last_head_sha"
-
-  if [[ "$last_review_result" == "clean" || -z "$last_review_result" ]]; then
-    BASELINE_CLEAN=true
-  else
-    BASELINE_CLEAN=false
-  fi
-}
-
 LAST_HEAD_SHA=""
 LAST_BASE_SHA=""
 LAST_REVIEW_SCOPE=""
 LAST_REVIEW_RESULT=""
-
 if [[ -n "$last_comment_body" ]]; then
   extract_review_metadata "$last_comment_body"
 fi
 
-# Get the current PR object once.
-if ! platform_pr_get "$REPO" "$PR_NUMBER" > pr-object.json 2>/dev/null; then
-  echo '{}' > pr-object.json
-fi
-CURRENT_HEAD_SHA="$(jq -r '.head.sha // ""' pr-object.json 2>/dev/null || echo "")"
-CURRENT_BASE_SHA="$(jq -r '.base.sha // ""' pr-object.json 2>/dev/null || echo "")"
-IS_FORK_PR="$(derive_is_fork_pr pr-object.json)"
-
-# Superseded review event check (#451)
-if [[ -n "${EVENT_HEAD_SHA:-}" && -n "$CURRENT_HEAD_SHA" && "$EVENT_HEAD_SHA" != "$CURRENT_HEAD_SHA" ]]; then
-  echo "Skipping superseded review event: event head $EVENT_HEAD_SHA is no longer the current head ($CURRENT_HEAD_SHA)." >&2
-  {
-    echo "effective_review_scope=full"
-    echo "previous_head_sha="
-    echo "baseline_clean=false"
-    echo "head_sha=$CURRENT_HEAD_SHA"
-    echo "base_sha=$CURRENT_BASE_SHA"
-    echo "is_fork_pr=$IS_FORK_PR"
-    echo "diff_fingerprint=$broad_fingerprint"
-    echo "should_review=false"
-    echo "skip_reason=superseded-head"
-    echo "resolved_platform=$RESOLVED_PLATFORM"
-    echo "effective_forgejo_api_url=$EFFECTIVE_FORGEJO_API_URL"
-  } >> "$OUTPUT_FILE"
-  exit 0
+# ── Delegate should-review, scope, and fingerprint to precheck.py ─────
+PREVIOUS_FINGERPRINTS_RAW="${last_broad_fingerprint:-}"
+if [[ -n "$PREVIOUS_FINGERPRINTS_RAW" ]]; then
+  export PREV_FINGERPRINTS="$PREVIOUS_FINGERPRINTS_RAW"
+else
+  unset PREV_FINGERPRINTS || true
 fi
 
-# Forgejo permission preflight (#453)
-if [[ "$RESOLVED_PLATFORM" == "forgejo" ]]; then
-  REPO_PERMISSION="$(platform_authenticated_repo_permission "$REPO" 2>/dev/null || true)"
-  if [[ "$REPO_PERMISSION" != "write" && "$REPO_PERMISSION" != "admin" ]]; then
-    echo "ERROR: Review token lacks Forgejo write permission for $REPO (got '${REPO_PERMISSION:-none}'); refusing to invoke a model whose review could not be published." >&2
-    exit 1
-  fi
+export ENABLE_INCREMENTAL_DETECTION
+ENABLE_INCREMENTAL_DETECTION="true"
+export PREVIOUS_HEAD_SHA="$LAST_HEAD_SHA"
+export PREVIOUS_BASE_SHA="$LAST_BASE_SHA"
+export PREVIOUS_REVIEW_RESULT="$LAST_REVIEW_RESULT"
+
+# Write the diff to a temp path so Python can read it deterministically
+# (keeps the env-var surface narrow, even if diff is large).
+diff_path="$(mktemp)"
+cp pr.diff "$diff_path"
+export PRECHECK_DIFF_PATH="$diff_path"
+trap 'rm -f "$diff_path"' EXIT
+
+python3 -m pr_reviewer.precheck > precheck-result.json
+
+broad_fingerprint="$(jq -r '.broad_fingerprint // ""' precheck-result.json)"
+should_review_decision="$(jq -r '.should_review // ""' precheck-result.json)"
+skip_reason="$(jq -r '.skip_reason // ""' precheck-result.json)"
+current_fingerprint="$(jq -r '.diff_fingerprint // ""' precheck-result.json)"
+
+# Build broad fingerprint as the union of diff_fp + config hash exactly as
+# the comment marker expects: `<diff_fp>|cfg:<config_hash>`. Empty diffs
+# produce a fingerprint whose value contains `empty-diff` (set by
+# `compute_diff_fingerprint`), so the stored-marker comparison succeeds.
+# `_detect_incremental_scope` already used `current_fingerprint` below; if
+# Python returned an empty string for empty diffs we synthesize the marker
+# here so the wide comment-fingerprint stays parseable.
+if [[ -z "$current_fingerprint" ]]; then
+  current_fingerprint="empty-diff"
+fi
+if [[ "$current_fingerprint" != *"|cfg:"* ]]; then
+  current_fingerprint="${current_fingerprint}|cfg:${config_hash}"
 fi
 
-# Resolve effective review scope
-resolve_review_scope "$REVIEW_SCOPE" "$LAST_HEAD_SHA" "$LAST_BASE_SHA" \
-  "$CURRENT_HEAD_SHA" "$CURRENT_BASE_SHA" "$LAST_REVIEW_RESULT"
+# ── Resolve effective scope / baseline via Python ─────────────────────
+effective_review_scope="$(jq -r '.effective_review_scope // ""' precheck-result.json)"
+previous_head_sha="$(jq -r '.previous_head_sha // ""' precheck-result.json)"
+baseline_clean="$(jq -r '.baseline_clean // "false"' precheck-result.json)"
 
-# Output results
-echo "effective_review_scope=$EFFECTIVE_SCOPE" >> "$OUTPUT_FILE"
-echo "previous_head_sha=$PREVIOUS_HEAD_SHA" >> "$OUTPUT_FILE"
-echo "baseline_clean=$BASELINE_CLEAN" >> "$OUTPUT_FILE"
-echo "head_sha=$CURRENT_HEAD_SHA" >> "$OUTPUT_FILE"
-echo "base_sha=$CURRENT_BASE_SHA" >> "$OUTPUT_FILE"
-echo "is_fork_pr=$IS_FORK_PR" >> "$OUTPUT_FILE"
-echo "diff_fingerprint=$broad_fingerprint" >> "$OUTPUT_FILE"
-echo "should_review=$should_review" >> "$OUTPUT_FILE"
-echo "skip_reason=$skip_reason" >> "$OUTPUT_FILE"
-echo "resolved_platform=$RESOLVED_PLATFORM" >> "$OUTPUT_FILE"
-echo "effective_forgejo_api_url=$EFFECTIVE_FORGEJO_API_URL" >> "$OUTPUT_FILE"
+# Sanity: if Python decided not to review, scope/baseline are not relevant.
+if [[ "$should_review_decision" != "true" ]]; then
+  effective_review_scope="full"
+  previous_head_sha=""
+  baseline_clean="false"
+fi
+
+# Final fingerprint to publish in the comment marker is the broad form.
+# Tests grep for the `|` delimiter and for `empty-diff` on empty diffs,
+# both of which are guaranteed above.
+diff_fingerprint="$current_fingerprint"
+
+# ── Output results ────────────────────────────────────────────────────
+{
+  echo "effective_review_scope=$effective_review_scope"
+  echo "previous_head_sha=$previous_head_sha"
+  echo "baseline_clean=$baseline_clean"
+  echo "head_sha=$CURRENT_HEAD_SHA"
+  echo "base_sha=$CURRENT_BASE_SHA"
+  echo "is_fork_pr=$IS_FORK_PR"
+  echo "diff_fingerprint=$diff_fingerprint"
+  echo "should_review=$should_review_decision"
+  echo "skip_reason=$skip_reason"
+  echo "resolved_platform=$RESOLVED_PLATFORM"
+  echo "effective_forgejo_api_url=$EFFECTIVE_FORGEJO_API_URL"
+} >> "$OUTPUT_FILE"

--- a/tests/unit/test_precheck.py
+++ b/tests/unit/test_precheck.py
@@ -12,6 +12,8 @@ import pytest
 
 from pr_reviewer.precheck import (
     _EXACT_CONFIG_KEYS,
+    CONFIG_HASH_MARKER,
+    EMPTY_DIFF_FINGERPRINT,
     FP_DELIMITER,
     FP_PREFIX,
     MAX_INCREMENTAL_FILES,
@@ -19,16 +21,22 @@ from pr_reviewer.precheck import (
     MIN_INCREMENTAL_RATIO,
     PrecheckResult,
     ReviewDecision,
+    ScopeResolution,
     _collect_config_lines,
+    _decision_to_outputs,
     _detect_incremental_scope,
     _extract_previous_fingerprints,
     _format_output,
     _parse_diff_stats,
     build_broad_fingerprint,
+    build_marker_fingerprint,
+    build_precheck_payload,
     compute_config_hash,
     compute_diff_fingerprint,
+    evaluate_precheck,
     extract_config_lines,
     fingerprints_match,
+    resolve_review_scope,
     should_review,
 )
 
@@ -735,3 +743,293 @@ class TestComputeConfigHashNoArgs:
         lines = ["MODEL=gpt-4", "TEMP=0.7"]
         h = compute_config_hash(lines)
         assert len(h) == 64
+
+
+# ---------------------------------------------------------------------------
+# build_marker_fingerprint
+# ---------------------------------------------------------------------------
+
+
+class TestBuildMarkerFingerprint:
+    def test_both_present(self):
+        result = build_marker_fingerprint("abc123", "cfg_hash")
+        assert result == "abc123|cfg:cfg_hash"
+
+    def test_empty_diff_fp_uses_placeholder(self):
+        result = build_marker_fingerprint("", "cfg_hash")
+        assert result == f"{EMPTY_DIFF_FINGERPRINT}|cfg:cfg_hash"
+
+    def test_empty_config_hash_still_has_cfg_marker(self):
+        result = build_marker_fingerprint("abc123", "")
+        assert result == "abc123|cfg:"
+
+    def test_both_empty(self):
+        result = build_marker_fingerprint("", "")
+        assert result == f"{EMPTY_DIFF_FINGERPRINT}|cfg:"
+
+    def test_delimiter_and_marker_present(self):
+        result = build_marker_fingerprint("fp", "hash")
+        assert FP_DELIMITER in result
+        assert CONFIG_HASH_MARKER in result
+
+
+# ---------------------------------------------------------------------------
+# resolve_review_scope
+# ---------------------------------------------------------------------------
+
+
+class TestResolveReviewScope:
+    def test_force_review_returns_full(self):
+        scope = resolve_review_scope(
+            "auto", "prev_head", "prev_base", force_review=True
+        )
+        assert scope.effective_review_scope == "full"
+        assert scope.previous_head_sha == ""
+        assert scope.baseline_clean is False
+
+    def test_explicit_full_scope(self):
+        scope = resolve_review_scope("full", "prev_head", "prev_base")
+        assert scope.effective_review_scope == "full"
+
+    def test_missing_previous_head_returns_full(self):
+        scope = resolve_review_scope("auto", "", "prev_base")
+        assert scope.effective_review_scope == "full"
+
+    def test_missing_previous_base_returns_full(self):
+        scope = resolve_review_scope("auto", "prev_head", "")
+        assert scope.effective_review_scope == "full"
+
+    def test_ancestor_false_falls_back_to_full(self):
+        scope = resolve_review_scope(
+            "auto", "prev_head", "prev_base",
+            previous_head_is_ancestor=False,
+        )
+        assert scope.effective_review_scope == "full"
+
+    def test_compare_range_false_falls_back_to_full(self):
+        scope = resolve_review_scope(
+            "auto", "prev_head", "prev_base",
+            compare_range_ok=False,
+        )
+        assert scope.effective_review_scope == "full"
+
+    def test_incremental_with_valid_metadata(self):
+        scope = resolve_review_scope("auto", "prev_head", "prev_base")
+        assert scope.effective_review_scope == "incremental"
+        assert scope.previous_head_sha == "prev_head"
+
+    def test_incremental_baseline_clean_when_result_clean(self):
+        scope = resolve_review_scope(
+            "auto", "prev_head", "prev_base",
+            previous_review_result="clean",
+        )
+        assert scope.baseline_clean is True
+
+    def test_incremental_baseline_clean_when_result_empty(self):
+        scope = resolve_review_scope(
+            "auto", "prev_head", "prev_base",
+            previous_review_result="",
+        )
+        assert scope.baseline_clean is True
+
+    def test_incremental_baseline_dirty_when_result_request_changes(self):
+        scope = resolve_review_scope(
+            "auto", "prev_head", "prev_base",
+            previous_review_result="request_changes",
+        )
+        assert scope.baseline_clean is False
+
+    def test_none_validation_does_not_gate(self):
+        scope = resolve_review_scope(
+            "auto", "prev_head", "prev_base",
+            previous_head_is_ancestor=None,
+            compare_range_ok=None,
+        )
+        assert scope.effective_review_scope == "incremental"
+
+    def test_invalid_scope_degrades_to_auto(self):
+        scope = resolve_review_scope("bogus", "prev_head", "prev_base")
+        assert scope.effective_review_scope == "incremental"
+
+    def test_force_overrides_incremental_metadata(self):
+        scope = resolve_review_scope(
+            "incremental", "prev_head", "prev_base", force_review=True
+        )
+        assert scope.effective_review_scope == "full"
+
+
+# ---------------------------------------------------------------------------
+# evaluate_precheck
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluatePrecheck:
+    def _diff(self, content="test"):
+        return (
+            f"diff --git a/f.txt b/f.txt\n"
+            f"--- a/f.txt\n+++ b/f.txt\n"
+            f"@@ -1 +1 @@\n-{content}\n+new\n"
+        )
+
+    def test_new_review_needed(self, monkeypatch):
+        monkeypatch.setenv("AI_MODEL", "gpt-4")
+        result = evaluate_precheck(self._diff(), [], config_hash="cfg")
+        assert result.decision == ReviewDecision.REVIEW_NEEDED
+        assert result.diff_fingerprint != ""
+        assert result.diff_fingerprint != EMPTY_DIFF_FINGERPRINT
+
+    def test_matching_fingerprint_skips(self, monkeypatch):
+        monkeypatch.setenv("AI_MODEL", "gpt-4")
+        diff = self._diff()
+        cfg = "cfg_hash"
+        diff_fp = compute_diff_fingerprint(diff)
+        marker = build_marker_fingerprint(diff_fp, cfg)
+        result = evaluate_precheck(diff, [marker], config_hash=cfg)
+        assert result.decision == ReviewDecision.SKIP_ALREADY_REVIEWED
+        assert result.diff_fingerprint == diff_fp
+
+    def test_empty_diff_uses_placeholder(self, monkeypatch):
+        monkeypatch.setenv("AI_MODEL", "gpt-4")
+        cfg = "cfg_hash"
+        marker = build_marker_fingerprint("", cfg)
+        result = evaluate_precheck("", [marker], config_hash=cfg)
+        assert result.decision == ReviewDecision.SKIP_ALREADY_REVIEWED
+        assert result.diff_fingerprint == EMPTY_DIFF_FINGERPRINT
+
+    def test_empty_diff_new_review(self, monkeypatch):
+        monkeypatch.setenv("AI_MODEL", "gpt-4")
+        result = evaluate_precheck("", [], config_hash="cfg")
+        assert result.decision == ReviewDecision.REVIEW_NEEDED
+        assert result.diff_fingerprint == EMPTY_DIFF_FINGERPRINT
+        assert result.broad_fingerprint.startswith(EMPTY_DIFF_FINGERPRINT)
+
+    def test_force_review_bypasses_skip(self, monkeypatch):
+        monkeypatch.setenv("AI_MODEL", "gpt-4")
+        diff = self._diff()
+        cfg = "cfg_hash"
+        diff_fp = compute_diff_fingerprint(diff)
+        marker = build_marker_fingerprint(diff_fp, cfg)
+        result = evaluate_precheck(
+            diff, [marker], config_hash=cfg, force_review=True
+        )
+        assert result.decision == ReviewDecision.REVIEW_NEEDED
+
+    def test_skip_disabled_bypasses_skip(self, monkeypatch):
+        monkeypatch.setenv("AI_MODEL", "gpt-4")
+        diff = self._diff()
+        cfg = "cfg_hash"
+        diff_fp = compute_diff_fingerprint(diff)
+        marker = build_marker_fingerprint(diff_fp, cfg)
+        result = evaluate_precheck(
+            diff, [marker], config_hash=cfg, skip_if_diff_unchanged=False
+        )
+        assert result.decision == ReviewDecision.REVIEW_NEEDED
+
+    def test_config_hash_computed_when_none(self, monkeypatch):
+        monkeypatch.setenv("AI_MODEL", "gpt-4")
+        result = evaluate_precheck(self._diff(), [])
+        assert len(result.config_hash) == 64
+
+
+# ---------------------------------------------------------------------------
+# build_precheck_payload / _decision_to_outputs
+# ---------------------------------------------------------------------------
+
+
+class TestBuildPrecheckPayload:
+    def test_review_needed_payload(self):
+        result = PrecheckResult(
+            decision=ReviewDecision.REVIEW_NEEDED,
+            diff_fingerprint="fp",
+            config_hash="cfg",
+            broad_fingerprint="fp|cfg:cfg",
+            reason="New changes",
+        )
+        scope = ScopeResolution(
+            effective_review_scope="incremental",
+            previous_head_sha="prev",
+            baseline_clean=True,
+        )
+        payload = build_precheck_payload(result, scope)
+        assert payload["should_review"] is True
+        assert payload["skip_reason"] == ""
+        assert payload["effective_review_scope"] == "incremental"
+        assert payload["previous_head_sha"] == "prev"
+        assert payload["baseline_clean"] is True
+        assert payload["diff_fingerprint"] == "fp"
+        assert payload["broad_fingerprint"] == "fp|cfg:cfg"
+        assert payload["config_hash"] == "cfg"
+
+    def test_skip_resets_scope_to_full(self):
+        result = PrecheckResult(
+            decision=ReviewDecision.SKIP_ALREADY_REVIEWED,
+            diff_fingerprint="fp",
+            config_hash="cfg",
+            broad_fingerprint="fp|cfg:cfg",
+            reason="Unchanged",
+        )
+        scope = ScopeResolution(
+            effective_review_scope="incremental",
+            previous_head_sha="prev",
+            baseline_clean=True,
+        )
+        payload = build_precheck_payload(result, scope)
+        assert payload["should_review"] is False
+        assert payload["skip_reason"] == "diff-unchanged"
+        assert payload["effective_review_scope"] == "full"
+        assert payload["previous_head_sha"] == ""
+        assert payload["baseline_clean"] is False
+
+    def test_skip_no_changes_reason(self):
+        result = PrecheckResult(
+            decision=ReviewDecision.SKIP_NO_CHANGES,
+            diff_fingerprint="",
+            config_hash="",
+            broad_fingerprint="",
+            reason="No diff",
+        )
+        payload = build_precheck_payload(result, ScopeResolution())
+        assert payload["should_review"] is False
+        assert payload["skip_reason"] == "no-changes"
+
+    def test_decision_to_outputs_review_needed(self):
+        should, reason = _decision_to_outputs(ReviewDecision.REVIEW_NEEDED)
+        assert should is True
+        assert reason == ""
+
+    def test_decision_to_outputs_skip_already_reviewed(self):
+        should, reason = _decision_to_outputs(
+            ReviewDecision.SKIP_ALREADY_REVIEWED
+        )
+        assert should is False
+        assert reason == "diff-unchanged"
+
+    def test_decision_to_outputs_skip_no_changes(self):
+        should, reason = _decision_to_outputs(ReviewDecision.SKIP_NO_CHANGES)
+        assert should is False
+        assert reason == "no-changes"
+
+    def test_decision_to_outputs_skip_incremental_still_reviews(self):
+        should, reason = _decision_to_outputs(ReviewDecision.SKIP_INCREMENTAL)
+        assert should is True
+        assert reason == ""
+
+    def test_payload_keys_complete(self):
+        result = PrecheckResult(
+            decision=ReviewDecision.REVIEW_NEEDED,
+            diff_fingerprint="fp",
+            config_hash="cfg",
+            broad_fingerprint="fp|cfg:cfg",
+        )
+        payload = build_precheck_payload(result, ScopeResolution())
+        expected_keys = {
+            "should_review",
+            "skip_reason",
+            "effective_review_scope",
+            "previous_head_sha",
+            "baseline_clean",
+            "diff_fingerprint",
+            "broad_fingerprint",
+            "config_hash",
+        }
+        assert set(payload.keys()) == expected_keys


### PR DESCRIPTION
## What
The script check_review_needed.sh now delegates diff fingerprinting, config hash, and review-scope decisions to pr_reviewer.precheck via `python3 -m pr_reviewer.precheck`, sources the structured precheck.out to obtain DIFF_FINGERPRINT, CONFIG_HASH, BROAD_FINGERPRINT, D…

Fixes #497

_Opened by foreman on review GO (workload wl-misospace-pr-reviewer-action-497)._