### PR TITLE
test: cover Forgejo gh_api `compare` endpoint in translation table

### DIFF
--- a/tests/test_platform_gh_api_forgejo.py
+++ b/tests/test_platform_gh_api_forgejo.py
@@ -138,6 +138,31 @@ def test_forgejo_blocks_disallowed_characters(tmp_path, monkeypatch):
     mock_run.assert_not_called()
 
 
+def test_forgejo_compare_endpoint_routes_to_api_v1(monkeypatch):
+    """``repos/{o}/{r}/compare/{base}...{head}`` is rewritten to
+    ``/api/v1/repos/{o}/{r}/compare/{base}...{head}`` and dispatched to
+    the configured Forgejo host.
+
+    Issue #438 lists ``compare`` as one of the endpoint patterns the
+    translation table must cover; this guards against a future
+    refactor silently regressing the entry.
+    """
+    result, captured = _exec_forgejo(
+        monkeypatch,
+        f"repos/{_REPO}/compare/main...feature-branch",
+        body='{"commits": []}',
+    )
+    assert "error" not in result, result
+    cmd = captured["cmd"]
+    assert cmd[0] == "curl"
+    # Translation table rewrote repos/.../compare/... → /api/v1/repos/.../compare/...
+    expected_url = _FORGEJO_BASE + "/api/v1/repos/" + _REPO + "/compare/main...feature-branch"
+    assert any(expected_url in tok for tok in cmd), cmd
+    # The configured Forgejo host is the one being hit, not api.github.com
+    assert "api.github.com" not in " ".join(cmd), cmd
+    assert result == {"data": {"commits": []}}
+
+
 # ---------------------------------------------------------------------------
 # 2. The translated URL goes to the configured Forgejo host — never to
 #    api.github.com — and uses the FORGEJO_TOKEN.


### PR DESCRIPTION
Closes #438.

Adds `test_forgejo_compare_endpoint_routes_to_api_v1` to `tests/test_platform_gh_api_forgejo.py`, asserting that `repos/{o}/{r}/compare/{base}...{head}` is rewritten to the `/api/v1/` form, dispatched to the configured Forgejo host, and never to `api.github.com`.

## Provenance
Written by the Foreman loop, which then failed to open this PR. The branch has been sitting current with main and unreferenced.

The review never ran. The coder pushed this commit on its final attempt, and the next run was dispatched onto the same branch, saw the commit, and correctly reported ALREADY-RESOLVED — so the workload completed with no PR and the review was skipped. The earlier attempts had been demoted from APPROVE to NO-GO because the reviewer's `issueAsk` failed verification: it quoted this commit's own subject line rather than the issue body, and the scope-overlap vouch that would have rescued it is unavailable for test-only diffs (LLMKube#1447).

So this diff has had no machine review that reached a verdict, and no human review. It is offered as unreviewed agent output — CI is the only thing that has looked at it.