### PR TITLE
fix(forgejo): bound gh CLI subprocess calls with a timeout

### DIFF
--- a/pr_reviewer/forgejo_backend.py
+++ b/pr_reviewer/forgejo_backend.py
@@ -309,14 +309,35 @@ def _curl(
     return http_code, body_text
 
 
-def _gh(*args: str) -> tuple[int, str]:
-    """Execute a ``gh`` CLI command and return (returncode, stdout)."""
+# Bounded wall-clock for every ``gh`` CLI invocation. A hung ``gh`` process
+# (interactive auth prompt on a 2FA account, stuck network read against
+# api.github.com, an OAuth token refresh that never returns) must not freeze
+# the action for the full GitHub Actions workflow timeout. Mirrors the
+# ``AI_REQUEST_TIMEOUT_SEC`` bound used for model calls; override via env.
+GH_API_TIMEOUT_SEC = float(os.environ.get("AI_REQUEST_TIMEOUT_SEC", "30"))
+
+
+def _gh(*args: str, timeout_sec: float = GH_API_TIMEOUT_SEC) -> tuple[int, str]:
+    """Execute a ``gh`` CLI command and return (returncode, stdout).
+
+    ``timeout_sec`` bounds the wall-clock so a hung ``gh`` process cannot
+    freeze the action. On ``subprocess.TimeoutExpired`` the child is killed
+    and ``(-1, "")`` is returned, mirroring ``safe_run``'s pattern.
+    """
     cmd = ["gh"] + list(args)
-    proc = subprocess.run(cmd, capture_output=True)
-    return proc.returncode, proc.stdout.decode("utf-8", errors="replace")
+    try:
+        proc = subprocess.run(cmd, capture_output=True, timeout=timeout_sec)
+        return proc.returncode, proc.stdout.decode("utf-8", errors="replace")
+    except subprocess.TimeoutExpired:
+        return -1, ""
 
 
-def _gh_api_json(method: str, path: str, data: dict[str, Any]) -> tuple[int, str]:
+def _gh_api_json(
+    method: str,
+    path: str,
+    data: dict[str, Any],
+    timeout_sec: float = GH_API_TIMEOUT_SEC,
+) -> tuple[int, str]:
     """POST/PATCH JSON to the GitHub REST API via ``gh api`` and return
     (returncode, stdout) — the structured JSON response, not human-oriented
     text.
@@ -325,6 +346,10 @@ def _gh_api_json(method: str, path: str, data: dict[str, Any]) -> tuple[int, str
     than as a ``-f field=value`` argv entry — the same pattern already used
     by ``create_pr_review_from_payload`` — because comment bodies can be
     large markdown blobs.
+
+    ``timeout_sec`` is forwarded to ``_gh`` so a hung ``gh api`` call cannot
+    freeze the action; the temp payload file is always unlinked in the
+    ``finally`` block, including on timeout.
     """
     import tempfile
 
@@ -332,7 +357,7 @@ def _gh_api_json(method: str, path: str, data: dict[str, Any]) -> tuple[int, str
         json.dump(data, tmp)
         tmp_path = tmp.name
     try:
-        return _gh("api", path, "--method", method, "--input", tmp_path)
+        return _gh("api", path, "--method", method, "--input", tmp_path, timeout_sec=timeout_sec)
     finally:
         try:
             os.unlink(tmp_path)
@@ -496,6 +521,7 @@ def get_pr_metadata(repo_full_name: str, pr_number: int) -> dict[str, Any] | Non
     # it has no user/head/base keys at all.
     status_code, body = _gh(
         "api", f"repos/{owner}/{repo}/pulls/{pr_number}",
+        timeout_sec=GH_API_TIMEOUT_SEC,
     )
     if status_code != 0 or not body.strip():
         return None
@@ -565,7 +591,10 @@ def get_pr_diff(repo_full_name: str, pr_number: int) -> str:
         return body
 
     # GitHub via gh CLI
-    status_code, body = _gh("pr", "diff", str(pr_number), "--repo", repo_full_name)
+    status_code, body = _gh(
+        "pr", "diff", str(pr_number), "--repo", repo_full_name,
+        timeout_sec=GH_API_TIMEOUT_SEC,
+    )
     if status_code != 0:
         return ""
     return body
@@ -608,6 +637,7 @@ def list_comments(repo_full_name: str, issue_number: int) -> list[dict[str, Any]
         "api", f"repos/{owner}/{repo}/issues/{issue_number}/comments",
         "--paginate",
         "--jq", ".[] | {id: .id, body: .body, created_at: .created_at, updated_at: .updated_at, user: .user.login}",
+        timeout_sec=GH_API_TIMEOUT_SEC,
     )
     if status_code != 0 or not body.strip():
         return []
@@ -684,6 +714,7 @@ def create_comment(
     # blob. The REST endpoint returns real JSON we can decode structurally.
     status_code, body_text = _gh_api_json(
         "POST", f"repos/{owner}/{repo}/issues/{issue_number}/comments", {"body": body},
+        timeout_sec=GH_API_TIMEOUT_SEC,
     )
     if status_code != 0 or not body_text.strip():
         return None
@@ -744,6 +775,7 @@ def edit_last_comment(
     # comment (the last one authored by the current gh user).
     status_code, body_text = _gh_api_json(
         "PATCH", f"repos/{owner}/{repo}/issues/comments/{target['id']}", {"body": new_body},
+        timeout_sec=GH_API_TIMEOUT_SEC,
     )
     if status_code != 0 or not body_text.strip():
         return None
@@ -779,6 +811,7 @@ def fetch_issue(repo_full_name: str, issue_number: int) -> dict[str, Any] | None
         # GitHub via gh CLI
         status_code, body_text = _gh(
             "api", f"repos/{owner}/{repo}/issues/{issue_number}",
+            timeout_sec=GH_API_TIMEOUT_SEC,
         )
         if status_code != 0:
             return None
@@ -817,7 +850,10 @@ def compare_commits(repo_full_name: str, spec: str) -> dict[str, Any] | None:
             return None
         return data
 
-    status_code, body_text = _gh("api", f"repos/{owner}/{repo}/compare/{spec}")
+    status_code, body_text = _gh(
+        "api", f"repos/{owner}/{repo}/compare/{spec}",
+        timeout_sec=GH_API_TIMEOUT_SEC,
+    )
     if status_code != 0 or not body_text.strip():
         return None
     data = _json_decode(body_text)
@@ -917,6 +953,7 @@ def list_pr_files(repo_full_name: str, pr_number: int) -> list[dict[str, Any]]:
         "api", f"repos/{owner}/{repo}/pulls/{pr_number}/files",
         "--paginate",
         "--jq", ".[] | {filename: .filename, status: .status, additions: .additions, deletions: .deletions, changes: .changes}",
+        timeout_sec=GH_API_TIMEOUT_SEC,
     )
     if status_code != 0 or not body_text.strip():
         return []
@@ -994,6 +1031,7 @@ def list_pr_reviews(repo_full_name: str, pr_number: int) -> list[dict[str, Any]]
 
     status_code, body_text = _gh(
         "api", f"repos/{owner}/{repo}/pulls/{pr_number}/reviews", "--paginate",
+        timeout_sec=GH_API_TIMEOUT_SEC,
     )
     if status_code != 0 or not body_text.strip():
         return []
@@ -1095,6 +1133,7 @@ def create_pr_review_from_payload(
     try:
         status_code, body_text = _gh(
             "api", f"repos/{owner}/{repo}/pulls/{pr_number}/reviews", "--method", "POST", "--input", tmp_path,
+            timeout_sec=GH_API_TIMEOUT_SEC,
         )
     finally:
         try:
@@ -1160,6 +1199,7 @@ def dismiss_pr_review(repo_full_name: str, pr_number: int, review_id: int, messa
     status_code, body_text = _gh(
         "api", f"repos/{owner}/{repo}/pulls/{pr_number}/reviews/{review_id}/dismissals",
         "--method", "PUT", "-f", f"message={message}", "--jq", ".id",
+        timeout_sec=GH_API_TIMEOUT_SEC,
     )
     if status_code != 0:
         return None
@@ -1237,6 +1277,7 @@ def get_commit_status(repo_full_name: str, sha: str) -> dict[str, Any] | None:
     # GitHub via gh CLI — already returns the right shape.
     status_code, body_text = _gh(
         "api", f"repos/{owner}/{repo}/commits/{sha}/status",
+        timeout_sec=GH_API_TIMEOUT_SEC,
     )
     if status_code != 0 or not body_text.strip():
         return None

--- a/tests/test_forgejo_backend.py
+++ b/tests/test_forgejo_backend.py
@@ -12,8 +12,9 @@ import io
 import json
 import os
 import subprocess
-import sys
 import unittest
+from unittest import mock
+import sys
 import urllib.error
 import urllib.request
 from contextlib import redirect_stderr, redirect_stdout
@@ -630,7 +631,10 @@ class TestCompareCommits(unittest.TestCase):
              patch.object(fb, "_gh", return_value=(0, json.dumps(self._COMPARE))) as mock_gh:
             result = fb.compare_commits("misospace/pr-reviewer-action", "abc...def")
 
-        mock_gh.assert_called_once_with("api", "repos/misospace/pr-reviewer-action/compare/abc...def")
+        mock_gh.assert_called_once_with(
+            "api", "repos/misospace/pr-reviewer-action/compare/abc...def",
+            timeout_sec=fb.GH_API_TIMEOUT_SEC,
+        )
         self.assertEqual(result["commits"][0]["sha"], "def")
 
 
@@ -706,7 +710,10 @@ class TestGitHubMode(unittest.TestCase):
              patch.object(fb, "_gh", return_value=(0, json.dumps(self.GH_REST_PR))) as mock_gh:
             result = fb.get_pr_metadata("misospace/pr-reviewer-action", 42)
 
-        mock_gh.assert_called_once_with("api", "repos/misospace/pr-reviewer-action/pulls/42")
+        mock_gh.assert_called_once_with(
+            "api", "repos/misospace/pr-reviewer-action/pulls/42",
+            timeout_sec=fb.GH_API_TIMEOUT_SEC,
+        )
         self.assertEqual(result["number"], 42)
         self.assertEqual(result["head"]["repo"]["full_name"], "outsider/pr-reviewer-action")
 
@@ -762,7 +769,7 @@ class TestGitHubMode(unittest.TestCase):
         ]
         patched = {"id": 1, "html_url": "https://github.com/misospace/pr-reviewer-action/pull/42#issuecomment-1", "body": "updated"}
 
-        def _fake_gh(*args):
+        def _fake_gh(*args, timeout_sec=None):
             if args[:2] == ("api", "repos/misospace/pr-reviewer-action/issues/42/comments"):
                 # list_comments consumes gh's --jq output, which is one JSON
                 # object per line (JSONL), not a JSON array.
@@ -784,7 +791,7 @@ class TestGitHubMode(unittest.TestCase):
     def test_edit_last_comment_falls_back_to_create_when_no_marker(self):
         created = {"id": 3, "html_url": "https://github.com/misospace/pr-reviewer-action/pull/42#issuecomment-3", "body": "fresh"}
 
-        def _fake_gh(*args):
+        def _fake_gh(*args, timeout_sec=None):
             # The list (no --method) and the create (--method POST) both
             # target .../issues/42/comments, so disambiguate on --method.
             if args[:2] == ("api", "repos/misospace/pr-reviewer-action/issues/42/comments") \
@@ -1745,6 +1752,144 @@ class TestJwtMasking(unittest.TestCase):
                 fb._fetch_authorized_integration_jwt()
         self.assertIn("401", str(ctx.exception))
         self.assertNotIn(_JWT_TOKEN, str(ctx.exception))
+
+
+class TestGhTimeout(unittest.TestCase):
+    """Issue #537: _gh / _gh_api_json must bound subprocess.run with a
+    timeout so a hung ``gh`` process cannot freeze the action."""
+
+    def setUp(self):
+        import tempfile
+
+        self._tmp = tempfile.TemporaryDirectory()
+        self.tmpdir = self._tmp.name
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_default_timeout_is_bounded(self):
+        self.assertGreater(fb.GH_API_TIMEOUT_SEC, 0)
+        self.assertLessEqual(fb.GH_API_TIMEOUT_SEC, 300)
+
+    def test_gh_timeout_fires_and_returns_sentinel(self):
+        """(a) A hung ``gh`` process is killed and (-1, "") is returned,
+        mirroring safe_run's TimeoutExpired pattern."""
+        with mock.patch.object(
+            fb.subprocess, "run",
+            side_effect=subprocess.TimeoutExpired(cmd=["gh"], timeout=1),
+        ) as mock_run:
+            rc, out = fb._gh("pr", "view", "1", timeout_sec=1)
+        self.assertEqual(rc, -1)
+        self.assertEqual(out, "")
+        mock_run.assert_called_once_with(
+            ["gh", "pr", "view", "1"],
+            capture_output=True,
+            timeout=1,
+        )
+
+    def test_gh_real_subprocess_timeout_fires(self):
+        """(a) A genuinely hung ``gh`` child process is killed by the timeout
+        and (-1, "") is returned — no mock involved."""
+        import stat
+        import time
+
+        fake_gh = os.path.join(self.tmpdir, "gh")
+        with open(fake_gh, "w", encoding="utf-8") as fh:
+            fh.write("#!/bin/sh\nsleep 30\n")
+        os.chmod(fake_gh, os.stat(fake_gh).st_mode | stat.S_IEXEC)
+
+        old_path = os.environ["PATH"]
+        os.environ["PATH"] = self.tmpdir + os.pathsep + old_path
+        try:
+            start = time.monotonic()
+            rc, out = fb._gh("pr", "view", "1", timeout_sec=1)
+            elapsed = time.monotonic() - start
+        finally:
+            os.environ["PATH"] = old_path
+        self.assertEqual(rc, -1)
+        self.assertEqual(out, "")
+        self.assertLess(elapsed, 10, "timeout must fire well before the child's sleep")
+
+    def test_gh_fast_call_still_works(self):
+        """(b) A successful fast call returns (returncode, stdout) and the
+        timeout kwarg is forwarded to subprocess.run."""
+        proc = mock.Mock()
+        proc.returncode = 0
+        proc.stdout = b'{"ok": true}'
+        with mock.patch.object(fb.subprocess, "run", return_value=proc) as mock_run:
+            rc, out = fb._gh("api", "repos/o/r", timeout_sec=5)
+        self.assertEqual(rc, 0)
+        self.assertEqual(out, '{"ok": true}')
+        mock_run.assert_called_once_with(
+            ["gh", "api", "repos/o/r"],
+            capture_output=True,
+            timeout=5,
+        )
+
+    def test_gh_api_json_timeout_fires_and_returns_sentinel(self):
+        """(a) _gh_api_json forwards the timeout and returns (-1, "") on
+        TimeoutExpired."""
+        with mock.patch.object(
+            fb.subprocess, "run",
+            side_effect=subprocess.TimeoutExpired(cmd=["gh"], timeout=1),
+        ) as mock_run:
+            rc, out = fb._gh_api_json("POST", "repos/o/r/issues/1/comments", {"body": "x"}, timeout_sec=1)
+        self.assertEqual(rc, -1)
+        self.assertEqual(out, "")
+        kwargs = mock_run.call_args.kwargs
+        self.assertEqual(kwargs["timeout"], 1)
+        self.assertIn("capture_output", kwargs)
+
+    def test_gh_api_json_timeout_does_not_leak_temp_payload(self):
+        """(c) The temp payload file is unlinked in the finally block even
+        when the subprocess times out."""
+        import tempfile as _tempfile
+
+        # Pre-warm the tempdir probe (tempfile lazily unlinks a probe file on
+        # first use) so it doesn't hit the patched os.unlink below.
+        _tempfile.gettempdir()
+        real_unlink = os.unlink
+        unlinked = []
+
+        def tracking_unlink(path):
+            real_unlink(path)
+            unlinked.append(path)
+
+        with mock.patch.object(
+            fb.subprocess, "run",
+            side_effect=subprocess.TimeoutExpired(cmd=["gh"], timeout=1),
+        ), mock.patch.object(fb.os, "unlink", side_effect=tracking_unlink):
+            rc, out = fb._gh_api_json("POST", "repos/o/r/issues/1/comments", {"body": "x"}, timeout_sec=1)
+        self.assertEqual(rc, -1)
+        self.assertEqual(out, "")
+        self.assertEqual(len(unlinked), 1, "temp payload file must be unlinked on timeout")
+        self.assertFalse(os.path.exists(unlinked[0]))
+
+    def test_gh_api_json_fast_call_still_works(self):
+        """(b) A successful fast _gh_api_json call returns the parsed
+        response and unlinks the temp payload file."""
+        import tempfile as _tempfile
+
+        # Pre-warm the tempdir probe (tempfile lazily unlinks a probe file on
+        # first use) so it doesn't hit the patched os.unlink below.
+        _tempfile.gettempdir()
+        proc = mock.Mock()
+        proc.returncode = 0
+        proc.stdout = b'{"id": 7}'
+        real_unlink = os.unlink
+        unlinked = []
+
+        def tracking_unlink(path):
+            real_unlink(path)
+            unlinked.append(path)
+
+        with mock.patch.object(fb.subprocess, "run", return_value=proc), \
+                mock.patch.object(fb.os, "unlink", side_effect=tracking_unlink):
+            rc, out = fb._gh_api_json("POST", "repos/o/r/issues/1/comments", {"body": "x"}, timeout_sec=5)
+        self.assertEqual(rc, 0)
+        self.assertEqual(out, '{"id": 7}')
+        self.assertEqual(len(unlinked), 1)
+        self.assertFalse(os.path.exists(unlinked[0]))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds wall-clock timeouts to `gh` CLI subprocess calls in forgejo_backend.py and adds comprehensive tests to ensure failures are bounded.

Fixes #537

_Opened by foreman on review GO (workload wl-misospace-pr-reviewer-action-537)._