### PR TITLE
fix(classifier): stop matching bare route.<ext> in public_route_changes

### DIFF
--- a/pr_reviewer/classifier.py
+++ b/pr_reviewer/classifier.py
@@ -115,7 +115,10 @@ AUTH_PATTERNS = [
 
 # Public route changes
 PUBLIC_ROUTE_PATTERNS = [
-    re.compile(r"(routes?|urls?|api|endpoints?|controller)\." + _SRC_EXT + r"$",
+    # NB: `routes` (plural) only — a bare `route.<ext>` is the mandated name of
+    # every Next.js App Router API handler (src/app/api/**/route.ts), so it
+    # carries no routing-layer signal and must not match. See #531.
+    re.compile(r"(routes|urls?|api|endpoints?|controller)\." + _SRC_EXT + r"$",
                re.IGNORECASE),
     re.compile(r"router[_.-]?py$"),
     re.compile(r"urlpatterns"),

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -168,10 +168,28 @@ class TestPRKindPublicRouteChanges:
         "routes.py",
         "urls.py",
         "api/endpoints.py",
-        "router.py",
+        "api.go",
+        "controller.py",
     ])
     def test_route_file_patterns(self, fname):
         files = [_make_file(fname)]
+        kind = _classify_pr_kind(files, "")
+        assert kind == "public_route_changes"
+
+    def test_bare_route_ts_is_not_public_route(self):
+        # Next.js App Router mandates the name `route.ts` for every API
+        # handler, so the filename carries no routing-layer signal and must
+        # not match. See #531.
+        files = [
+            _make_file("src/app/api/groomer/route.ts"),
+            _make_file("src/app/api/status/route.ts"),
+        ]
+        kind = _classify_pr_kind(files, "")
+        assert kind != "public_route_changes"
+
+    def test_routes_ts_still_public_route(self):
+        # The plural `routes.<ext>` is a chosen name and still matches.
+        files = [_make_file("src/routes.ts")]
         kind = _classify_pr_kind(files, "")
         assert kind == "public_route_changes"
 


### PR DESCRIPTION
Issue #531 fix: Modified PUBLIC_ROUTE_PATTERNS regex to exclude bare `route.ts` (Next.js App Router mandated filename) while keeping `routes.ts`, `urls.py`, `api.go`, `controller.py` matches; added tests verifying bare route.ts is excluded and routes.ts still matches.

Fixes #531

_Opened by foreman on review GO (workload wl-misospace-pr-reviewer-action-531)._