### PR TITLE
feat(action): add fail_on_request_changes input to gate merges without a GitHub App

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ Only three inputs are required: `github_token`, `ai_base_url`, and `ai_model`. E
 | Input | Description | Required | Default |
 |-------|-------------|----------|---------|
 | `verdict_policy` | How the final verdict is decided: `model` (the model's own verdict) or `findings_severity_gated` (one-way escalation: model request_changes is preserved; blocker findings can escalate approve to request_changes; non-blocker findings never weaken a rejection). Enforcement settings still apply afterwards | No | `model` |
+| `fail_on_request_changes` | Fail the action step when the final verdict is `request_changes`, so the review can act as a CI merge gate without a GitHub App. Runs **after** publishing, so the review comment and inline findings still land on the PR. Reads the same final verdict the `verdict` output reports (post-`verdict_policy`, post-evidence-blocker and tool-failure enforcement), not the raw model verdict. `on_model_failure: notice` still passes — a model outage produces no verdict and must not wedge merges; only an actual `request_changes` fails the step | No | `false` |
 | `inline_findings` | Attach diff-anchorable structured findings as native line-anchored review comments in `review_comment`/`review_verdict` modes. Ignored for `comment` mode | No | `false` |
 | `inline_findings_max` | Maximum inline review comments per review when `inline_findings=true` | No | `20` |
 | `validate_required_checks` | Validate the final review against the classifier's `must_check` items: `auto` (when must_check is non-empty), `true`, or `false` | No | `auto` |

--- a/action.yml
+++ b/action.yml
@@ -93,6 +93,18 @@ inputs:
       so reviewers see an explanation instead of only a red check.
     required: false
     default: "fail"
+  fail_on_request_changes:
+    description: >-
+      If true, fail the action step when the final verdict is request_changes,
+      so the review can act as a CI merge gate without a GitHub App. The gate
+      runs after publishing, so the review comment and inline findings still
+      land on the PR. It reads the same final verdict the `verdict` output
+      reports (post-verdict_policy, post-evidence-blocker and tool-failure
+      enforcement), not the raw model verdict. on_model_failure=notice still
+      passes: a model outage produces no verdict and must not wedge merges.
+      Default false — existing consumers see no behaviour change.
+    required: false
+    default: "false"
   verdict_policy:
     description: >-
       How the final verdict is decided. 'model' (default) uses the model's own verdict.
@@ -1227,3 +1239,21 @@ runs:
         PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
         LABEL: ${{ inputs.rereview_label }}
       run: gh api -X DELETE "repos/${REPO}/issues/${PR_NUMBER}/labels/${LABEL}" --silent 2>/dev/null || true
+
+    - name: Fail on request_changes
+      # Gate the merge on the final verdict. Runs after publishing, so the
+      # review comment and inline findings have already landed on the PR.
+      # Reads the same value the `verdict` output reports (post-verdict_policy,
+      # post-evidence-blocker and tool-failure enforcement) from the output
+      # file, so the gate never re-derives the verdict from the raw model
+      # output. A model outage (on_model_failure=notice) writes no
+      # request_changes verdict, so it does not wedge merges.
+      if: ${{ inputs.fail_on_request_changes == 'true' }}
+      shell: bash
+      run: |
+        verdict="$(grep '^verdict=' "$GITHUB_OUTPUT" | tail -n1 | cut -d= -f2-)"
+        if [ "$verdict" = "request_changes" ]; then
+          echo "::error::Final verdict is request_changes; failing the step (fail_on_request_changes=true)."
+          exit 1
+        fi
+        echo "Final verdict is '${verdict:-<none>}'; not blocking (fail_on_request_changes=true)."

--- a/tests/test_action_inputs.py
+++ b/tests/test_action_inputs.py
@@ -214,9 +214,67 @@ def test_fallback_inputs_inherit_from_primary():
     )
 
 
+def test_fail_on_request_changes_input():
+    """fail_on_request_changes gates merges without a GitHub App (issue #518).
+
+    - Declared with default "false" so existing consumers see no change.
+    - The gate step reads the final verdict from $GITHUB_OUTPUT (the same
+      value the `verdict` output reports) and exits non-zero only on
+      request_changes.
+    - The gate runs after the publish step, so the review comment and inline
+      findings land on the PR before the step goes red.
+    """
+    content = (_REPO_ROOT / "action.yml").read_text()
+
+    # Declared with a "false" default.
+    m = re.search(
+        r"^  fail_on_request_changes:\n(?:^    .*\n)*?^    default: \"false\"\s*$",
+        content,
+        re.MULTILINE,
+    )
+    assert m, (
+        "fail_on_request_changes must be declared in action.yml inputs with "
+        'default "false" so existing consumers see no behaviour change.'
+    )
+
+    # The gate step exists, is conditional on the input, and reads the final
+    # verdict from the output file rather than re-deriving it.
+    gate = re.search(
+        r"^    - name: Fail on request_changes\n"
+        r"(?:^      .*\n)*?^      if: \$\{\{ inputs\.fail_on_request_changes == 'true' \}\}\n"
+        r"(?:^      .*\n)*?^      run: \|\n"
+        r"(?:^        .*\n)*?^          exit 1\n",
+        content,
+        re.MULTILINE,
+    )
+    assert gate, (
+        "action.yml must contain a 'Fail on request_changes' step that is "
+        "conditional on inputs.fail_on_request_changes and exits non-zero."
+    )
+    gate_body = gate.group(0)
+    assert '"$GITHUB_OUTPUT"' in gate_body, (
+        "the gate must read the final verdict from $GITHUB_OUTPUT (the same "
+        "value the `verdict` output reports), not re-derive it."
+    )
+    assert 'verdict' in gate_body and 'request_changes' in gate_body
+
+    # The gate runs after the publish step (a red check with no explanation
+    # attached is worse than no gate).
+    publish_idx = content.find("Publish review")
+    gate_idx = content.find("Fail on request_changes")
+    assert publish_idx != -1 and gate_idx != -1, (
+        "both the publish step and the fail_on_request_changes gate step must exist."
+    )
+    assert gate_idx > publish_idx, (
+        "the fail_on_request_changes gate must run after the publish step so "
+        "the review comment and inline findings land on the PR first."
+    )
+
+
 if __name__ == "__main__":
     test_readme_inputs_in_action()
     test_action_inputs_in_readme()
     test_comment_marker_input_exists()
     test_fallback_inputs_inherit_from_primary()
+    test_fail_on_request_changes_input()
     print("All action inputs tests passed!")


### PR DESCRIPTION
Adds fail_on_request_changes input to allow the action to fail the step when verdict is request_changes, enabling CI gate without GitHub App - resolves issue #518.

Fixes #518

_Opened by foreman on review GO (workload wl-misospace-pr-reviewer-action-518)._