### PR TITLE
fix(ssrf): gate host allowlist on resolved IP

### DIFF
--- a/pr_reviewer/enrichment.py
+++ b/pr_reviewer/enrichment.py
@@ -6,7 +6,9 @@ Consumed by scripts/run_enrichment.py CLI and optionally sourced by shell sectio
 
 from __future__ import annotations
 
+import ipaddress
 import re
+import socket
 from urllib.parse import urlparse
 
 
@@ -55,9 +57,81 @@ def _url_host(url: str) -> str:
     return (parsed.hostname or "").lower()
 
 
+def _is_public_ip(ip: "ipaddress.IPv4Address | ipaddress.IPv6Address") -> bool:
+    """Return True only for IP addresses safe to fetch from.
+
+    Rejects loopback, link-local (incl. cloud IMDS 169.254.169.254),
+    private (RFC-1918 / ULA), multicast, reserved, and unspecified ranges.
+    """
+    return not (
+        ip.is_loopback
+        or ip.is_link_local
+        or ip.is_private
+        or ip.is_multicast
+        or ip.is_reserved
+        or ip.is_unspecified
+    )
+
+
+def _resolve_host_ips(host: str) -> list[str]:
+    """Resolve *host* to a list of IP literal strings.
+
+    If *host* is itself an IP literal, return [host]. Resolution failures
+    return an empty list so the caller treats the host as untrusted.
+    """
+    if not host:
+        return []
+    try:
+        # If host is already an IP literal, return it directly without DNS.
+        ipaddress.ip_address(host)
+        return [host]
+    except ValueError:
+        pass
+    try:
+        infos = socket.getaddrinfo(host, None)
+    except Exception:
+        return []
+    ips: list[str] = []
+    for info in infos:
+        sockaddr = info[4]
+        if sockaddr:
+            ips.append(sockaddr[0])
+    # De-duplicate while preserving order.
+    seen: set[str] = set()
+    unique: list[str] = []
+    for ip in ips:
+        if ip not in seen:
+            seen.add(ip)
+            unique.append(ip)
+    return unique
+
+
+def _host_ips_are_public(host: str) -> bool:
+    """Return True iff every resolved IP for *host* is publicly routable.
+
+    Any private/loopback/link-local resolution is treated as unsafe; this
+    closes the DNS-rebinding / IMDS arc where an allowlisted hostname is
+    pointed at 169.254.169.254 or RFC-1918 space.
+    """
+    ips = _resolve_host_ips(host)
+    if not ips:
+        return False
+    for ip_str in ips:
+        try:
+            ip = ipaddress.ip_address(ip_str)
+        except ValueError:
+            return False
+        if not _is_public_ip(ip):
+            return False
+    return True
+
+
 def host_allowed(url: str, allowed: set[str]) -> bool:
-    """Check if a URL's host is in the allowlist."""
-    return _url_host(url) in allowed
+    """Check if a URL's host is in the allowlist AND resolves only to public IPs."""
+    host = _url_host(url)
+    if host not in allowed:
+        return False
+    return _host_ips_are_public(host)
 
 
 # --- Version hints ---

--- a/pr_reviewer/http_client.py
+++ b/pr_reviewer/http_client.py
@@ -23,8 +23,27 @@ from pr_reviewer.platform import USER_AGENT
 
 
 def _host_allowed(host: str, allowed_hosts: set[str]) -> bool:
-    """Check whether *host* is in the allowlist (case-insensitive)."""
+    """Hostname allowlist check (case-insensitive, no DNS check).
+
+    Use ``_host_resolves_safely`` after this for the resolved-IP gate.
+    """
     return host.lower() in {h.lower() for h in allowed_hosts}
+
+
+def _host_resolves_safely(host: str) -> bool:
+    """Return True iff *host* resolves only to publicly routable IPs.
+
+    Reuses the same predicate as ``pr_reviewer.enrichment.host_allowed`` so
+    the initial fetch and every redirect hop share the SSRF gate. Any
+    link-local / loopback / private resolution is treated as unsafe.
+    """
+    if not host:
+        return False
+    try:
+        from pr_reviewer.enrichment import _host_ips_are_public
+    except ImportError:
+        return True
+    return _host_ips_are_public(host)
 
 
 class _AllowListRedirectHandler(urllib.request.HTTPRedirectHandler):
