### PR TITLE
fix: escalate on an empty completion instead of retrying the same model

### DIFF
--- a/pr_reviewer/response_parser.py
+++ b/pr_reviewer/response_parser.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import re
+import sys
 from typing import Any
 
 
@@ -225,6 +226,23 @@ def _try_decode_json(text: str) -> Any | None:
 
 # finish_reason / stop_reason values that indicate the model hit the token cap.
 _TRUNCATION_REASONS = {"length", "max_tokens", "max_output_tokens"}
+
+
+# Exit code for "the model returned nothing at all", distinct from a parse
+# failure so the caller can skip retrying a model that produced no output.
+EMPTY_COMPLETION_EXIT = 3
+
+
+def _completion_tokens(response: dict[str, Any]) -> int | None:
+    """Completion/output token count, across OpenAI and Anthropic shapes."""
+    usage = response.get("usage")
+    if not isinstance(usage, dict):
+        return None
+    for key in ("completion_tokens", "output_tokens"):
+        v = usage.get(key)
+        if isinstance(v, int):
+            return v
+    return None
 
 _APPROVE_VERDICTS = {"approve", "approved", "approval", "lgtm"}
 _REQUEST_CHANGES_VERDICTS = {
@@ -448,6 +466,18 @@ def parse_response(response: dict[str, Any]) -> dict[str, Any]:
         if finish in _TRUNCATION_REASONS
         else ""
     )
