### PR TITLE
ci(release): open release PRs as its-miso, not its-saffron

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -29,8 +29,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          client-id: ${{ secrets.BOT_CLIENT_ID }}
-          private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.MISO_APP_ID }}
+          private-key: ${{ secrets.MISO_APP_PRIVATE_KEY }}
 
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
         id: release
@@ -51,8 +51,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          client-id: ${{ secrets.BOT_CLIENT_ID }}
-          private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.MISO_APP_ID }}
+          private-key: ${{ secrets.MISO_APP_PRIVATE_KEY }}
 
       # The sha is read back from the tag release-please just created rather
       # than taken from github.sha, so this cannot drift if the release commit


### PR DESCRIPTION
## Summary
- Switches the release-please app token from `BOT_CLIENT_ID`/`BOT_APP_PRIVATE_KEY` (its-saffron) to `MISO_APP_ID`/`MISO_APP_PRIVATE_KEY` (its-miso).

## Why
The AI PR reviewer authenticates as **its-saffron**, and release-please was opening the release PR as the same app. GitHub refuses a self-approval, so every release PR failed its `review` check:

```
VERDICT: approve
failed to create review: GraphQL: Review Can not approve your own pull request (addPullRequestReview)
```

The review itself was clean. Only the submission failed, which turned a passing review into a red check on every release PR.

The workflow's error hint points at "Allow GitHub Actions to create and approve pull requests". That is a red herring here: the restriction is GitHub refusing self-approval, not a missing setting, so enabling it would not have helped.

This aligns with the convention that PRs are opened by **its-miso** and approvals come from **its-saffron**, which keeps author and reviewer as distinct identities.

## Scope
Only the release-please workflow changes. Every other `BOT_*` usage stays on saffron.

## Verification
- YAML parses; `BOT_CLIENT_ID` no longer present in the workflow.
- `app-id` is a documented input of `actions/create-github-app-token` alongside `client-id`, so `MISO_APP_ID` is used with `app-id:` rather than `client-id:`.