@@ -33,6 +52,10 @@ class _AllowListRedirectHandler(urllib.request.HTTPRedirectHandler):
     If a redirect target's host is not in the allowlist, raise
     ``URLError`` so the caller sees a clean error instead of silently
     fetching from an arbitrary host (e.g. cloud IMDS).
+
+    The same resolved-IP gate used for the initial URL is re-applied on
+    every hop so a DNS-rebinding redirect cannot smuggle a private or
+    link-local address past the hostname allowlist.
     """
 
     def __init__(self, allowed_hosts: set[str], max_redirects: int = 10):
@@ -53,6 +76,10 @@ class _AllowListRedirectHandler(urllib.request.HTTPRedirectHandler):
         if not _host_allowed(host, self._allowed_hosts):
             raise urllib.error.URLError(
                 f"Redirect to disallowed host: {host}"
+            )
+        if not _host_resolves_safely(host):
+            raise urllib.error.URLError(
+                f"Redirect host {host!r} resolves to a non-public IP"
             )
 
         self._redirect_count += 1
@@ -76,6 +103,10 @@ def fetch_url(
     Validates the host against an allowlist (defaulting to common trusted hosts).
     Re-validates on every redirect hop to prevent SSRF via redirect.
     Returns parsed body bytes on success, or ``None`` on any error.
+
+    Before opening the socket, the hostname is resolved and any
+    link-local / loopback / private address is rejected so DNS-rebinding
+    or an IP-literal allowlisted host cannot reach cloud IMDS.
     """
     if allowed_hosts is None:
         allowed_hosts = {
@@ -93,6 +124,9 @@ def fetch_url(
         return None
 
     if not _host_allowed(host, allowed_hosts):
+        return None
+
+    if not _host_resolves_safely(host):
         return None
 
     try:

--- a/tests/test_redirect_ssrf.py
+++ b/tests/test_redirect_ssrf.py
@@ -6,8 +6,10 @@ Verifies that both ``web_fetch`` (tool_executors) and ``fetch_url``
 """
 
 import http.server
+import socket
 import threading
 import time
+from unittest.mock import patch
 
 import pytest
 
@@ -18,6 +20,23 @@ from pr_reviewer.tool_executors import web_fetch
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+def _stub_public_resolution(monkeypatch, ip="93.184.216.34"):
+    """Patch the resolved-IP gate so loopback / private test addresses
+    are treated as publicly routable.
+
+    These tests exercise the redirect handler; they should not depend on
+    the SSRF resolved-IP gate (covered separately in
+    tests/test_resolved_ip_ssrf.py). Issue #510 closes the SSRF arc; the
+    gate runs alongside the hostname allowlist.
+    """
+    def fake_resolve(host):
+        return [ip]
+    monkeypatch.setattr(
+        "pr_reviewer.enrichment._resolve_host_ips", fake_resolve
+    )
+
 
 class _RedirectHandler(http.server.BaseHTTPRequestHandler):
     """Sends a redirect to *target*."""
@@ -77,8 +96,9 @@ def _start_server(handler_cls, port):
 class TestWebFetchRedirect:
     """web_fetch must re-validate redirect targets against the allowlist."""
 
-    def test_allowlisted_to_allowlisted_succeeds(self):
+    def test_allowlisted_to_allowlisted_succeeds(self, monkeypatch):
         """Allowlisted → allowlisted redirect should succeed."""
+        _stub_public_resolution(monkeypatch)
         srv1 = _start_server(_RedirectHandler, 0)
         port1 = srv1.server_address[1]
         srv2 = _start_server(_OkHandler, 0)
@@ -91,8 +111,9 @@ class TestWebFetchRedirect:
         assert "content" in result, f"Expected success but got: {result}"
         assert "OK-DATA" in result["content"]
 
-    def test_allowlisted_to_imds_fails(self):
+    def test_allowlisted_to_imds_fails(self, monkeypatch):
         """Allowlisted → 169.254.169.254 redirect should be rejected."""
+        _stub_public_resolution(monkeypatch)
         srv = _start_server(_RedirectHandler, 0)
         port = srv.server_address[1]
         _RedirectHandler.target = "http://169.254.169.254/latest/meta-data/"
@@ -102,8 +123,9 @@ class TestWebFetchRedirect:
         assert "error" in result, f"Expected error but got: {result}"
         assert "disallowed host" in result["error"].lower() or "redirect" in result["error"].lower()
 
-    def test_allowlisted_to_localhost_fails(self):
+    def test_allowlisted_to_localhost_fails(self, monkeypatch):
         """Allowlisted → localhost redirect should be rejected."""
+        _stub_public_resolution(monkeypatch)
         srv = _start_server(_RedirectHandler, 0)
         port = srv.server_address[1]
         _RedirectHandler.target = "http://localhost:9999/secret"
@@ -114,8 +136,9 @@ class TestWebFetchRedirect:
         assert "error" in result, f"Expected error but got: {result}"
         assert "disallowed host" in result["error"].lower() or "redirect" in result["error"].lower()
 
-    def test_too_many_redirects_fails(self):
+    def test_too_many_redirects_fails(self, monkeypatch):
         """A chain of >10 redirects should be rejected."""
+        _stub_public_resolution(monkeypatch)
         srv = _start_server(_RedirectHandler, 0)
         port = srv.server_address[1]
         # Redirect to itself (same host, so always allowlisted).
@@ -134,8 +157,9 @@ class TestWebFetchRedirect:
 class TestFetchUrlRedirect:
     """fetch_url must re-validate redirect targets against the allowlist."""
 
-    def test_allowlisted_to_allowlisted_succeeds(self):
+    def test_allowlisted_to_allowlisted_succeeds(self, monkeypatch):
         """Allowlisted → allowlisted redirect should succeed."""
+        _stub_public_resolution(monkeypatch)
         srv1 = _start_server(_RedirectHandler, 0)
         port1 = srv1.server_address[1]
         srv2 = _start_server(_OkHandler, 0)
@@ -149,8 +173,9 @@ class TestFetchUrlRedirect:
         assert result is not None, f"Expected bytes but got: {result}"
         assert b"OK-DATA" in result
 
-    def test_allowlisted_to_imds_fails(self):
+    def test_allowlisted_to_imds_fails(self, monkeypatch):
         """Allowlisted → 169.254.169.254 redirect should be rejected."""
+        _stub_public_resolution(monkeypatch)
         srv = _start_server(_RedirectHandler, 0)
         port = srv.server_address[1]
         _RedirectHandler.target = "http://169.254.169.254/latest/meta-data/"
@@ -159,8 +184,9 @@ class TestFetchUrlRedirect:
 
         assert result is None, f"Expected None but got: {result}"
 
-    def test_allowlisted_to_localhost_fails(self):
+    def test_allowlisted_to_localhost_fails(self, monkeypatch):
         """Allowlisted → localhost redirect should be rejected."""
+        _stub_public_resolution(monkeypatch)
         srv = _start_server(_RedirectHandler, 0)
         port = srv.server_address[1]
         _RedirectHandler.target = "http://localhost:9999/secret"
@@ -169,8 +195,9 @@ class TestFetchUrlRedirect:
 
         assert result is None, f"Expected None but got: {result}"
 
-    def test_too_many_redirects_fails(self):
+    def test_too_many_redirects_fails(self, monkeypatch):
         """A chain of >10 redirects should be rejected."""
+        _stub_public_resolution(monkeypatch)
         srv = _start_server(_RedirectHandler, 0)
         port = srv.server_address[1]
         _RedirectHandler.target = f"http://127.0.0.1:{port}/loop"

--- a/tests/test_resolved_ip_ssrf.py
+++ b/tests/test_resolved_ip_ssrf.py
@@ -1,0 +1,243 @@
+"""SSRF: resolved-IP gate for allowlisted hosts (issue #510).
+
+Covers the remaining gap in the SSRF hardening arc: the hostname allowlist
+is no longer trusted on its own; the hostname must resolve only to
+publicly routable IPs. Link-local (cloud IMDS), loopback, and RFC-1918
+private ranges are refused.
+
+We stub ``socket.getaddrinfo`` (and the urllib opener) so no real
+network traffic is issued.
+"""
+
+from __future__ import annotations
+
+import socket
+import urllib.error
+import urllib.request
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from pr_reviewer.enrichment import host_allowed
+from pr_reviewer.http_client import (
+    _host_resolves_safely,
+    fetch_url,
+)
+
+
+def _fake_getaddrinfo(ips):
+    """Build a fake socket.getaddrinfo returning *ips* (strings)."""
+    def fake(host, port, *args, **kwargs):
+        # socket.getaddrinfo returns 5-tuples: (family, type, proto,
+        # canonname, (host, port)). Keep canonname empty.
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", (ip, port or 0)) for ip in ips]
+    return fake
+
+
+# --- enrichment.host_allowed --------------------------------------------------
+
+class TestHostAllowedResolvedIPGate:
+    """``host_allowed`` must require every resolved IP to be public."""
+
+    def test_allowlisted_host_resolves_only_to_public_ips(self):
+        with patch(
+            "pr_reviewer.enrichment.socket.getaddrinfo",
+            _fake_getaddrinfo(["93.184.216.34"]),
+        ):
+            assert host_allowed(
+                "https://example.com/x", {"example.com"}
+            ) is True
+
+    def test_allowlisted_host_resolves_to_imds_link_local(self):
+        """169.254.169.254 is the canonical AWS/GCP/Azure IMDS endpoint."""
+        with patch(
+            "pr_reviewer.enrichment.socket.getaddrinfo",
+            _fake_getaddrinfo(["169.254.169.254"]),
+        ):
+            assert host_allowed(
+                "https://example.com/x", {"example.com"}
+            ) is False
+
+    def test_allowlisted_host_resolves_to_loopback(self):
+        with patch(
+            "pr_reviewer.enrichment.socket.getaddrinfo",
+            _fake_getaddrinfo(["127.0.0.1"]),
+        ):
+            assert host_allowed(
+                "https://example.com/x", {"example.com"}
+            ) is False
+
+    def test_allowlisted_host_resolves_to_ipv6_loopback(self):
+        with patch(
+            "pr_reviewer.enrichment.socket.getaddrinfo",
+            _fake_getaddrinfo(["::1"]),
+        ):
+            assert host_allowed(
+                "https://example.com/x", {"example.com"}
+            ) is False
+
+    def test_allowlisted_host_resolves_to_private_rfc1918(self):
+        with patch(
+            "pr_reviewer.enrichment.socket.getaddrinfo",
+            _fake_getaddrinfo(["10.0.0.5"]),
+        ):
+            assert host_allowed(
+                "https://example.com/x", {"example.com"}
+            ) is False
+
+    def test_allowlisted_host_resolves_to_private_192(self):
+        with patch(
+            "pr_reviewer.enrichment.socket.getaddrinfo",
+            _fake_getaddrinfo(["192.168.1.10"]),
+        ):
+            assert host_allowed(
+                "https://example.com/x", {"example.com"}
+            ) is False
+
+    def test_allowlisted_host_resolves_to_mixed_public_and_link_local(self):
+        """Any non-public resolution poisons the result (rebind defense)."""
+        with patch(
+            "pr_reviewer.enrichment.socket.getaddrinfo",
+            _fake_getaddrinfo(["93.184.216.34", "169.254.169.254"]),
+        ):
+            assert host_allowed(
+                "https://example.com/x", {"example.com"}
+            ) is False
+
+    def test_hostname_not_in_allowlist_still_rejected(self):
+        with patch(
+            "pr_reviewer.enrichment.socket.getaddrinfo",
+            _fake_getaddrinfo(["93.184.216.34"]),
+        ):
+            assert host_allowed(
+                "https://other.example/x", {"example.com"}
+            ) is False
+
+    def test_ip_literal_in_allowlist_resolves_to_public(self):
+        with patch(
+            "pr_reviewer.enrichment.socket.getaddrinfo",
+            _fake_getaddrinfo(["93.184.216.34"]),
+        ):
+            assert host_allowed(
+                "https://93.184.216.34/x", {"93.184.216.34"}
+            ) is True
+
+    def test_ip_literal_in_allowlist_resolves_to_link_local(self):
+        """An IP-literal allowlisted entry that is itself link-local is refused."""
+        with patch(
+            "pr_reviewer.enrichment.socket.getaddrinfo",
+            _fake_getaddrinfo(["169.254.169.254"]),
+        ):
+            assert host_allowed(
+                "https://169.254.169.254/latest/meta-data/",
+                {"169.254.169.254"},
+            ) is False
+
+    def test_resolution_failure_rejects_host(self):
+        """DNS failure is treated as unsafe, not as a pass-through."""
+        def fail(*_args, **_kwargs):
+            raise socket.gaierror("no such host")
+        with patch(
+            "pr_reviewer.enrichment.socket.getaddrinfo",
+            fail,
+        ):
+            assert host_allowed(
+                "https://example.com/x", {"example.com"}
+            ) is False
+
+
+# --- http_client.fetch_url ---------------------------------------------------
+
+class TestFetchUrlResolvedIPGate:
+    """``fetch_url`` must short-circuit before opening the socket."""
+
+    def test_returns_none_when_resolution_is_link_local(self):
+        """The acceptance test: link-local resolution ⇒ no request issued."""
+        captured: dict[str, object] = {"called": False}
+
+        def fail_open(*args, **kwargs):
+            captured["called"] = True
+            raise AssertionError("urllib opener must not be invoked")
+
+        with patch(
+            "pr_reviewer.enrichment.socket.getaddrinfo",
+            _fake_getaddrinfo(["169.254.169.254"]),
+        ), patch(
+            "urllib.request.build_opener", side_effect=fail_open
+        ):
+            assert fetch_url("https://example.com/x") is None
+        assert captured["called"] is False
+
+    def test_returns_none_when_resolution_is_loopback(self):
+        with patch(
+            "pr_reviewer.enrichment.socket.getaddrinfo",
+            _fake_getaddrinfo(["127.0.0.1"]),
+        ):
+            assert fetch_url(
+                "https://example.com/x",
+                allowed_hosts={"example.com"},
+            ) is None
+
+    def test_ip_literal_link_local_in_allowlist_rejected(self):
+        """Even when the link-local IP is itself in the allowlist."""
+        with patch(
+            "pr_reviewer.enrichment.socket.getaddrinfo",
+            _fake_getaddrinfo(["169.254.169.254"]),
+        ):
+            assert fetch_url(
+                "https://169.254.169.254/latest/meta-data/iam/info",
+                allowed_hosts={"169.254.169.254"},
+            ) is None
+
+    def test_fetch_proceeds_when_resolution_is_public(self, monkeypatch):
+        """Sanity check: a publicly-routable resolution still allows the fetch."""
+        opened = MagicMock()
+        opened.__enter__.return_value.read.return_value = b"ok"
+        opener = MagicMock()
+        opener.open.return_value = opened
+
+        monkeypatch.setattr(
+            "pr_reviewer.enrichment.socket.getaddrinfo",
+            _fake_getaddrinfo(["93.184.216.34"]),
+        )
+        monkeypatch.setattr(
+            "urllib.request.build_opener", lambda *a, **kw: opener
+        )
+        assert fetch_url(
+            "https://example.com/x",
+            allowed_hosts={"example.com"},
+        ) == b"ok"
+
+
+# --- http_client redirect handler -------------------------------------------
+
+class TestRedirectResolvedIPGate:
+    """The same resolved-IP gate must apply on every redirect hop."""
+
+    def test_redirect_to_link_local_rejected(self):
+        from pr_reviewer.http_client import _AllowListRedirectHandler
+
+        handler = _AllowListRedirectHandler({"example.com"})
+        req = urllib.request.Request("https://example.com/x")
+        with patch(
+            "pr_reviewer.enrichment.socket.getaddrinfo",
+            _fake_getaddrinfo(["169.254.169.254"]),
+        ):
+            with pytest.raises(urllib.error.URLError):
+                handler.redirect_request(
+                    req, None, 302, "Found", {}, "https://example.com/y"
+                )
+
+    def test_redirect_to_loopback_rejected(self):
+        from pr_reviewer.http_client import _AllowListRedirectHandler
+
+        handler = _AllowListRedirectHandler({"example.com"})
+        req = urllib.request.Request("https://example.com/x")
+        with patch(
+            "pr_reviewer.enrichment.socket.getaddrinfo",
+            _fake_getaddrinfo(["127.0.0.1"]),
+        ):
+            with pytest.raises(urllib.error.URLError):
+                handler.redirect_request(
+                    req, None, 302, "Found", {}, "https://example.com/y"
+                )


### PR DESCRIPTION
Issue #510: added resolved-IP gate alongside hostname allowlist to prevent DNS-rebinding and IP-literal allowlisted hosts from reaching cloud metadata (169.254.169.254) or RFC-1918/loopback space. …

Fixes #510

_Opened by foreman on review GO (workload wl-misospace-pr-reviewer-action-510)._