### PR TITLE
fix(evidence): scrub AI_PRIMARY_API_KEY, AI_SMART_API_KEY, LINEAR_API_KEY from provider env

### DIFF
--- a/scripts/run_evidence_providers.py
+++ b/scripts/run_evidence_providers.py
@@ -95,11 +95,18 @@ def parse_findings(payload: object) -> tuple[str, list[dict[str, str]]]:
     return highest, findings[:40]
 
 
-# Model API keys are stripped from provider subprocess environments: providers
-# talk to the repo, not the model, so they have no legitimate use for them,
-# and this keeps a misbehaving provider command from echoing them into
-# captured output. GH_TOKEN is intentionally kept — providers commonly use gh.
-_SCRUBBED_ENV_KEYS = ("AI_API_KEY", "AI_FALLBACK_API_KEY")
+# Model API keys and other injected credentials are stripped from provider
+# subprocess environments: providers talk to the repo, not the model, so they
+# have no legitimate use for them, and this keeps a misbehaving provider
+# command from echoing them into captured output. GH_TOKEN is intentionally
+# kept — providers commonly use gh.
+_SCRUBBED_ENV_KEYS = (
+    "AI_API_KEY",
+    "AI_FALLBACK_API_KEY",
+    "AI_PRIMARY_API_KEY",
+    "AI_SMART_API_KEY",
+    "LINEAR_API_KEY",
+)
 
 
 def provider_env() -> dict:

--- a/tests/test_evidence_providers.py
+++ b/tests/test_evidence_providers.py
@@ -702,7 +702,7 @@ class TestParallelExecution:
     def test_model_api_keys_scrubbed_from_provider_env(self, tmp_path: Path):
         config = {
             "providers": [
-                {"id": "env-probe", "command": "echo \"key=[${AI_API_KEY:-}] fb=[${AI_FALLBACK_API_KEY:-}] gh=[${GH_TOKEN:-}]\""}
+                {"id": "env-probe", "command": "echo \"key=[${AI_API_KEY:-}] fb=[${AI_FALLBACK_API_KEY:-}] primary=[${AI_PRIMARY_API_KEY:-}] smart=[${AI_SMART_API_KEY:-}] linear=[${LINEAR_API_KEY:-}] gh=[${GH_TOKEN:-}]\""}
             ]
         }
         result = _run_caps(
@@ -711,17 +711,49 @@ class TestParallelExecution:
             {
                 "AI_API_KEY": "sk-should-never-leak",
                 "AI_FALLBACK_API_KEY": "sk-fallback-never-leak",
+                "AI_PRIMARY_API_KEY": "sk-primary-never-leak",
+                "AI_SMART_API_KEY": "sk-smart-never-leak",
+                "LINEAR_API_KEY": "lin_api_never_leak",
                 "GH_TOKEN": "gh-token-ok",
             },
         )
         assert result.returncode == 0, f"stderr: {result.stderr}"
         data = _load_json_output(tmp_path)
         stdout = data["providers"][0]["stdout"]
-        # Model keys are scrubbed before the provider runs (not just redacted
-        # after); GH_TOKEN stays available for gh-based providers.
+        # Model keys and the Linear PAT are scrubbed before the provider runs
+        # (not just redacted after); GH_TOKEN stays available for gh-based
+        # providers.
         assert "key=[]" in stdout
         assert "fb=[]" in stdout
+        assert "primary=[]" in stdout
+        assert "smart=[]" in stdout
+        assert "linear=[]" in stdout
         assert "gh-token-ok" not in stdout or "gh=[" in stdout
+
+    def test_provider_env_drops_injected_credentials(self):
+        from run_evidence_providers import provider_env
+
+        with mock.patch.dict(
+            os.environ,
+            {
+                "AI_API_KEY": "sk-a",
+                "AI_FALLBACK_API_KEY": "sk-b",
+                "AI_PRIMARY_API_KEY": "sk-c",
+                "AI_SMART_API_KEY": "sk-d",
+                "LINEAR_API_KEY": "lin-e",
+                "GH_TOKEN": "gh-token-ok",
+            },
+        ):
+            env = provider_env()
+        for key in (
+            "AI_API_KEY",
+            "AI_FALLBACK_API_KEY",
+            "AI_PRIMARY_API_KEY",
+            "AI_SMART_API_KEY",
+            "LINEAR_API_KEY",
+        ):
+            assert key not in env, f"{key} leaked into provider env"
+        assert env.get("GH_TOKEN") == "gh-token-ok"
 
     def test_blocker_flag_still_aggregates(self, tmp_path: Path):
         helper = tmp_path / "blocker.py"


### PR DESCRIPTION
Issue #513 fix: added AI_PRIMARY_API_KEY, AI_SMART_API_KEY, LINEAR_API_KEY to _SCRUBBED_ENV_KEYS in scripts/run_evidence_providers.py and updated tests to verify they are scrubbed from provider subprocess environments.

Fixes #513

_Opened by foreman on review GO (workload wl-misospace-pr-reviewer-action-513)._