### PR TITLE
chore(ci): add gitleaks secret-scan step to validate job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,6 +14,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Full history so the gitleaks CLI below can scan every commit, not
+          # just the PR merge ref of a shallow checkout.
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -50,16 +54,15 @@ jobs:
 
       # Secret scan: this action forwards operator PATs and AI_API_KEYs, so a
       # hardcoded credential in a committed diff is exactly the regression class
-      # the redaction work (#471, #360) guards against. gitleaks scans the PR
-      # diff on pull_request and the full history on push, failing the build on
-      # any detection. .gitleaks.toml allowlists the intentionally fake
+      # the redaction work (#471, #360) guards against. The official license-free
+      # gitleaks CLI (image pinned by digest) scans the full checkout history —
+      # the checkout above uses fetch-depth 0 — on every run, failing the build
+      # on any detection. .gitleaks.toml allowlists the intentionally fake
       # credential fixtures in the redaction test suites.
       - name: Scan for leaked secrets (gitleaks)
-        uses: gitleaks/gitleaks-action@1938557f6a58837331b99822ab17b8e536e7bef9 # v2.3.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: docker://ghcr.io/gitleaks/gitleaks@sha256:090a2715530bd6592342e6a66c3f35eafcaaf2a3227a312482504f9c854997e3
         with:
-          config: .gitleaks.toml
+          args: git --config /github/workspace/.gitleaks.toml --no-banner --redact /github/workspace
 
       - name: Check shell scripts
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,6 +48,19 @@ jobs:
       - name: Lint GitHub Actions workflows
         uses: rhysd/actionlint@914e7df21a07ef503a81201c76d2b11c789d3fca # v1.7.12
 
+      # Secret scan: this action forwards operator PATs and AI_API_KEYs, so a
+      # hardcoded credential in a committed diff is exactly the regression class
+      # the redaction work (#471, #360) guards against. gitleaks scans the PR
+      # diff on pull_request and the full history on push, failing the build on
+      # any detection. .gitleaks.toml allowlists the intentionally fake
+      # credential fixtures in the redaction test suites.
+      - name: Scan for leaked secrets (gitleaks)
+        uses: gitleaks/gitleaks-action@1938557f6a58837331b99822ab17b8e536e7bef9 # v2.3.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          config: .gitleaks.toml
+
       - name: Check shell scripts
         run: |
           set -euo pipefail

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -8,6 +8,11 @@
 # committed anywhere else in the tree.
 title = "pr-reviewer-action gitleaks config"
 
+# Merge in gitleaks' built-in rules; without this this file defines no rules
+# and would detect nothing.
+[extend]
+useDefault = true
+
 [allowlist]
 description = "Intentionally fake credential fixtures under tests/"
 paths = [

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,15 @@
+# Gitleaks config for the CI secret-scan step (.github/workflows/ci.yaml).
+#
+# The redaction and redteam test suites carry intentionally fake credentials
+# as fixtures (e.g. "ghp_..." strings that must match the redaction rules,
+# plus "sk-..." keys, AWS "AKIA..." identifiers, and Slack "xox..." tokens
+# used as redact-targets). Allowlisting the tests tree by path keeps the
+# push (full-history) scan green while still catching any real secret
+# committed anywhere else in the tree.
+title = "pr-reviewer-action gitleaks config"
+
+[allowlist]
+description = "Intentionally fake credential fixtures under tests/"
+paths = [
+  '''(^|/)tests/.*''',
+]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+# Mirrors the CI secret-scan gate: same pinned gitleaks image (by digest,
+# not tag), same args, scanning this checkout's available git history with
+# the repo-root .gitleaks.toml, as in .github/workflows/ci.yaml.
+
+.PHONY: secret-scan
+
+secret-scan:
+	docker run --rm \
+		-v "$(CURDIR):/github/workspace" \
+		ghcr.io/gitleaks/gitleaks@sha256:090a2715530bd6592342e6a66c3f35eafcaaf2a3227a312482504f9c854997e3 \
+		git --config /github/workspace/.gitleaks.toml --no-banner --redact /github/workspace


### PR DESCRIPTION
Add gitleaks secret-scanning step to CI validate job with allowlist for redaction test fixtures - resolves issue #511.

Fixes #511

_Opened by foreman on review GO (workload wl-misospace-pr-reviewer-action-511)._