### PR TITLE
fix(forgejo): make the Authorized Integration JWT cache thread-safe

### DIFF
--- a/pr_reviewer/forgejo_backend.py
+++ b/pr_reviewer/forgejo_backend.py
@@ -28,6 +28,7 @@ import re
 import subprocess
 import sys
 import tempfile
+import threading
 import time
 import urllib.error
 import urllib.request
@@ -73,6 +74,12 @@ GH_TOKEN = os.environ.get("GH_TOKEN", os.environ.get("GITHUB_TOKEN", ""))
 _JWT_CACHE: str | None = None
 _JWT_CACHE_TIME: float = 0.0
 _JWT_TTL_SECONDS = 2700  # 45 min, well under Forgejo's 1h default
+# Guards the read-check and write of the cache above so concurrent _get_jwt()
+# calls (e.g. from the linked_sources prewarm ThreadPoolExecutor) cannot
+# race-write the cache or both pass the expiry check and both fetch.
+# RLock (reentrant) because _get_jwt holds the lock across the fetch and
+# _fetch_authorized_integration_jwt re-acquires it to publish the result.
+_JWT_LOCK = threading.RLock()
 
 
 def _is_forgejo_mode() -> bool:
@@ -179,20 +186,28 @@ def _fetch_authorized_integration_jwt() -> str:
             "Forgejo JWT token exchange returned no .value field"
         )
 
-    _JWT_CACHE = jwt
-    _JWT_CACHE_TIME = time.time()
+    with _JWT_LOCK:
+        _JWT_CACHE = jwt
+        _JWT_CACHE_TIME = time.time()
     return jwt
 
 
 def _get_jwt() -> str:
-    """Return a valid JWT, fetching one if the cache is empty or expired."""
+    """Return a valid JWT, fetching one if the cache is empty or expired.
+
+    The lock guards both the expiry check and the fetch so that N concurrent
+    callers landing just past the TTL window issue exactly one token-exchange
+    request: the first to acquire the lock fetches and repopulates the cache,
+    and the rest re-check under the lock and hit the fresh entry.
+    """
     global _JWT_CACHE, _JWT_CACHE_TIME
-    if (
-        _JWT_CACHE is not None
-        and (time.time() - _JWT_CACHE_TIME) < _JWT_TTL_SECONDS
-    ):
-        return _JWT_CACHE
-    return _fetch_authorized_integration_jwt()
+    with _JWT_LOCK:
+        if (
+            _JWT_CACHE is not None
+            and (time.time() - _JWT_CACHE_TIME) < _JWT_TTL_SECONDS
+        ):
+            return _JWT_CACHE
+        return _fetch_authorized_integration_jwt()
 
 
 def _resolve_auth_header(token: str | None) -> str | None:

--- a/tests/test_forgejo_backend.py
+++ b/tests/test_forgejo_backend.py
@@ -13,6 +13,8 @@ import json
 import os
 import subprocess
 import sys
+import threading
+import time
 import unittest
 import urllib.error
 import urllib.request
@@ -1745,6 +1747,92 @@ class TestJwtMasking(unittest.TestCase):
                 fb._fetch_authorized_integration_jwt()
         self.assertIn("401", str(ctx.exception))
         self.assertNotIn(_JWT_TOKEN, str(ctx.exception))
