### PR TITLE
fix: give the native_loop verdict turn the real tool harness findings

### DIFF
--- a/scripts/run_tool_harness.py
+++ b/scripts/run_tool_harness.py
@@ -322,6 +322,55 @@ def tool_result_md_lines(index, tool_name, args, tool_result):
     return lines
 
 
+def verdict_harness_findings_body(outcome):
+    """Render the Tool Harness Findings section body for the verdict turn.
+
+    Deliberately compact: every tool result is already in the verdict turn's
+    conversation as a tool message, so re-sending the full tool-harness.md here
+    would duplicate tens of kilobytes the model already has. What the corpus
+    section must carry is that the harness ran, and an index of what it ran.
+    """
+    lines = [
+        f"The tool harness ran for this review: {len(outcome.executed)} tool call(s) "
+        f"executed across {outcome.rounds} round(s) "
+        f"({outcome.tool_calls_issued} issued; stop reason: {outcome.stop_reason}).",
+        "",
+        "The full results are the tool messages earlier in this conversation. "
+        "Treat them as this review's tool harness evidence and report what they "
+        "showed under Tool Harness Findings.",
+        "",
+    ]
+    for index, executed in enumerate(outcome.executed, 1):
+        status = executed.result.get("status", "error")
+        args = json.dumps(executed.args, ensure_ascii=False)
+        if len(args) > 300:
+            args = args[:300] + "…"
+        lines.append(f"{index}. `{executed.tool}` ({status}) — {args}")
+    lines.append("")
+    return mask_secrets("\n".join(lines))
+
+
+def replace_harness_findings_section(corpus, body):
+    """Swap the body of the corpus's Tool Harness Findings section.
+
+    Sections are delimited by level-1 ATX headers — the same rule
+    build_review_corpus emits and dedupe_verdict_corpus splits on. The header
+    line itself is preserved (it carries the "(incremental review)" suffix on
+    delta reviews). Returns the corpus unchanged when the section is absent.
+    """
+    lines = corpus.split("\n")
+    starts = [i for i, ln in enumerate(lines) if ln.startswith("# ")]
+    if not starts:
+        return corpus
+    bounds = starts + [len(lines)]
+    for idx, start in enumerate(starts):
+        if lines[start][2:].strip().startswith("Tool Harness Findings"):
+            return "\n".join(
+                lines[: start + 1] + body.split("\n") + lines[bounds[idx + 1] :]
+            )
+    return corpus
+
+
 def write_outputs(summary, markdown):
     """Write JSON and markdown outputs from the tool harness."""
     Path("tool-harness.json").write_text(
@@ -696,6 +745,13 @@ def run_native_loop(
         result["native_loop_usage"] = _usage_with_cache_ratio(usage_acc)
         return False
 
+    # Fold the outcome into `result` and build tool-harness.md now, before the
+    # verdict turn — the verdict re-sends a corpus built before this harness ran,
+    # and its Tool Harness Findings section still holds the pre-harness
+    # placeholder. Substituting a real section there (below) is what stops the
+    # review from reporting "planning pending" on a run that gathered evidence.
+    harness_markdown = _summarize_loop_outcome(result, outcome, build_evidence_digest)
+
     # ── In-conversation verdict (#205, Option 1) ─────────────────────────────
     # The loop's final turn produces the review verdict itself — preserving the
     # multi-hop reasoning trajectory — instead of flattening evidence into the
@@ -720,6 +776,15 @@ def run_native_loop(
                 else ""
             )
             if verdict_corpus:
+                # The corpus was assembled before this harness ran, so its Tool
+                # Harness Findings section is the scaffold placeholder ("Tool
+                # harness planning pending."). run_review.sh rebuilds the corpus
+                # after the harness, but that rebuild only feeds the separate
+                # review call this verdict turn replaces — so the placeholder is
+                # what the verdict reads unless we substitute it here.
+                verdict_corpus = replace_harness_findings_section(
+                    verdict_corpus, verdict_harness_findings_body(outcome)
+                )
                 # #372/#398: the loop's first user message (corpus_text — the
                 # planning context) embeds several corpus sections verbatim,
                 # extracted from this same corpus file by build_planning_context,
@@ -772,6 +837,18 @@ def run_native_loop(
     # prompt-cache-effectiveness signal (0.0 when the backend doesn't report it).
     result["usage"] = _usage_with_cache_ratio(usage_acc)
 
+    write_outputs(result, harness_markdown)
+    return True
+
+
+def _summarize_loop_outcome(result, outcome, build_evidence_digest):
+    """Fold the loop outcome into `result` and return the harness markdown.
+
+    Runs BEFORE the verdict turn so the verdict corpus can be corrected with
+    real findings; the outputs themselves are written after it, once the
+    verdict's token usage has been accumulated. build_evidence_digest is passed
+    in because run_native_loop imports the pr_reviewer package lazily.
+    """
     result["mode"] = "native_loop"
     result["rounds"] = outcome.rounds
     result["stop_reason"] = outcome.stop_reason
@@ -833,8 +910,7 @@ def run_native_loop(
         md_lines.append(summary_text)
         md_lines.append("")
 
-    write_outputs(result, "\n".join(md_lines))
-    return True
+    return "\n".join(md_lines)
 
 
 def main():

--- a/tests/test_run_native_loop_wiring.py
+++ b/tests/test_run_native_loop_wiring.py
@@ -648,3 +648,131 @@ class TestResolveMcpToolName:
 
     def test_empty_routes_returns_none(self):
         assert rth.resolve_mcp_tool_name("mcp_konflate_get_pr_diff", {}) is None
+
+
+# ── Verdict-corpus Tool Harness Findings section ──────────────────────────────
+# The corpus the verdict turn re-sends is built BEFORE the harness runs, so its
+# Tool Harness Findings section holds the pre-harness scaffold placeholder.
+# run_review.sh rebuilds the corpus afterwards, but that rebuild only feeds the
+# separate review call the in-conversation verdict replaces — so without a
+# substitution the verdict reads "Tool harness planning pending." on every
+# successful native_loop review and reports that no evidence was gathered
+# (observed on misospace/llmkube-images#216).
+
+_PLACEHOLDER_CORPUS = (
+    "# PR Diff (truncated)\n"
+    "```diff\n+bump\n```\n"
+    "\n"
+    "# Tool Harness Findings\n"
+    "Tool harness planning pending.\n"
+    "\n"
+    "# Image Digest Provenance\n"
+    "(none)\n"
+)
+
+
+def _verdict_user_text(payloads):
+    return "\n".join(
+        m.get("content") or "" for m in payloads[-1]["messages"] if m["role"] == "user"
+    )
+
+
+def test_verdict_corpus_reports_real_harness_findings(monkeypatch, tmp_path):
+    """A successful loop must not hand the verdict turn the pending placeholder."""
+    monkeypatch.setenv("AI_RESPONSE_FORMAT", "json_object")
+    (tmp_path / "review-corpus.truncated.md").write_text(
+        _PLACEHOLDER_CORPUS, encoding="utf-8"
+    )
+    (tmp_path / "machineconfig.yaml.j2").write_text(
+        "install: factory.talos.dev/installer:v1.13.4\n", encoding="utf-8"
+    )
+    verdict_json = '{"verdict": "approve", "review_markdown": "ok", "findings": []}'
+    handled, result, payloads = _run_capturing(
+        monkeypatch, tmp_path, "openai",
+        [
+            _openai_call("c1", "read_file", '{"path": "machineconfig.yaml.j2"}'),
+            _openai_text("Evidence gathered: Talos v1.13.4."),
+            {"choices": [{"finish_reason": "stop", "message": {"content": verdict_json}}]},
+        ],
+    )
+    assert handled is True
+    assert result.get("native_loop_verdict_produced") is True
+
+    user_text = _verdict_user_text(payloads)
+    assert "Tool harness planning pending." not in user_text
+    assert "1 tool call(s) executed" in user_text
+    assert "`read_file`" in user_text
+    # The surrounding corpus sections are untouched by the substitution.
+    assert "# Image Digest Provenance" in user_text
+    assert "+bump" in user_text
+
+
+def test_verdict_path_still_writes_real_harness_outputs(monkeypatch, tmp_path):
+    """Moving the summary ahead of the verdict turn must not lose the outputs:
+    tool-harness.md/json still carry the real findings and counts afterwards."""
+    monkeypatch.setenv("AI_RESPONSE_FORMAT", "json_object")
+    (tmp_path / "review-corpus.truncated.md").write_text(
+        _PLACEHOLDER_CORPUS, encoding="utf-8"
+    )
+    (tmp_path / "machineconfig.yaml.j2").write_text(
+        "install: factory.talos.dev/installer:v1.13.4\n", encoding="utf-8"
+    )
+    verdict_json = '{"verdict": "approve", "review_markdown": "ok", "findings": []}'
+    _run_capturing(
+        monkeypatch, tmp_path, "openai",
+        [
+            _openai_call("c1", "read_file", '{"path": "machineconfig.yaml.j2"}'),
+            _openai_text("Evidence gathered: Talos v1.13.4."),
+            {"choices": [{"finish_reason": "stop", "message": {"content": verdict_json}}]},
+        ],
+    )
+    harness = json.loads((tmp_path / "tool-harness.json").read_text())
+    assert harness["mode"] == "native_loop"
+    assert harness["executed_request_count"] == 1
+    assert harness["planned_request_count"] == 1
+    assert harness["usage"]["cache_hit_ratio"] == 0.0
+    md = (tmp_path / "tool-harness.md").read_text()
+    assert "read_file" in md
+    assert "v1.13.4" in md
+    assert "Evidence summary" in md
+
+
+class TestReplaceHarnessFindingsSection:
+    def test_replaces_body_and_keeps_header(self):
+        out = rth.replace_harness_findings_section(_PLACEHOLDER_CORPUS, "real body\n")
+        assert "# Tool Harness Findings\nreal body\n\n# Image Digest Provenance" in out
+        assert "planning pending" not in out
+
+    def test_incremental_header_suffix_is_preserved(self):
+        corpus = "# Tool Harness Findings (incremental review)\nplaceholder\n\n# Next\nx\n"
+        out = rth.replace_harness_findings_section(corpus, "real body\n")
+        assert out.startswith("# Tool Harness Findings (incremental review)\nreal body")
+        assert out.endswith("# Next\nx\n")
+
+    def test_absent_section_returns_corpus_unchanged(self):
+        corpus = "# PR Diff\n```diff\n+x\n```\n"
+        assert rth.replace_harness_findings_section(corpus, "body") == corpus
+
+    def test_headerless_corpus_returns_unchanged(self):
+        assert rth.replace_harness_findings_section("no headers here", "body") == "no headers here"
+
+
+def test_verdict_harness_body_indexes_every_executed_call():
+    class _R:
+        def __init__(self, tool, args, status):
+            self.tool = tool
+            self.args = args
+            self.result = {"status": status}
+
+    class _Outcome:
+        executed = [_R("read_file", {"path": "a.yaml"}, "ok"),
+                    _R("web_fetch", {"url": "https://x.test/y"}, "error")]
+        rounds = 2
+        tool_calls_issued = 3
+        stop_reason = "tool-call-budget-exhausted"
+
+    body = rth.verdict_harness_findings_body(_Outcome())
+    assert "2 tool call(s) executed across 2 round(s)" in body
+    assert "3 issued; stop reason: tool-call-budget-exhausted" in body
+    assert "1. `read_file` (ok)" in body
+    assert "2. `web_fetch` (error)" in body


### PR DESCRIPTION
## The bug

Every successful `native_loop` review reported:

> **Tool Harness Findings**
> Tool harness planning was pending; no tool harness findings were produced for this review.

Seen on `misospace/llmkube-images#216`, workflow run [32523108049](https://github.com/misospace/llmkube-images/actions/runs/32523108049), whose log has all three of:

```
native_loop: 4 tool call(s) executed in 2 round(s), 5 issued (stop: tool-call-budget-exhausted)
native_loop: verdict-corpus dedup dropped 6 section(s) already in the planning context (7300 bytes saved)
native_loop produced an in-conversation verdict; using it and skipping the separate review call
```

## Mechanism

`scripts/sections/corpus.sh` writes a scaffold `Tool harness planning pending.` into `tool-harness.md` (the file `build_review_corpus` cats unconditionally), builds the corpus, runs the harness, then rebuilds the corpus. That rebuild does pick up the real `tool-harness.md`, and `run_tool_harness.py` does write real findings on the success path.

The problem is who reads what. The in-conversation verdict turn (#205) runs inside `run_tool_harness.py` and re-sends `review-corpus.truncated.md` as it stood **before** the harness ran, so the model read the placeholder and reported it. The corrected rebuild only feeds the separate review call, and `run_review.sh` skips that call precisely when the verdict was produced. So the corrected corpus was written and then never used.

## Fix

- Move the loop-outcome summarization ahead of the verdict turn (`_summarize_loop_outcome`), so real findings exist before the corpus is re-sent. Outputs are still written after the verdict so its token usage lands in `usage`.
- Substitute the corpus's `Tool Harness Findings` section (`replace_harness_findings_section`) with a real body: executed/round/issued counts, stop reason, and an index of the calls, pointing at the tool messages already in the conversation.

The substituted body is compact on purpose. Every tool result is already in the verdict turn's conversation as a tool message, so pasting the full `tool-harness.md` would re-send tens of kilobytes the model holds, working against the #372/#398 dedup. Substitution happens before the dedup pass, and the section is not part of the planning context, so dedup is unaffected.

## Impact

Review quality was not affected. The tool evidence was in the conversation and did inform the verdict. Only the report was wrong, and the misreport is worth fixing on its own: it made every tool-using review look like it had gathered nothing.

`tool-harness.json` was already correct on the success path, so telemetry and the step summary were not affected.

## The placeholder and its smoke test

`tests/smoke_test.sh` pins `Tool harness planning pending.`, and that test still describes correct behaviour, so it is unchanged. The placeholder is a pre-harness scaffold for a file the corpus builder cats unconditionally; with this fix it no longer reaches a model on the `native_loop` path (the degraded, disabled, fork-skip and failure paths each write their own accurate text).

## Tests

New coverage in `tests/test_run_native_loop_wiring.py`: the verdict turn's user text must not contain the placeholder and must name the executed calls; the harness outputs must still be written after the verdict; unit tests for the section substitution (including the `(incremental review)` header suffix) and the rendered body. The behavioural test fails on `main` and passes here.

Suites run locally, all green: `test_response_parser.py` (52), `test_model_parsing.py` (29), `test_model_call.sh` (55), `smoke_test.sh` (25), full `pytest tests/` (1575; the one failure, `test_run_eval_harness_step_passes_shellcheck`, is a local missing-shellcheck issue unrelated to this change).

https://claude.ai/code/session_0189WpTVXUhnduTupUM9M2oD