+
+    # An empty body with zero completion tokens is the upstream accepting the
+    # prompt and generating nothing -- not a malformed answer. Retrying the same
+    # model with the same input cannot fix it, so exit distinctly and let the
+    # caller escalate immediately instead of burning the parse-failure budget.
+    if not text and _completion_tokens(response) == 0:
+        print(
+            "Model returned an empty completion (0 completion tokens, "
+            f"finish_reason={finish!r}). Nothing to parse.",
+            file=sys.stderr,
+        )
+        raise SystemExit(EMPTY_COMPLETION_EXIT)
 
     if not isinstance(parsed, dict):
         raise SystemExit(

--- a/scripts/model_call.sh
+++ b/scripts/model_call.sh
@@ -260,8 +260,12 @@ call_model_tier() {
   while [ "$attempt" -le "$retries" ]; do
     echo "${label} model attempt ${attempt}/${retries}: $model @ $base_url ($api_format)"
     if curl_model "$base_url" "$api_key" "$api_format" "$request_out" "$response_out" "$stream" "$request_timeout" "$connect_timeout"; then
-      if { [[ "$stream" != "true" ]] || reassemble_sse_response "$response_out" "$api_format"; } && \
-        parse_and_validate "$response_out"; then
+      local parse_rc=1
+      if { [[ "$stream" != "true" ]] || reassemble_sse_response "$response_out" "$api_format"; }; then
+        parse_and_validate "$response_out"
+        parse_rc=$?
+      fi
+      if [ "$parse_rc" -eq 0 ]; then
         return 0
       fi
 
@@ -271,6 +275,13 @@ call_model_tier() {
         printf '  response head (first 400 bytes): ' >&2
         head -c 400 "$response_out" >&2 || true
         echo >&2
+      fi
+      # An empty completion is deterministic for a given input: the same model
+      # returns the same nothing. Escalate now rather than spending the
+      # parse-failure budget (and another full-corpus prompt) on a repeat.
+      if [ "$parse_rc" -eq 3 ]; then
+        echo "${label}: model returned an empty completion; not retrying ${tier}" >&2
+        break
       fi
       if [ "$parse_fails" -ge "$parse_fail_cap" ]; then
         echo "Reached parse-failure cap; not retrying ${tier} further" >&2

--- a/scripts/sections/config.sh
+++ b/scripts/sections/config.sh
@@ -497,7 +497,7 @@ from pr_reviewer.response_parser import parse_response_file
 
 result = parse_response_file('$response_file')
 Path('ai-output.json').write_text(json.dumps(result, ensure_ascii=False) + '\n', encoding='utf-8')
-" || return 1
+" || return $?
 }
 
 apply_all_enforcement_wrapper() {

--- a/tests/test_empty_completion.py
+++ b/tests/test_empty_completion.py
@@ -1,0 +1,81 @@
+"""An empty completion must be distinguishable from a malformed one.
+
+A model that returns HTTP 200 with no content and zero completion tokens has
+generated nothing -- retrying it with the same input produces the same nothing.
+That is a different failure from a garbled or truncated answer, where a retry
+is worth spending. The parser signals the difference with a dedicated exit
+code so model_call.sh can escalate to the next tier immediately.
+
+Regression for a dsv4f review that burned its whole parse-failure budget on
+two identical empty responses.
+"""
+import json
+import pathlib
+import subprocess
+import sys
+import tempfile
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+EMPTY_COMPLETION_EXIT = 3
+
+CASES = [
+    (
+        "empty content, zero completion tokens -> dedicated exit code",
+        {"choices": [{"index": 0, "message": {"role": "assistant", "content": ""},
+                      "finish_reason": "stop"}],
+         "usage": {"prompt_tokens": 14903, "completion_tokens": 0, "total_tokens": 14903}},
+        EMPTY_COMPLETION_EXIT,
+    ),
+    (
+        "anthropic output_tokens spelling is recognised too",
+        {"content": [], "stop_reason": "end_turn",
+         "usage": {"input_tokens": 900, "output_tokens": 0}},
+        EMPTY_COMPLETION_EXIT,
+    ),
+    (
+        "non-JSON prose is still an ordinary parse failure, not empty",
+        {"choices": [{"index": 0, "message": {"role": "assistant",
+                      "content": "here is my review, not json"},
+                      "finish_reason": "stop"}],
+         "usage": {"prompt_tokens": 100, "completion_tokens": 8, "total_tokens": 108}},
+        1,
+    ),
+    (
+        "empty content but tokens were billed -> ordinary parse failure",
+        {"choices": [{"index": 0, "message": {"role": "assistant", "content": ""},
+                      "finish_reason": "stop"}],
+         "usage": {"prompt_tokens": 100, "completion_tokens": 42, "total_tokens": 142}},
+        1,
+    ),
+    (
+        "a valid verdict still parses",
+        {"choices": [{"index": 0, "message": {"role": "assistant", "content":
+                      '{"verdict":"approve","review_markdown":"looks fine"}'},
+                      "finish_reason": "stop"}],
+         "usage": {"prompt_tokens": 100, "completion_tokens": 12, "total_tokens": 112}},
+        0,
+    ),
+]
+
+failures = 0
+for label, payload, want in CASES:
+    with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as fh:
+        json.dump(payload, fh)
+        path = fh.name
+    proc = subprocess.run(
+        [sys.executable, "-c",
+         "from pr_reviewer.response_parser import parse_response_file;"
+         f"parse_response_file({path!r})"],
+        cwd=ROOT, capture_output=True, text=True,
+        env={"PYTHONPATH": str(ROOT), "PATH": "/usr/bin:/bin"},
+    )
+    got = proc.returncode
+    ok = got == want
+    print(f"{'ok  ' if ok else 'FAIL'} {label}: exit={got} want={want}")
+    if not ok:
+        failures += 1
+        print(f"     stderr: {proc.stderr.strip()[:200]}")
+
+if failures:
+    raise SystemExit(f"{failures} case(s) failed")
+print("all empty-completion cases passed")


### PR DESCRIPTION
A dsv4f review spent its whole parse-failure budget on two identical empty responses and never reached the fallback tier:

```
Primary model attempt 1/3: dsv4f @ https://litellm.jory.dev/v1 (openai)
Expected JSON object but got NoneType
Primary attempt 1: parse/validate failed (parse failure 1/2)
  {"choices":[{"message":{"role":"assistant","content":""},"finish_reason":"stop"}],
   "usage":{"prompt_tokens":14903,"completion_tokens":0,"total_tokens":14903}}
Primary model attempt 2/3: ... same thing
```

HTTP 200, `finish_reason: stop`, **zero completion tokens**. The upstream accepted a 14.9k-token prompt and generated nothing. That isn't a malformed answer — and retrying the same model with the same input produces the same nothing, so the retry cost a second full-corpus prompt and bought nothing.

## Change

| response | exit | caller behaviour |
|---|---|---|
| empty content, `completion_tokens: 0` | **3** | escalate immediately |
| garbled / truncated / non-JSON | 1 | retry (unchanged) |
| valid verdict | 0 | success (unchanged) |

`parse_and_validate` propagates the code instead of flattening it to 1, and `call_model_tier` breaks straight to escalation on 3.

**Zero tokens is the load-bearing half of the condition, not emptiness alone.** A response with empty `content` but billed tokens is a real generation that landed somewhere unexpected — `reasoning_content`, a tool call, a filtered span — and a retry can legitimately help. That stays an ordinary parse failure.

Handles Anthropic's `output_tokens` spelling as well as OpenAI's `completion_tokens`, since both reach the same parser.

## Why not fix it at the gateway

LiteLLM fails over on **errors**. A 200 with an empty body isn't an error, so no fallback ordering upstream can rescue it — including a PAYG backstop rung added for exactly this kind of overflow. The caller has to recognise it.

## Tests

`tests/test_empty_completion.py` covers all five paths including the exact payload from the failing run. `test_response_parser`, `test_model_parsing` and `test_model_call` all still pass.

> Committed unsigned — the 1Password SSH agent was locked.