+
+
+class TestJwtCacheConcurrency(unittest.TestCase):
+    """Concurrent _get_jwt() calls must not race-write the JWT cache (#538)."""
+
+    def setUp(self):
+        fb._JWT_CACHE = None
+        fb._JWT_CACHE_TIME = 0.0
+
+    def _run_concurrent_get_jwt(self, n=10):
+        """Run n threads through _get_jwt() and return (results, urlopen_mock)."""
+        barrier = threading.Barrier(n)
+        results = [None] * n
+        errors = []
+
+        def worker(i):
+            try:
+                barrier.wait()
+                results[i] = fb._get_jwt()
+            except Exception as exc:  # noqa: BLE001 - surfaced via errors list
+                errors.append(exc)
+
+        # A small delay in the token-exchange widens the race window so the
+        # test deterministically fails if the lock is removed (N threads would
+        # all pass the expiry check before any repopulates the cache).
+        def slow_urlopen(*args, **kwargs):
+            time.sleep(0.05)
+            return _mock_oidc_response()
+
+        with patch.object(fb, "FORGEJO_AUTHORIZED_INTEGRATION_AUDIENCE", _AUDIENCE), \
+             _jwt_env_patch(), \
+             patch("pr_reviewer.forgejo_backend.urllib.request.urlopen",
+                   side_effect=slow_urlopen) as mock_urlopen:
+            threads = [threading.Thread(target=worker, args=(i,)) for i in range(n)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join(timeout=30)
+        self.assertEqual(errors, [])
+        return results, mock_urlopen
+
+    def test_concurrent_calls_cleared_cache_single_fetch(self):
+        """(a) 10 concurrent _get_jwt() calls with a cleared cache -> exactly 1 urlopen."""
+        results, mock_urlopen = self._run_concurrent_get_jwt(10)
+        self.assertEqual(mock_urlopen.call_count, 1)
+        self.assertEqual(results, [_JWT_TOKEN] * 10)
+
+    def test_concurrent_calls_past_ttl_single_fetch(self):
+        """(b) 10 concurrent calls landing just past the TTL -> exactly 1 fetch."""
+        fb._JWT_CACHE = "stale-token"
+        fb._JWT_CACHE_TIME = time.time() - fb._JWT_TTL_SECONDS - 10
+        results, mock_urlopen = self._run_concurrent_get_jwt(10)
+        self.assertEqual(mock_urlopen.call_count, 1)
+        self.assertEqual(results, [_JWT_TOKEN] * 10)
+
+    def test_serial_cache_hit_no_fetch(self):
+        """(c) Serial cache-hit / cache-miss / TTL-expiry behaviour is preserved."""
+        # Cache hit: fresh cache -> no fetch
+        fb._JWT_CACHE = _JWT_TOKEN
+        fb._JWT_CACHE_TIME = time.time()
+        with patch.object(fb, "FORGEJO_AUTHORIZED_INTEGRATION_AUDIENCE", _AUDIENCE), \
+             _jwt_env_patch(), \
+             patch("pr_reviewer.forgejo_backend.urllib.request.urlopen",
+                   return_value=_mock_oidc_response()) as mock_urlopen:
+            self.assertEqual(fb._get_jwt(), _JWT_TOKEN)
+        self.assertEqual(mock_urlopen.call_count, 0)
+
+        # Cache miss: cleared cache -> exactly one fetch
+        fb._JWT_CACHE = None
+        fb._JWT_CACHE_TIME = 0.0
+        with patch.object(fb, "FORGEJO_AUTHORIZED_INTEGRATION_AUDIENCE", _AUDIENCE), \
+             _jwt_env_patch(), \
+             patch("pr_reviewer.forgejo_backend.urllib.request.urlopen",
+                   return_value=_mock_oidc_response()) as mock_urlopen:
+            self.assertEqual(fb._get_jwt(), _JWT_TOKEN)
+        self.assertEqual(mock_urlopen.call_count, 1)
+
+        # TTL expiry: stale cache -> exactly one fetch
+        fb._JWT_CACHE = "stale-token"
+        fb._JWT_CACHE_TIME = time.time() - fb._JWT_TTL_SECONDS - 10
+        with patch.object(fb, "FORGEJO_AUTHORIZED_INTEGRATION_AUDIENCE", _AUDIENCE), \
+             _jwt_env_patch(), \
+             patch("pr_reviewer.forgejo_backend.urllib.request.urlopen",
+                   return_value=_mock_oidc_response()) as mock_urlopen:
+            self.assertEqual(fb._get_jwt(), _JWT_TOKEN)
+        self.assertEqual(mock_urlopen.call_count, 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Added thread-safe locking for Forgejo JWT cache to prevent race conditions during concurrent fetches.

Fixes #538

_Opened by foreman on review GO (workload wl-misospace-pr-reviewer-action-538)._